### PR TITLE
SA-P0-006: Fix constraint gaps blocking refund flow

### DIFF
--- a/RELEASES/EVIDENCE/SA-P0-006/parity-and-scope.txt
+++ b/RELEASES/EVIDENCE/SA-P0-006/parity-and-scope.txt
@@ -1,0 +1,52 @@
+SA-P0-006: Parity and Scope — Constraint Gaps Blocking Refund Flow
+===================================================================
+
+Date: 2026-02-10
+Branch: feat/sa-p0-006-constraint-gaps
+Base: main (8446cd4)
+
+FILES CHANGED
+=============
+
+1. backend/migrations/125_sa_p0_006_constraint_gaps.sql  [NEW]
+   - Expands chk_sale_payment_status to include 'refunded' and 'due'
+   - Expands chk_ledger_reference_type to include 'digitisation'
+   - Wrapped in BEGIN/COMMIT for atomic application
+   - Idempotent: uses DROP CONSTRAINT IF EXISTS before ADD
+
+2. scripts/test-refund-e2e.ps1  [NEW]
+   - 15-step E2E refund test with 17 assertions
+   - Fail-fast: aborts on seeding failures or stock mismatch
+   - Idempotent: unique barcode per run (timestamp-based RUN_ID)
+   - DB proof: verifies sale row, ledger entries, stock tables
+   - Returns exit code 0 (PASS) or 1 (FAIL)
+
+3. RELEASES/EVIDENCE/SA-P0-006/runtime-proofs.md  [NEW]
+   - Full PASS output from 2 back-to-back runs
+   - Expected vs actual table
+   - Typecheck gate result
+
+4. RELEASES/EVIDENCE/SA-P0-006/parity-and-scope.txt  [NEW]
+   - This file
+
+5. RELEASES/EVIDENCE/SA-P0-006/rollback.md  [NEW]
+   - Rollback procedure for migration 125
+
+LOCKFILE DRIFT
+==============
+
+No lockfile changes. Migration is SQL-only. Test script is PowerShell-only.
+No package.json or pnpm-lock.yaml modifications.
+
+SCOPE NOTES
+===========
+
+This PR fixes CHECK constraint gaps only. It does NOT include the full
+refund approval workflow from the original PR #4 (feat/sa-p0-006-refund-capability),
+which added migration 119, admin refund endpoints, POS refund UI, and SA approval
+queue. That is separate future scope.
+
+The existing return endpoint (POST /pos/sales/:saleId/return) was already on main
+but was blocked by the chk_sale_payment_status constraint. Migration 125 unblocks it.
+
+NO BACKEND CODE CHANGES — only a migration file and a test script.

--- a/RELEASES/EVIDENCE/SA-P0-006/rollback.md
+++ b/RELEASES/EVIDENCE/SA-P0-006/rollback.md
@@ -1,0 +1,60 @@
+# SA-P0-006: Rollback Procedure
+
+## Git Rollback
+
+```bash
+# Option A: Revert the merge commit
+git revert <merge-commit-sha> --no-edit
+git push origin main
+
+# Option B: Revert the PR commit range (if squash-merged)
+git revert <squash-commit-sha> --no-edit
+git push origin main
+```
+
+## SQL Rollback (Migration 125)
+
+Migration 125 only modifies CHECK constraints. Rollback restores the original
+restrictive constraints:
+
+```sql
+BEGIN;
+
+-- 1. Restore original chk_sale_payment_status (without 'refunded' and 'due')
+ALTER TABLE public.sales
+  DROP CONSTRAINT IF EXISTS chk_sale_payment_status;
+ALTER TABLE public.sales
+  ADD CONSTRAINT chk_sale_payment_status
+  CHECK (payment_status IN ('pending', 'paid', 'failed'));
+
+-- 2. Restore original chk_ledger_reference_type (without 'digitisation')
+ALTER TABLE inventory.inventory_ledger
+  DROP CONSTRAINT IF EXISTS chk_ledger_reference_type;
+ALTER TABLE inventory.inventory_ledger
+  ADD CONSTRAINT chk_ledger_reference_type
+  CHECK (reference_type IS NULL OR reference_type IN ('sale', 'po', 'return', 'manual'));
+
+COMMIT;
+```
+
+**WARNING**: Rolling back the constraints will cause:
+- POST /pos/sales/:saleId/return to fail with 500 (cannot set payment_status='refunded')
+- POST /pos/sales/:saleId/confirm with DUE payment mode to fail (cannot set payment_status='due')
+- POS store-products digitisation to fail with 503 (cannot write reference_type='digitisation')
+
+If any rows already have 'refunded', 'due', or 'digitisation' values, the rollback
+ALTER TABLE will fail. In that case, update or delete those rows first:
+
+```sql
+-- Check for affected rows before rollback:
+SELECT COUNT(*) FROM public.sales WHERE payment_status IN ('refunded', 'due');
+SELECT COUNT(*) FROM inventory.inventory_ledger WHERE reference_type = 'digitisation';
+```
+
+## Safe Fallback Behavior
+
+If migration 125 is NOT applied:
+- The return endpoint returns HTTP 500 (constraint violation caught, transaction rolled back)
+- No data corruption occurs — the SERIALIZABLE transaction ensures atomicity
+- POS digitisation returns HTTP 503 — the store-products endpoint catches and returns service unavailable
+- All other POS flows (sale, payment, stock) are unaffected

--- a/RELEASES/EVIDENCE/SA-P0-006/runtime-proofs.md
+++ b/RELEASES/EVIDENCE/SA-P0-006/runtime-proofs.md
@@ -1,0 +1,233 @@
+# SA-P0-006: Runtime Proofs — Constraint Gaps Blocking Refund Flow
+
+> Date: 2026-02-10
+> Branch: feat/sa-p0-006-constraint-gaps
+> Stack: docker-compose.local-prod.yml (backend at localhost:3010)
+> Migration: 125_sa_p0_006_constraint_gaps.sql
+> Test script: scripts/test-refund-e2e.ps1
+
+---
+
+## Root Cause
+
+Two PostgreSQL CHECK constraints were too restrictive:
+
+1. **`chk_sale_payment_status`** on `public.sales` — allowed only `(pending, paid, failed)`.
+   The return endpoint sets `payment_status = 'refunded'` and the DUE flow sets `payment_status = 'due'` — both violated the constraint, causing 500 errors.
+
+2. **`chk_ledger_reference_type`** on `inventory.inventory_ledger` — allowed only `(sale, po, return, manual)`.
+   The POS digitisation service writes `reference_type = 'digitisation'`, causing 503 on the store-products endpoint.
+
+---
+
+## Fix
+
+Migration 125 expands both constraints:
+
+```sql
+-- chk_sale_payment_status: added 'refunded' and 'due'
+CHECK (payment_status IN ('pending', 'paid', 'failed', 'refunded', 'due'))
+
+-- chk_ledger_reference_type: added 'digitisation'
+CHECK (reference_type IS NULL OR reference_type IN ('sale', 'po', 'return', 'manual', 'digitisation'))
+```
+
+---
+
+## Back-to-Back Stability: Run 1 (17/17 PASS)
+
+```
+=== SA-P0-006 Refund E2E Test (RUN_ID=015200, BARCODE=89010301520099) ===
+
+=== STEP 1: Create store ===
+  STORE_ID = a8edb2e7-3d50-4ce7-880a-24ca504a8396  |  Code = RE260210-009
+
+=== STEP 2: Activate store via SQL ===
+  Store status = ACTIVE UPDATE 1
+
+=== STEP 3: Generate enrollment code ===
+  ENROLLMENT CODE = SM-Y2HPU9
+
+=== STEP 4: Enroll POS device ===
+  DEVICE TOKEN = 97e4b46495ad2627...
+  STORE = Refund E2E 015200  |  Active = True
+
+=== STEP 5: Seed product ===
+  Created via POS API: SP=b6db5598-8a08-4dbc-b2f4-9db79aa344f5  PROD=07847235-49d5-4f4d-bf7b-7f3d82d1cbba
+
+=== STEP 6: Verify seed stock ===
+  PASS: stock_before_sale = 100
+
+=== STEP 7: Create sale ===
+  SALE_ID = 816944c1-d85c-4ad9-b1d5-440cbf51eb46
+  Bill Ref = 6852201213XRY  |  Total = 9000 paise
+
+=== STEP 8: Confirm payment ===
+  PASS: payment_status is present (PAID_CASH)
+  PAID_CASH | Payment confirmed and stock deducted
+
+=== STEP 9: Stock after sale ===
+  PASS: stock_after_sale = 98
+
+=== STEP 10: Return the sale ===
+  RAW: {"saleId":"816944c1-d85c-4ad9-b1d5-440cbf51eb46","returnId":"7ad4ba74-38b2-456f-b71f-27b821329b5b","status":"REFUNDED","message":"Sale returned successfully. Stock has been restored.","itemsReturned":1}
+  PASS: return.saleId is present (816944c1-d85c-4ad9-b1d5-440cbf51eb46)
+  PASS: return.returnId is present (7ad4ba74-38b2-456f-b71f-27b821329b5b)
+  PASS: return.status = REFUNDED
+  PASS: return.message is present (Sale returned successfully. Stock has been restored.)
+  PASS: return.itemsReturned is present (1)
+
+=== STEP 11: Stock after return ===
+  PASS: stock_after_return = 100
+
+=== STEP 12: Ledger proof (API) ===
+  Sale return entries: 1
+    [sale_return] Test Tomato 015200: delta=2 | 98 -> 100
+
+=== STEP 13: Double return blocked ===
+  PASS: double_return_blocked = cannot_return
+
+=== STEP 14: DB proof - sale row ===
+  PASS: db_sale_status = REFUNDED
+  PASS: db_payment_status = refunded
+  PASS: db_total_minor = 9000
+
+=== STEP 15: DB proof - ledger entries ===
+  Ledger return entries for store: 1
+  PASS: ledger_return_entries >= 1
+  PASS: db_stock_balances = 100
+  PASS: db_store_inventory = 100
+  PASS: db_catalog_current_stock = 100
+
+=====================================
+  SA-P0-006 Refund E2E Results
+=====================================
+  PASS:     17
+  FAIL:     0
+=====================================
+OVERALL: PASS (17/17)
+```
+
+---
+
+## Back-to-Back Stability: Run 2 (17/17 PASS)
+
+```
+=== SA-P0-006 Refund E2E Test (RUN_ID=015209, BARCODE=89010301520999) ===
+
+=== STEP 1: Create store ===
+  STORE_ID = b44b1ff8-2d5c-4dbc-afe4-b5797782d3a6  |  Code = RE260210-010
+
+=== STEP 2: Activate store via SQL ===
+  Store status = ACTIVE UPDATE 1
+
+=== STEP 3: Generate enrollment code ===
+  ENROLLMENT CODE = SM-N8GTNY
+
+=== STEP 4: Enroll POS device ===
+  DEVICE TOKEN = c7572fdca395d046...
+  STORE = Refund E2E 015209  |  Active = True
+
+=== STEP 5: Seed product ===
+  Created via POS API: SP=5d4310cb-ea4e-418f-b099-5eaf664e3be5  PROD=68b51ab9-027f-48d6-a4af-762aed4f6317
+
+=== STEP 6: Verify seed stock ===
+  PASS: stock_before_sale = 100
+
+=== STEP 7: Create sale ===
+  SALE_ID = d446f0c6-1a42-4bc0-977a-9f4073440441
+  Bill Ref = 685302752XDOW  |  Total = 9000 paise
+
+=== STEP 8: Confirm payment ===
+  PASS: payment_status is present (PAID_CASH)
+  PAID_CASH | Payment confirmed and stock deducted
+
+=== STEP 9: Stock after sale ===
+  PASS: stock_after_sale = 98
+
+=== STEP 10: Return the sale ===
+  RAW: {"saleId":"d446f0c6-1a42-4bc0-977a-9f4073440441","returnId":"b108c297-f3f2-4b93-b4e0-2f47fb5ce8c9","status":"REFUNDED","message":"Sale returned successfully. Stock has been restored.","itemsReturned":1}
+  PASS: return.saleId is present (d446f0c6-1a42-4bc0-977a-9f4073440441)
+  PASS: return.returnId is present (b108c297-f3f2-4b93-b4e0-2f47fb5ce8c9)
+  PASS: return.status = REFUNDED
+  PASS: return.message is present (Sale returned successfully. Stock has been restored.)
+  PASS: return.itemsReturned is present (1)
+
+=== STEP 11: Stock after return ===
+  PASS: stock_after_return = 100
+
+=== STEP 12: Ledger proof (API) ===
+  Sale return entries: 1
+    [sale_return] Test Tomato 015209: delta=2 | 98 -> 100
+
+=== STEP 13: Double return blocked ===
+  PASS: double_return_blocked = cannot_return
+
+=== STEP 14: DB proof - sale row ===
+  PASS: db_sale_status = REFUNDED
+  PASS: db_payment_status = refunded
+  PASS: db_total_minor = 9000
+
+=== STEP 15: DB proof - ledger entries ===
+  Ledger return entries for store: 1
+  PASS: ledger_return_entries >= 1
+  PASS: db_stock_balances = 100
+  PASS: db_store_inventory = 100
+  PASS: db_catalog_current_stock = 100
+
+=====================================
+  SA-P0-006 Refund E2E Results
+=====================================
+  PASS:     17
+  FAIL:     0
+=====================================
+OVERALL: PASS (17/17)
+```
+
+---
+
+## Expected vs Actual Summary
+
+| Metric | Expected | Actual | Status |
+|--------|----------|--------|--------|
+| Stock before sale | 100 | 100 | PASS |
+| Stock after sale (2 units) | 98 | 98 | PASS |
+| Stock after return | 100 | 100 | PASS |
+| Refund response: saleId | present | present | PASS |
+| Refund response: returnId | UUID | UUID | PASS |
+| Refund response: status | REFUNDED | REFUNDED | PASS |
+| Refund response: message | present | present | PASS |
+| Refund response: itemsReturned | 1 | 1 | PASS |
+| Ledger entry: delta | +2 | +2 | PASS |
+| Ledger entry: transition | 98 -> 100 | 98 -> 100 | PASS |
+| Double return blocked | cannot_return | cannot_return | PASS |
+| DB sale status | REFUNDED | REFUNDED | PASS |
+| DB payment_status | refunded | refunded | PASS |
+| DB total_minor | 9000 | 9000 | PASS |
+| DB ledger entries >= 1 | true | true | PASS |
+| DB stock_balances | 100 | 100 | PASS |
+| DB store_inventory | 100 | 100 | PASS |
+| DB catalog current_stock | 100 | 100 | PASS |
+| Back-to-back stability | 2/2 PASS | 2/2 PASS | PASS |
+
+---
+
+## Typecheck Gate
+
+```
+pnpm -r typecheck: 22/22 projects PASS (0 errors)
+```
+
+---
+
+## Operator Checklist
+
+- [ ] Migration 125 applied to local-prod Postgres
+- [ ] Run 1: 17/17 PASS
+- [ ] Run 2: 17/17 PASS (back-to-back)
+- [ ] Stock lifecycle: 100 -> 98 (sale) -> 100 (return)
+- [ ] Refund JSON: all 5 fields stable
+- [ ] Double return: blocked with `cannot_return`
+- [ ] DB proof: sale status REFUNDED, payment_status refunded, total 9000
+- [ ] DB proof: ledger, stock_balances, store_inventory, catalog all restored
+- [ ] Typecheck: 22/22 PASS

--- a/backend/migrations/125_sa_p0_006_constraint_gaps.sql
+++ b/backend/migrations/125_sa_p0_006_constraint_gaps.sql
@@ -1,0 +1,33 @@
+-- SA-P0-006: Fix constraint gaps blocking refund flow and POS digitisation
+--
+-- Bug 1: chk_sale_payment_status on public.sales allows only (pending, paid, failed).
+--         The return endpoint sets payment_status = 'refunded' and the DUE flow sets
+--         payment_status = 'due' — both violate the constraint.
+--
+-- Bug 2: chk_ledger_reference_type on inventory.inventory_ledger allows only
+--         (sale, po, return, manual). The POS digitisation service writes
+--         reference_type = 'digitisation' — violates the constraint and causes
+--         the store-products endpoint to return 503.
+--
+-- Both constraints were created in earlier migrations but never updated when
+-- new code paths were added.
+
+BEGIN;
+
+-- 1. Expand sales.payment_status to include 'refunded' and 'due'
+ALTER TABLE public.sales
+  DROP CONSTRAINT IF EXISTS chk_sale_payment_status;
+
+ALTER TABLE public.sales
+  ADD CONSTRAINT chk_sale_payment_status
+  CHECK (payment_status IN ('pending', 'paid', 'failed', 'refunded', 'due'));
+
+-- 2. Expand inventory.inventory_ledger.reference_type to include 'digitisation'
+ALTER TABLE inventory.inventory_ledger
+  DROP CONSTRAINT IF EXISTS chk_ledger_reference_type;
+
+ALTER TABLE inventory.inventory_ledger
+  ADD CONSTRAINT chk_ledger_reference_type
+  CHECK (reference_type IS NULL OR reference_type IN ('sale', 'po', 'return', 'manual', 'digitisation'));
+
+COMMIT;

--- a/scripts/test-refund-e2e.ps1
+++ b/scripts/test-refund-e2e.ps1
@@ -1,0 +1,283 @@
+# SA-P0-006: End-to-End Refund Test Script (Hardened)
+# Usage: powershell -ExecutionPolicy Bypass -File scripts\test-refund-e2e.ps1
+# Requires: Docker local-prod stack running on port 3010
+# Pre-req: Migration 125 applied (chk_sale_payment_status + chk_ledger_reference_type)
+#
+# Exit codes:
+#   0 = ALL PASS
+#   1 = FAIL (with reason printed)
+#
+# Idempotent: Uses unique barcode per run to avoid collisions on back-to-back runs.
+
+$ErrorActionPreference = "Continue"
+$API = "http://localhost:3010/api/v1"
+$PASS_COUNT = 0
+$FAIL_COUNT = 0
+$RUN_ID = (Get-Date).ToString("HHmmss")
+$BARCODE = "890103${RUN_ID}99"
+
+# =============================================================================
+# HELPERS
+# =============================================================================
+
+function RunSQL($sql) {
+    $raw = docker exec scripts-postgres-1 psql -U postgres -d supermandi -t -A -c $sql 2>&1
+    return ("$raw".Trim() -split '\s')[0]
+}
+
+function RunSQLRaw($sql) {
+    docker exec scripts-postgres-1 psql -U postgres -d supermandi -t -A -c $sql 2>&1
+}
+
+function Assert-Equal($name, $actual, $expected) {
+    if ("$actual" -eq "$expected") {
+        Write-Host "  PASS: $name = $actual" -ForegroundColor Green
+        $script:PASS_COUNT++
+    } else {
+        Write-Host "  FAIL: $name = $actual (expected $expected)" -ForegroundColor Red
+        $script:FAIL_COUNT++
+    }
+}
+
+function Assert-NotEmpty($name, $value) {
+    if ($value -and "$value".Trim() -ne "") {
+        Write-Host "  PASS: $name is present ($value)" -ForegroundColor Green
+        $script:PASS_COUNT++
+    } else {
+        Write-Host "  FAIL: $name is empty or missing" -ForegroundColor Red
+        $script:FAIL_COUNT++
+    }
+}
+
+function Fatal($msg) {
+    Write-Host "FATAL: $msg" -ForegroundColor Red
+    Write-Host "`n=== RESULT: ABORTED ===" -ForegroundColor Red
+    Write-Host "PASS=$script:PASS_COUNT  FAIL=$script:FAIL_COUNT  ABORTED=true"
+    exit 1
+}
+
+Write-Host "=== SA-P0-006 Refund E2E Test (RUN_ID=$RUN_ID, BARCODE=$BARCODE) ===" -ForegroundColor Yellow
+Write-Host ""
+
+# =============================================================================
+# STEP 1: Create store
+# =============================================================================
+Write-Host "=== STEP 1: Create store ===" -ForegroundColor Cyan
+$body = "{`"storeName`":`"Refund E2E $RUN_ID`",`"city`":`"Mumbai`",`"state`":`"Maharashtra`",`"pincode`":`"400001`"}"
+$store = curl.exe -s -X POST "$API/admin/stores" -H "Content-Type: application/json" -H "x-admin-token: local-test-token" -d $body | ConvertFrom-Json
+$STORE_ID = $store.store.id
+if (-not $STORE_ID) { Fatal "Store creation failed: $($store | ConvertTo-Json -Compress)" }
+Write-Host "  STORE_ID = $STORE_ID  |  Code = $($store.store.code)"
+
+# =============================================================================
+# STEP 2: Activate store via SQL (bypass state machine for test speed)
+# =============================================================================
+Write-Host "`n=== STEP 2: Activate store via SQL ===" -ForegroundColor Cyan
+$result = RunSQLRaw "UPDATE platform.stores SET status='ACTIVE', device_bound=true, kyc_complete=true, upi_complete=true, admin_approved=true, updated_at=NOW() WHERE id='$STORE_ID' RETURNING status;"
+Write-Host "  Store status = $result"
+
+# =============================================================================
+# STEP 3: Generate enrollment code
+# =============================================================================
+Write-Host "`n=== STEP 3: Generate enrollment code ===" -ForegroundColor Cyan
+$enroll = curl.exe -s -X POST "$API/admin/stores/$STORE_ID/device-enrollments" -H "x-admin-token: local-test-token" | ConvertFrom-Json
+$CODE = $enroll.code
+if (-not $CODE) { Fatal "Enrollment code generation failed: $($enroll | ConvertTo-Json -Compress)" }
+Write-Host "  ENROLLMENT CODE = $CODE"
+
+# =============================================================================
+# STEP 4: Enroll POS device
+# =============================================================================
+Write-Host "`n=== STEP 4: Enroll POS device ===" -ForegroundColor Cyan
+$enrollBody = @{
+    code = $CODE
+    deviceMeta = @{
+        label = "Refund Test $RUN_ID"
+        deviceType = "OEM_HANDHELD"
+        printingMode = "NONE"
+    }
+} | ConvertTo-Json -Compress
+$device = curl.exe -s -X POST "$API/pos/enroll" -H "Content-Type: application/json" -d $enrollBody | ConvertFrom-Json
+$TOKEN = $device.deviceToken
+if (-not $TOKEN) { Fatal "Device enrollment failed: $($device | ConvertTo-Json -Compress)" }
+Write-Host "  DEVICE TOKEN = $($TOKEN.Substring(0,16))..."
+Write-Host "  STORE = $($device.storeName)  |  Active = $($device.storeActive)"
+
+# =============================================================================
+# STEP 5: Seed product (POS API first, SQL fallback)
+# =============================================================================
+Write-Host "`n=== STEP 5: Seed product ===" -ForegroundColor Cyan
+$body = "{`"barcode`":`"$BARCODE`",`"name`":`"Test Tomato $RUN_ID`",`"sellPrice`":4500,`"mrp`":5000,`"initialStockQty`":100,`"unit`":`"kg`"}"
+$product = curl.exe -s -X POST "$API/pos/store-products" -H "Content-Type: application/json" -H "x-device-token: $TOKEN" -d $body | ConvertFrom-Json
+
+if ($product.storeProduct) {
+    $SP_ID = $product.storeProduct.storeProductId
+    $PROD_ID = RunSQL "SELECT product_id::text FROM catalog.store_products WHERE id='$SP_ID';"
+    Write-Host "  Created via POS API: SP=$SP_ID  PROD=$PROD_ID"
+} else {
+    Write-Host "  POS API failed ($($product.error)). Seeding via SQL..." -ForegroundColor Yellow
+
+    $PROD_ID = RunSQL "INSERT INTO catalog.products (name, primary_barcode, unit) VALUES ('Test Tomato $RUN_ID', '$BARCODE', 'kg') ON CONFLICT (primary_barcode) WHERE primary_barcode IS NOT NULL DO UPDATE SET name=EXCLUDED.name RETURNING id;"
+    Write-Host "    Product ID = $PROD_ID"
+
+    $SP_ID = RunSQL "INSERT INTO catalog.store_products (store_id, product_id, sell_price, mrp, current_stock, display_name, is_active) VALUES ('$STORE_ID', '$PROD_ID', 4500, 5000, 100, 'Test Tomato $RUN_ID', true) ON CONFLICT (store_id, product_id) DO UPDATE SET current_stock=100, sell_price=4500, mrp=5000 RETURNING id;"
+    Write-Host "    Store Product ID = $SP_ID"
+
+    RunSQLRaw "INSERT INTO catalog.product_barcodes (product_id, barcode) VALUES ('$PROD_ID', '$BARCODE') ON CONFLICT DO NOTHING;" | Out-Null
+
+    RunSQLRaw "INSERT INTO public.variants (id, product_id, name) VALUES ('$SP_ID', '$PROD_ID', 'Test Tomato $RUN_ID') ON CONFLICT (id) DO NOTHING;" | Out-Null
+    Write-Host "    Variant record created"
+
+    RunSQLRaw "INSERT INTO inventory.stock_balances (store_id, product_id, current_qty) VALUES ('$STORE_ID', '$PROD_ID', 100) ON CONFLICT (store_id, product_id) DO UPDATE SET current_qty=100;" | Out-Null
+
+    RunSQLRaw "INSERT INTO store_inventory (store_id, global_product_id, available_qty) VALUES ('$STORE_ID', '$PROD_ID', 100) ON CONFLICT (store_id, global_product_id) DO UPDATE SET available_qty=100;" | Out-Null
+    Write-Host "    Stock seeded: 100 units (stock_balances + store_inventory)"
+}
+
+if (-not $SP_ID -or -not $PROD_ID) { Fatal "Missing IDs (SP=$SP_ID, PROD=$PROD_ID)" }
+
+# =============================================================================
+# STEP 6: Verify seed stock = 100 (fail-fast)
+# =============================================================================
+Write-Host "`n=== STEP 6: Verify seed stock ===" -ForegroundColor Cyan
+$stock = curl.exe -s "$API/pos/inventory/stock/${PROD_ID}?refresh=true" -H "x-device-token: $TOKEN" | ConvertFrom-Json
+$stockBefore = $stock.data.currentQty
+Assert-Equal "stock_before_sale" $stockBefore 100
+if ($stockBefore -ne 100) { Fatal "seed_stock_mismatch expected=100 actual=$stockBefore" }
+
+# =============================================================================
+# STEP 7: Create sale (2 units x 4500 paise = 9000 paise total)
+# =============================================================================
+Write-Host "`n=== STEP 7: Create sale ===" -ForegroundColor Cyan
+$saleBody = @{
+    items = @(@{
+        storeProductId = $SP_ID
+        quantity = 2
+        priceMinor = 4500
+        name = "Test Tomato $RUN_ID"
+    })
+    discountMinor = 0
+} | ConvertTo-Json -Depth 5 -Compress
+$sale = curl.exe -s -X POST "$API/pos/sales" -H "Content-Type: application/json" -H "x-device-token: $TOKEN" -d $saleBody | ConvertFrom-Json
+$SALE_ID = $sale.saleId
+if (-not $SALE_ID) { Fatal "Sale creation failed: $($sale | ConvertTo-Json -Depth 5 -Compress)" }
+Write-Host "  SALE_ID = $SALE_ID"
+Write-Host "  Bill Ref = $($sale.billRef)  |  Total = $($sale.totals.totalMinor) paise"
+
+# =============================================================================
+# STEP 8: Confirm payment (CASH)
+# =============================================================================
+Write-Host "`n=== STEP 8: Confirm payment ===" -ForegroundColor Cyan
+$body = '{"paymentMode":"CASH"}'
+$pay = curl.exe -s -X POST "$API/pos/sales/$SALE_ID/confirm" -H "Content-Type: application/json" -H "x-device-token: $TOKEN" -d $body | ConvertFrom-Json
+Assert-NotEmpty "payment_status" $pay.status
+Write-Host "  $($pay.status) | $($pay.message)"
+
+# =============================================================================
+# STEP 9: Stock after sale (expect 98)
+# =============================================================================
+Write-Host "`n=== STEP 9: Stock after sale ===" -ForegroundColor Cyan
+$stock = curl.exe -s "$API/pos/inventory/stock/${PROD_ID}?refresh=true" -H "x-device-token: $TOKEN" | ConvertFrom-Json
+Assert-Equal "stock_after_sale" $stock.data.currentQty 98
+
+# =============================================================================
+# STEP 10: RETURN the sale
+# =============================================================================
+Write-Host "`n=== STEP 10: Return the sale ===" -ForegroundColor Cyan
+$body = '{"reason":"Customer changed mind - E2E refund test"}'
+$retRaw = curl.exe -s -X POST "$API/pos/sales/$SALE_ID/return" -H "Content-Type: application/json" -H "x-device-token: $TOKEN" -d $body
+Write-Host "  RAW: $retRaw"
+$ret = $retRaw | ConvertFrom-Json
+
+# Verify all 5 expected fields
+Assert-NotEmpty "return.saleId" $ret.saleId
+Assert-NotEmpty "return.returnId" $ret.returnId
+Assert-Equal "return.status" $ret.status "REFUNDED"
+Assert-NotEmpty "return.message" $ret.message
+Assert-NotEmpty "return.itemsReturned" $ret.itemsReturned
+
+# =============================================================================
+# STEP 11: Stock after return (expect 100)
+# =============================================================================
+Write-Host "`n=== STEP 11: Stock after return ===" -ForegroundColor Cyan
+$stock = curl.exe -s "$API/pos/inventory/stock/${PROD_ID}?refresh=true" -H "x-device-token: $TOKEN" | ConvertFrom-Json
+Assert-Equal "stock_after_return" $stock.data.currentQty 100
+
+# =============================================================================
+# STEP 12: Ledger proof via API
+# =============================================================================
+Write-Host "`n=== STEP 12: Ledger proof (API) ===" -ForegroundColor Cyan
+$ledger = curl.exe -s "$API/pos/inventory/ledger?transactionType=sale_return&limit=5" -H "x-device-token: $TOKEN" | ConvertFrom-Json
+Write-Host "  Sale return entries: $($ledger.pagination.total)"
+if ($ledger.data -and $ledger.data.Count -gt 0) {
+    $ledger.data | ForEach-Object {
+        Write-Host "    [$($_.transactionType)] $($_.productName): delta=$($_.deltaQty) | $($_.stockBefore) -> $($_.stockAfter)"
+    }
+}
+
+# =============================================================================
+# STEP 13: Double return blocked (idempotency guard)
+# =============================================================================
+Write-Host "`n=== STEP 13: Double return blocked ===" -ForegroundColor Cyan
+$body = '{"reason":"Try returning again"}'
+$ret2 = curl.exe -s -X POST "$API/pos/sales/$SALE_ID/return" -H "Content-Type: application/json" -H "x-device-token: $TOKEN" -d $body | ConvertFrom-Json
+Assert-Equal "double_return_blocked" $ret2.error "cannot_return"
+
+# =============================================================================
+# STEP 14: DB proof — sale row
+# =============================================================================
+Write-Host "`n=== STEP 14: DB proof — sale row ===" -ForegroundColor Cyan
+$dbStatus = RunSQL "SELECT status FROM public.sales WHERE id='$SALE_ID';"
+$dbPayStatus = RunSQL "SELECT payment_status FROM public.sales WHERE id='$SALE_ID';"
+$dbTotal = RunSQL "SELECT total_minor::text FROM public.sales WHERE id='$SALE_ID';"
+Assert-Equal "db_sale_status" $dbStatus "REFUNDED"
+Assert-Equal "db_payment_status" $dbPayStatus "refunded"
+Assert-Equal "db_total_minor" $dbTotal "9000"
+
+# =============================================================================
+# STEP 15: DB proof — ledger entry exists for this sale
+# =============================================================================
+Write-Host "`n=== STEP 15: DB proof — ledger entries ===" -ForegroundColor Cyan
+$ledgerCount = RunSQL "SELECT COUNT(*)::text FROM inventory.inventory_ledger WHERE reference_type='return' AND store_id='$STORE_ID';"
+Write-Host "  Ledger return entries for store: $ledgerCount"
+if ([int]$ledgerCount -ge 1) {
+    Write-Host "  PASS: ledger_return_entries >= 1" -ForegroundColor Green
+    $PASS_COUNT++
+} else {
+    Write-Host "  FAIL: ledger_return_entries = $ledgerCount (expected >= 1)" -ForegroundColor Red
+    $FAIL_COUNT++
+}
+
+# DB proof — stock_balances restored
+$dbStockBal = RunSQL "SELECT current_qty::text FROM inventory.stock_balances WHERE store_id='$STORE_ID' AND product_id='$PROD_ID';"
+Assert-Equal "db_stock_balances" $dbStockBal "100"
+
+# DB proof — store_inventory restored
+$dbStoreInv = RunSQL "SELECT available_qty::text FROM store_inventory WHERE store_id='$STORE_ID' AND global_product_id='$PROD_ID';"
+Assert-Equal "db_store_inventory" $dbStoreInv "100"
+
+# DB proof — catalog.store_products.current_stock restored
+$dbCatalogStock = RunSQL "SELECT current_stock::text FROM catalog.store_products WHERE id='$SP_ID';"
+Assert-Equal "db_catalog_current_stock" $dbCatalogStock "100"
+
+# =============================================================================
+# RESULT
+# =============================================================================
+Write-Host ""
+Write-Host "=====================================" -ForegroundColor Yellow
+Write-Host "  SA-P0-006 Refund E2E Results" -ForegroundColor Yellow
+Write-Host "=====================================" -ForegroundColor Yellow
+Write-Host "  Store:    $STORE_ID"
+Write-Host "  Product:  $PROD_ID (catalog) / $SP_ID (store)"
+Write-Host "  Sale:     $SALE_ID"
+Write-Host "  PASS:     $PASS_COUNT" -ForegroundColor Green
+Write-Host "  FAIL:     $FAIL_COUNT" -ForegroundColor $(if ($FAIL_COUNT -gt 0) { "Red" } else { "Green" })
+Write-Host "=====================================" -ForegroundColor Yellow
+
+if ($FAIL_COUNT -gt 0) {
+    Write-Host "`nOVERALL: FAIL ($FAIL_COUNT failures)" -ForegroundColor Red
+    exit 1
+} else {
+    Write-Host "`nOVERALL: PASS ($PASS_COUNT/$PASS_COUNT)" -ForegroundColor Green
+    exit 0
+}


### PR DESCRIPTION
## Summary

- **Migration 125** expands two PostgreSQL CHECK constraints that were blocking the existing POS return endpoint and digitisation service
  - `chk_sale_payment_status`: adds `'refunded'` and `'due'` to allowed values
  - `chk_ledger_reference_type`: adds `'digitisation'` to allowed values
- **E2E test script** (`scripts/test-refund-e2e.ps1`): 15-step, 17-assertion hardened test covering full sale-return lifecycle
- **Evidence pack** in `RELEASES/EVIDENCE/SA-P0-006/`

## Runtime Proof (Operator-Verified)

- Stock lifecycle: 100 → 98 (sale 2 units) → 100 (return)
- Refund JSON: all 5 fields stable (`saleId`, `returnId`, `status`, `message`, `itemsReturned`)
- Ledger entry: `[sale_return] delta=2 | 98 -> 100`
- Double return blocked: `cannot_return`
- DB proof: sale status `REFUNDED`, payment_status `refunded`, total `9000`
- DB proof: `stock_balances`, `store_inventory`, `catalog.store_products` all restored to 100
- Back-to-back stability: **2/2 runs PASS (17/17 each)**
- Typecheck: **22/22 PASS**

## Scope Note

This PR fixes constraint gaps only. The full refund approval workflow (PR #4 / `feat/sa-p0-006-refund-capability`) is separate future scope. The existing `POST /pos/sales/:saleId/return` endpoint works correctly once constraints are expanded.

## Test plan

- [ ] Migration 125 applied to local-prod Postgres
- [ ] `pwsh -ExecutionPolicy Bypass -File scripts/test-refund-e2e.ps1` → 17/17 PASS
- [ ] Back-to-back run → 17/17 PASS (idempotent via unique barcode per run)
- [ ] `pnpm -r typecheck` → 22/22 PASS
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)