### PR TITLE
SA-P0-001: Store suspension & reactivation

### DIFF
--- a/RELEASES/MASTER_PLAN.md
+++ b/RELEASES/MASTER_PLAN.md
@@ -444,9 +444,17 @@ Link: https://github.com/ORG/REPO/actions/runs/XXXXX
 
 ```
 BATCH-004 Retailer ──┐
-BATCH-005 Supplier ──┼──► BATCH-008 Cloud Run ──► BATCH-009 CI/CD ──► BATCH-012 Auth ──► BATCH-013 Infra ──► DEFERRED ──► BATCH-014 Polish ──► BATCH-010 Staging ──► BATCH-011 Go-Live
+BATCH-005 Supplier ──┼──► BATCH-008 Cloud Run ──► BATCH-009 CI/CD ──► BATCH-012 Auth ──► BATCH-013 Infra ──► DEFERRED ──► BATCH-014 Polish
 BATCH-006 Admin ─────┤                                                                                                         │
-BATCH-007 POS ───────┘                                                                                         Operator: GCP infra (Cloud SQL, Memorystore, AR, VPC, Secret Manager)
+BATCH-007 POS ───────┘                                                                              ┌──────────────────────────┘
+                                                                                                     ▼
+                                                                                              SA-MERGED (8 tickets)
+                                                                                                     │
+                                                                                              SA-GOLIVE (17 tickets) ◄── YOU ARE HERE
+                                                                                                     │
+                                                                                              BATCH-010 Staging ──► BATCH-011 Go-Live
+                                                                                                                          │
+                                                                                                                   SA-DEFERRED (8 tickets, post go-live)
 ```
 
 ---
@@ -461,12 +469,15 @@ BATCH-007 POS ───────┘                                          
 | BATCH-007 | POS App | `CODE_COMPLETE` | 7/7 DONE | Claude | d3e9e45 | — | 2026-02-05 |
 | BATCH-008 | Cloud Run Prep | `CODE_COMPLETE` | 11/11 DONE | Claude | 59d7ebb | — | 2026-02-05 |
 | BATCH-009 | GCP CI/CD | `CODE_COMPLETE` | 9/9 DONE | Claude+Operator | 59d7ebb | — | 2026-02-05 |
-| BATCH-010 | Staging Deploy | `NEXT` | 1/6 DONE (E2E config) | Claude+Operator | — | — | 2026-02-07 |
-| BATCH-011 | Go-Live | `DRAFT` | 0/4 | Operator | — | — | 2026-02-05 |
 | BATCH-012 | Auth & Session Security | `CODE_COMPLETE` | 18/18 DONE | Claude | 9bb03f7 | — | 2026-02-06 |
 | BATCH-013 | Prod Testing + Infra Hardening | `CODE_COMPLETE` | FULL PASS | Claude | f7cb90d | — | 2026-02-06 |
-| DEFERRED  | Deferred Tickets (P1+P2+P3) | `CODE_COMPLETE` | 7/7 DONE | Claude | 609d875 | — | 2026-02-06 |
 | BATCH-014 | Production Grade Polish | `CODE_COMPLETE` | 10/10 DONE | Claude | 609d875 | — | 2026-02-07 |
+| SA-MERGED | SuperAdmin Tickets (merged) | `CODE_COMPLETE` | 8/8 MERGED | Claude | bd90493 | — | 2026-02-10 |
+| **SA-GOLIVE** | **SuperAdmin Critical Go-Live** | `NEXT` | **0/17** | **Claude** | — | — | **2026-02-10** |
+| SA-DEFERRED | SuperAdmin Post Go-Live | `DEFERRED` | 0/8 | — | — | — | 2026-02-10 |
+| DEFERRED  | Deferred Tickets (P1+P2+P3) | `CODE_COMPLETE` | 7/7 DONE | Claude | 609d875 | — | 2026-02-06 |
+| BATCH-010 | Staging Deploy | `BLOCKED` | 1/6 DONE (E2E config) | Claude+Operator | — | — | 2026-02-07 |
+| BATCH-011 | Go-Live | `DRAFT` | 0/4 | Operator | — | — | 2026-02-05 |
 
 ### Scaling Note
 
@@ -1626,9 +1637,69 @@ Grants AR push + Cloud Run deploy permissions.
 
 ---
 
+### SA-GOLIVE: SuperAdmin Critical Go-Live Tickets
+
+**Status**: `NEXT` | **RC_SHA**: — | **CI Run**: — | **Updated**: 2026-02-10
+
+> **Goal**: Implement 17 remaining SuperAdmin tickets required before go-live.
+> Operator phasing decision (2026-02-10): 8 tickets deferred to post go-live.
+> Full ticket specs: `RELEASES/SUPERADMIN_IMPLEMENTATION_TICKETS.md`
+
+#### Already Merged (8 tickets — reference only)
+| # | Ticket | PR | SHA |
+|---|--------|----|-----|
+| 1 | SA-P0-005 — Feature kill switch | #9 | 0b8fac7 |
+| 2 | SA-P0-006 — Refund & sale reversal | #11 | f2bfe25 |
+| 3 | SA-P1-001 — Staff identity/RBAC | #5 | 9fcf73f |
+| 4 | SA-P1-004 — GRN quantity validation | #6 | 6dd82d9 |
+| 5 | SA-P1-005 — Supplier suspension | #7 | 477682d |
+| 6 | SA-P1-006 — Payment method control | #8 | 861d009 |
+| 7 | SA-P1-007 — Per-store feature flags | #9 | 0b8fac7 |
+| 8 | SA-P1-008 — Bank detail re-verification | #10 | 8446cd4 |
+
+#### Critical Go-Live Progress (17 tickets)
+| # | Ticket | Risk | Status | Evidence |
+|---|--------|------|--------|----------|
+| 1 | SA-P0-001 — Store suspension & reactivation | B | PENDING | — |
+| 2 | SA-P0-004 — Stock-in supplier info (optional) | B | PENDING | — |
+| 3 | SA-P0-007 — System maintenance mode | B | PENDING | — |
+| 4 | SA-P1-009 — Store health dashboard | A | PENDING | — |
+| 5 | SA-P1-012 — Offline sale re-validation | B | PENDING | — |
+| 6 | SA-P1-014 — Store settings visibility | A | PENDING | — |
+| 7 | SA-P1-015 — Reorder policy supervision | B | PENDING | — |
+| 8 | SA-P2-001 — Force device re-enrollment | B | PENDING | — |
+| 9 | SA-P2-002 — Remote config push notification | B | PENDING | — |
+| 10 | SA-P2-003 — Minimum app version enforcement | B | PENDING | — |
+| 11 | SA-P2-004 — Compliance status aggregation | A | PENDING | — |
+| 12 | SA-P2-005 — Force POS sync trigger | B | PENDING | — |
+| 13 | SA-P2-006 — Product category manual override | A | PENDING | — |
+| 14 | SA-P2-007 — BNPL limit adjustment UI | A | PENDING | — |
+| 15 | SA-P2-008 — Retailer bulk import notification | A | PENDING | — |
+| 16 | SA-P2-009 — Device hardware whitelist | B | PENDING | — |
+| 17 | SA-P2-010 — Retailer user force password reset | B | PENDING | — |
+
+#### Deferred — Post Go-Live (8 tickets)
+| # | Ticket | Reason |
+|---|--------|--------|
+| 1 | SA-P0-002 — Discount limits | Store-owned, not blocking launch |
+| 2 | SA-P0-003 — Price bounds | Store-owned, not blocking launch |
+| 3 | SA-P1-002 — Spending limits | Retailer Dashboard owned |
+| 4 | SA-P1-003 — Due limits | Retailer Dashboard owned |
+| 5 | SA-P1-010 — Anomaly detection | Nice-to-have, not blocking |
+| 6 | SA-P1-011 — Stock adjustment audit | Retailer Dashboard owned |
+| 7 | SA-P1-013 — Device token revocation UI | Covered by SA-P2-001 (force re-enroll) |
+| 8 | SA-P2-011 — Persistent rate limiting | Infra optimization, not blocking |
+
+#### Gates
+- [ ] `pnpm -r typecheck` = 0 errors
+- [ ] `@prod` E2E = 0 failures
+- [ ] CI green for RC_SHA
+
+---
+
 ### BATCH-010: Staging Deploy + Pre-Live Testing
 
-**Status**: `DRAFT` | **RC_SHA**: — | **CI Run**: —
+**Status**: `BLOCKED` (waiting for SA-GOLIVE) | **RC_SHA**: — | **CI Run**: —
 
 > **Goal**: Full staging environment working on Cloud Run. All portals tested.
 > E2E passes against staging. Rollback drill completed. Operator signs off.

--- a/RELEASES/RESUME_ANCHOR.md
+++ b/RELEASES/RESUME_ANCHOR.md
@@ -1,22 +1,55 @@
 # RESUME ANCHOR
 
-Date: 02/09/2026 18:00:00
+Date: 02/10/2026 21:00:00
 
-State:
-- All SA-P0 tickets complete
-- SA-P1-001 (POS Staff Identity & Basic RBAC) MERGED to main via PR #5
-  - SHA: 9fcf73f (merge commit)
-  - CI: 6/6 green (run 21820635027)
-  - Includes: CI-RECOVERY-001, CI-RECOVERY-002 fixes
-- SA-P1-004 (GRN Quantity Validation) MERGED to main via PR #6
-  - SHA: 6dd82d9 (merge commit)
-  - CI: 6/6 green (run 21822875816)
-  - Migration 122: relaxed chk_order_item_bounds, created grn_excess_alerts table
-  - Backend: excess detection in receive handler + admin alerts API
-  - POS: excess warning UI + two-step confirmation
-  - SuperAdmin: GRN alerts panel with acknowledge/dismiss
-  - Lint: eliminated all new warnings (superadmin 59/67, backend 642/642)
-- SA-P0-004 (Stock-In Supplier Info) queued — do NOT start unless operator instructs
-- Next ticket: SA-P1-005 (Supplier Suspension)
-- Branch to create next: feat/sa-p1-005-supplier-suspension
-- Rule: Await operator instruction before starting SA-P1-005
+## Current State
+
+HEAD: bd90493 | Tag: sa-p0-006-2026-02-10_IST | Branch: main (clean)
+
+### Merged SuperAdmin Tickets (8/33)
+| # | Ticket | PR | Merge SHA |
+|---|--------|----|-----------|
+| 1 | SA-P0-005 — Feature kill switch | #9 | 0b8fac7 |
+| 2 | SA-P0-006 — Refund & sale reversal | #11 | f2bfe25 |
+| 3 | SA-P1-001 — Staff identity/RBAC | #5 | 9fcf73f |
+| 4 | SA-P1-004 — GRN quantity validation | #6 | 6dd82d9 |
+| 5 | SA-P1-005 — Supplier suspension | #7 | 477682d |
+| 6 | SA-P1-006 — Payment method control | #8 | 861d009 |
+| 7 | SA-P1-007 — Per-store feature flags | #9 | 0b8fac7 |
+| 8 | SA-P1-008 — Bank detail re-verification | #10 | 8446cd4 |
+
+### Phasing Decision (Operator, 2026-02-10)
+
+**CRITICAL GO-LIVE — 17 tickets to implement:**
+1. SA-P0-001 — Store suspension & reactivation
+2. SA-P0-004 — Stock-in supplier info (optional)
+3. SA-P0-007 — System maintenance mode
+4. SA-P1-009 — Store health dashboard
+5. SA-P1-012 — Offline sale re-validation
+6. SA-P1-014 — Store settings visibility
+7. SA-P1-015 — Reorder policy supervision
+8. SA-P2-001 — Force device re-enrollment
+9. SA-P2-002 — Remote config push notification
+10. SA-P2-003 — Minimum app version enforcement
+11. SA-P2-004 — Compliance status aggregation
+12. SA-P2-005 — Force POS sync trigger
+13. SA-P2-006 — Product category manual override
+14. SA-P2-007 — BNPL limit adjustment UI
+15. SA-P2-008 — Retailer bulk import notification
+16. SA-P2-009 — Device hardware whitelist
+17. SA-P2-010 — Retailer user force password reset
+
+**DEFERRED — 8 tickets (post go-live):**
+- SA-P0-002 — Discount limits & approval gate
+- SA-P0-003 — Price bounds enforcement
+- SA-P1-002 — Spending limits (Retailer Dashboard)
+- SA-P1-003 — Due limits (Retailer Dashboard)
+- SA-P1-010 — Anomaly detection & alerting
+- SA-P1-011 — Stock adjustment audit logging (Retailer Dashboard)
+- SA-P1-013 — Device token revocation UI
+- SA-P2-011 — Persistent rate limiting
+
+### Next Action
+- Await operator instruction on which ticket to start
+- Suggested order: SA-P0-001 → SA-P0-007 → SA-P0-004 (P0s first)
+- Rule: One ticket per branch, one PR per ticket

--- a/RELEASES/SUPERADMIN_IMPLEMENTATION_TICKETS.md
+++ b/RELEASES/SUPERADMIN_IMPLEMENTATION_TICKETS.md
@@ -16,7 +16,14 @@
 > | SA-P1-003 | Due limits → **Retailer Dashboard** (retailer-owned) |
 > | SA-P1-011 | Stock adjustment logging → **Retailer Dashboard** (retailer-owned) |
 > | SA-P1-015 | Reorder policy supervision → **Retailer Dashboard** (store-owned) |
-> | **ALL** | **ALL 33 tickets (P0 + P1 + P2) are CRITICAL before go-live** — no phasing |
+>
+> ## PHASING DECISION (2026-02-10)
+>
+> | Category | Tickets | Count |
+> |----------|---------|-------|
+> | **ALREADY MERGED** | SA-P0-005, SA-P0-006, SA-P1-001, SA-P1-004, SA-P1-005, SA-P1-006, SA-P1-007, SA-P1-008 | 8 |
+> | **CRITICAL GO-LIVE** | SA-P0-001, SA-P0-004, SA-P0-007, SA-P1-009, SA-P1-012, SA-P1-014, SA-P1-015, SA-P2-001 thru SA-P2-010 | 17 |
+> | **DEFERRED (post go-live)** | SA-P0-002, SA-P0-003, SA-P1-002, SA-P1-003, SA-P1-010, SA-P1-011, SA-P1-013, SA-P2-011 | 8 |
 
 ---
 
@@ -794,56 +801,62 @@ Reorder policies control automated purchasing. Retailers need visibility into po
 
 ---
 
-## TICKET SUMMARY
+## TICKET SUMMARY (Updated 2026-02-10)
 
-| Priority | Count | Ticket IDs |
-|----------|-------|------------|
-| **P0** | **7** | SA-P0-001 through SA-P0-007 |
-| **P1** | **15** | SA-P1-001 through SA-P1-015 |
-| **P2** | **11** | SA-P2-001 through SA-P2-011 |
+| Category | Count | Details |
+|----------|-------|---------|
+| **Already Merged** | **8** | SA-P0-005, SA-P0-006, SA-P1-001, SA-P1-004, SA-P1-005, SA-P1-006, SA-P1-007, SA-P1-008 |
+| **Critical Go-Live** | **17** | 3 P0 + 4 P1 + 10 P2 (see implementation order) |
+| **Deferred (post go-live)** | **8** | SA-P0-002, SA-P0-003, SA-P1-002, SA-P1-003, SA-P1-010, SA-P1-011, SA-P1-013, SA-P2-011 |
 | **Total** | **33** | |
 
 ---
 
-## IMPLEMENTATION ORDER — ALL CRITICAL BEFORE GO-LIVE
+## IMPLEMENTATION ORDER (Updated 2026-02-10)
 
-> **Operator Decision:** ALL 33 tickets (P0 + P1 + P2) are required before go-live. No phasing.
+> **Operator Decision (2026-02-10):** Phased approach. 17 tickets critical for go-live; 8 deferred to post-launch.
 
-### Superadmin Tickets (SA-owned)
-1. SA-P0-005 — Feature kill switch (enables emergency control)
-2. SA-P0-001 — Store suspension (enables rogue store control)
+### ALREADY MERGED (8 tickets — DONE)
+1. ~~SA-P0-005 — Feature kill switch~~ (PR #9 — MERGED)
+2. ~~SA-P0-006 — Refund & sale reversal~~ (PR #11 — MERGED)
+3. ~~SA-P1-001 — Staff identity/RBAC~~ (PR #5 — MERGED)
+4. ~~SA-P1-004 — GRN quantity validation~~ (PR #6 — MERGED)
+5. ~~SA-P1-005 — Supplier suspension~~ (PR #7 — MERGED)
+6. ~~SA-P1-006 — Payment method control per store~~ (PR #8 — MERGED)
+7. ~~SA-P1-007 — Per-store feature flag overrides~~ (PR #9 — MERGED)
+8. ~~SA-P1-008 — Supplier bank detail re-verification~~ (PR #10 — MERGED)
+
+### CRITICAL GO-LIVE (17 tickets — must implement before launch)
+
+**P0 — Go-Live Blockers (3 tickets)**
+1. SA-P0-001 — Store suspension & reactivation
+2. SA-P0-004 — Stock-in supplier info (optional + editable on POS)
 3. SA-P0-007 — Maintenance mode (enables emergency shutdown)
-4. SA-P0-002 — Discount limits (prevents revenue loss)
-5. SA-P0-003 — Price bounds (prevents pricing abuse)
-6. SA-P0-004 — Stock-in supplier info (optional + editable on POS)
-7. SA-P0-006 — Refund capability (basic retail operation)
-8. SA-P1-001 — Staff identity/RBAC
-9. SA-P1-004 — GRN quantity validation
-10. SA-P1-005 — Supplier suspension
-11. SA-P1-006 — Payment method control per store
-12. SA-P1-007 — Per-store feature flag overrides
-13. SA-P1-008 — Supplier bank detail re-verification
-14. SA-P1-009 — Store health dashboard
-15. SA-P1-010 — Anomaly detection & alerting
-16. SA-P1-012 — Offline sale re-validation
-17. SA-P1-013 — Device token revocation UI
-18. SA-P1-014 — Store settings visibility (read-only)
 
-### Retailer Dashboard Tickets (Retailer-owned)
-19. SA-P1-002 — Purchase order spending limits (Retailer Dashboard)
-20. SA-P1-003 — Customer due limits (Retailer Dashboard)
-21. SA-P1-011 — Stock adjustment audit logging (Retailer Dashboard)
-22. SA-P1-015 — Reorder policy supervision (Retailer Dashboard)
+**P1 — Operational (4 tickets)**
+4. SA-P1-009 — Store health dashboard
+5. SA-P1-012 — Offline sale re-validation
+6. SA-P1-014 — Store settings visibility (read-only)
+7. SA-P1-015 — Reorder policy supervision (Retailer Dashboard)
 
-### Platform Tickets (Backend/Infra)
-23. SA-P2-001 — Force device re-enrollment
-24. SA-P2-002 — Remote config push notification
-25. SA-P2-003 — Minimum app version enforcement
-26. SA-P2-004 — Compliance status aggregation
-27. SA-P2-005 — Force POS sync trigger
-28. SA-P2-006 — Product category manual override
-29. SA-P2-007 — BNPL limit adjustment UI
-30. SA-P2-008 — Retailer bulk import notification
-31. SA-P2-009 — Device hardware whitelist
-32. SA-P2-010 — Retailer user force password reset
-33. SA-P2-011 — Persistent rate limiting
+**P2 — Platform (10 tickets)**
+8. SA-P2-001 — Force device re-enrollment
+9. SA-P2-002 — Remote config push notification
+10. SA-P2-003 — Minimum app version enforcement
+11. SA-P2-004 — Compliance status aggregation
+12. SA-P2-005 — Force POS sync trigger
+13. SA-P2-006 — Product category manual override
+14. SA-P2-007 — BNPL limit adjustment UI
+15. SA-P2-008 — Retailer bulk import notification
+16. SA-P2-009 — Device hardware whitelist
+17. SA-P2-010 — Retailer user force password reset
+
+### DEFERRED — POST GO-LIVE (8 tickets)
+- SA-P0-002 — Discount limits & approval gate
+- SA-P0-003 — Price bounds enforcement
+- SA-P1-002 — Purchase order spending limits (Retailer Dashboard)
+- SA-P1-003 — Customer due limits (Retailer Dashboard)
+- SA-P1-010 — Anomaly detection & alerting
+- SA-P1-011 — Stock adjustment audit logging (Retailer Dashboard)
+- SA-P1-013 — Device token revocation UI
+- SA-P2-011 — Persistent rate limiting

--- a/backend/src/routes/v1/admin/stores.ts
+++ b/backend/src/routes/v1/admin/stores.ts
@@ -706,10 +706,14 @@ adminStoresRouter.patch("/stores/:storeId/status", requirePermission("stores", "
     }
 
     // Perform the transition
+    // SA-P0-001: Skip validation for admin-initiated reactivation (SUSPENDED→ACTIVE)
+    // Matches reactivateStore() which uses skipValidation to bypass readiness flag checks
+    const skipValidation = currentStore.status === "SUSPENDED" && newStatus === "ACTIVE";
     const result = await transitionStore(storeId, newStatus, {
       reason: reason || undefined,
       changedBy: adminId,
       changedByType: "admin",
+      skipValidation,
     });
 
     if (!result.success) {

--- a/backend/src/routes/v1/pos/store.ts
+++ b/backend/src/routes/v1/pos/store.ts
@@ -11,8 +11,9 @@ posStoreRouter.get("/stores/:storeId/status", requireDeviceToken, async (req, re
 
   const { storeId } = (req as any).posDevice as { storeId: string };
 
+  // SA-P0-001: Return raw status and suspension reason alongside active boolean
   const result = await pool.query(
-    `SELECT id::TEXT as id, name, (status = 'ACTIVE') AS active FROM platform.stores WHERE id = $1::uuid`,
+    `SELECT id::TEXT as id, name, status, status_reason, (status = 'ACTIVE') AS active FROM platform.stores WHERE id = $1::uuid`,
     [storeId]
   );
   const store = result.rows[0];
@@ -20,5 +21,11 @@ posStoreRouter.get("/stores/:storeId/status", requireDeviceToken, async (req, re
     return res.status(404).json({ error: "store not found" });
   }
 
-  return res.json({ storeId: store.id, active: Boolean(store.active), name: store.name });
+  return res.json({
+    storeId: store.id,
+    active: Boolean(store.active),
+    name: store.name,
+    status: store.status,
+    statusReason: store.status_reason ?? null,
+  });
 });

--- a/backend/src/services/storeStateMachine.ts
+++ b/backend/src/services/storeStateMachine.ts
@@ -195,7 +195,7 @@ export async function getStoreStatus(storeId: string): Promise<StoreWithStatus |
       status_reason,
       COALESCE(status_updated_at, created_at) as status_updated_at
     FROM platform.stores
-    WHERE id = $1 AND status != 'deleted'`,
+    WHERE id = $1::uuid AND status != 'deleted'`,
     [storeId]
   );
 
@@ -239,7 +239,7 @@ export async function transitionStore(
         status_reason,
         COALESCE(status_updated_at, created_at) as status_updated_at
       FROM platform.stores
-      WHERE id = $1 AND status != 'deleted'
+      WHERE id = $1::uuid AND status != 'deleted'
       FOR UPDATE`,
       [storeId]
     );
@@ -287,13 +287,13 @@ export async function transitionStore(
     const updateResult = await client.query<StoreWithStatus>(
       `UPDATE platform.stores
       SET
-        status = $2,
+        status = $2::varchar,
         status_reason = $3,
         status_updated_at = NOW(),
-        status_updated_by = $4,
-        admin_approved = CASE WHEN $2 = 'ACTIVE' THEN true ELSE admin_approved END,
+        status_updated_by = $4::uuid,
+        admin_approved = CASE WHEN $2::varchar = 'ACTIVE' THEN true ELSE admin_approved END,
         updated_at = NOW()
-      WHERE id = $1
+      WHERE id = $1::uuid
       RETURNING
         id,
         name,
@@ -304,7 +304,10 @@ export async function transitionStore(
         admin_approved,
         status_reason,
         status_updated_at`,
-      [storeId, newStatus, options.reason || null, options.changedBy || null]
+      [storeId, newStatus, options.reason || null,
+       // SA-P0-001: status_updated_by is uuid; pass null if changedBy is not a valid UUID
+       options.changedBy && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(options.changedBy)
+         ? options.changedBy : null]
     );
 
     await client.query("COMMIT");
@@ -363,7 +366,7 @@ export async function updateStoreFlags(
   const result = await pool.query<StoreWithStatus>(
     `UPDATE platform.stores
     SET ${setClauses.join(", ")}
-    WHERE id = $1 AND status != 'deleted'
+    WHERE id = $1::uuid AND status != 'deleted'
     RETURNING
       id,
       name,

--- a/e2e-tests/tests/store-suspension/helpers.ts
+++ b/e2e-tests/tests/store-suspension/helpers.ts
@@ -1,0 +1,252 @@
+/**
+ * Shared test utilities for SA-P0-001: Store Suspension & Reactivation tests
+ * @store_suspension
+ */
+import { APIRequestContext, expect } from "@playwright/test";
+
+export const API_BASE = process.env.API_BASE_URL || "http://localhost:3010";
+export const ADMIN_TOKEN = process.env.ADMIN_TOKEN || "local-test-token";
+export const RUN_ID =
+  Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+
+// ---------------------------------------------------------------------------
+// Rate-limit retry
+// ---------------------------------------------------------------------------
+
+async function retryOn429<T extends { status: number }>(
+  fn: () => Promise<T>,
+  maxRetries = 3
+): Promise<T> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    const result = await fn();
+    if (result.status !== 429 || attempt === maxRetries) return result;
+    await new Promise((r) => setTimeout(r, 10_000));
+  }
+  return fn();
+}
+
+export async function withRateLimitRetry(
+  fn: () => Promise<{ status: number; body: any }>
+): Promise<{ status: number; body: any }> {
+  return retryOn429(fn);
+}
+
+// ---------------------------------------------------------------------------
+// Unique data generators
+// ---------------------------------------------------------------------------
+
+let phoneCounter = 0;
+export function uniquePhone(): string {
+  phoneCounter++;
+  const ts = Date.now().toString().slice(-5);
+  const rnd = Math.floor(Math.random() * 100)
+    .toString()
+    .padStart(2, "0");
+  const cnt = phoneCounter.toString().padStart(2, "0");
+  return `+918${ts}${rnd}${cnt}`;
+}
+
+let gstinCounter = 0;
+export function uniqueGstin(): string {
+  gstinCounter++;
+  const alpha = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const r = () => alpha[Math.floor(Math.random() * 26)];
+  const cnt = gstinCounter.toString().padStart(4, "0");
+  return `27${r()}${r()}${r()}SS${cnt}A1Z5`;
+}
+
+// ---------------------------------------------------------------------------
+// Context types
+// ---------------------------------------------------------------------------
+
+export interface TestStoreContext {
+  storeId: string;
+  deviceToken: string;
+  enrollmentCode: string;
+}
+
+// ---------------------------------------------------------------------------
+// Auth header builders
+// ---------------------------------------------------------------------------
+
+export function adminHeaders() {
+  return {
+    "x-admin-token": ADMIN_TOKEN,
+    "Content-Type": "application/json",
+  };
+}
+
+export function posHeaders(deviceToken: string) {
+  return {
+    "x-device-token": deviceToken,
+    "Content-Type": "application/json",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Store setup helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a store and enroll a POS device via admin endpoints.
+ * Uses admin store creation (no OTP needed) + admin enrollment code + POS enroll.
+ * Store starts in DRAFT status after creation.
+ */
+export async function setupTestStore(
+  request: APIRequestContext,
+  suffix: string
+): Promise<TestStoreContext> {
+  // Step 1: Create store via admin endpoint (no OTP required)
+  const createRes = await request.post(`${API_BASE}/api/v1/admin/stores`, {
+    headers: adminHeaders(),
+    data: {
+      storeName: `Suspend Test ${suffix} ${RUN_ID}`,
+    },
+  });
+
+  expect(createRes.status(), `Store creation failed for ${suffix}`).toBe(201);
+  const createBody = await createRes.json();
+  const storeId = createBody.store?.id;
+  expect(storeId, "storeId missing from admin store creation").toBeTruthy();
+
+  // Step 2: Create enrollment code via admin endpoint
+  const enrollCodeRes = await request.post(
+    `${API_BASE}/api/v1/admin/stores/${storeId}/device-enrollments`,
+    { headers: adminHeaders() }
+  );
+
+  expect(enrollCodeRes.status(), `Enrollment code creation failed for ${suffix}`).toBe(200);
+  const enrollCodeBody = await enrollCodeRes.json();
+  const enrollmentCode = enrollCodeBody.code;
+  expect(enrollmentCode, "enrollmentCode missing").toBeTruthy();
+
+  // Step 3: Enroll POS device
+  const enrollRes = await request.post(`${API_BASE}/api/v1/pos/enroll`, {
+    data: {
+      code: enrollmentCode,
+      deviceMeta: {
+        label: `suspend-test-${suffix}-${RUN_ID}`,
+        deviceType: "RETAILER_PHONE",
+        model: "TestDevice",
+        manufacturer: "TestMfg",
+        appVersion: "1.0.0",
+      },
+    },
+  });
+
+  expect(enrollRes.status(), `Enrollment failed for ${suffix}`).toBeLessThan(300);
+  const enrollBody = await enrollRes.json();
+  const deviceToken = enrollBody.deviceToken;
+  expect(deviceToken, "deviceToken missing").toBeTruthy();
+
+  return { storeId, deviceToken, enrollmentCode };
+}
+
+// ---------------------------------------------------------------------------
+// Admin store status helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Admin: Change store status via state machine.
+ * Auto-retries on 429.
+ */
+export async function adminChangeStoreStatus(
+  request: APIRequestContext,
+  storeId: string,
+  status: string,
+  reason?: string
+): Promise<{ status: number; body: any }> {
+  const makeRequest = async () => {
+    const res = await request.patch(
+      `${API_BASE}/api/v1/admin/stores/${storeId}/status`,
+      {
+        headers: adminHeaders(),
+        data: { status, reason },
+      }
+    );
+    const body = await res.json().catch(() => ({}));
+    return { status: res.status(), body };
+  };
+
+  return retryOn429(makeRequest);
+}
+
+/**
+ * Admin: Activate a store by pushing it through the state machine.
+ * DRAFT → SUSPENDED (admin override) → ACTIVE (reactivate with skipValidation)
+ * This bypasses the normal enrollment flow for testing purposes.
+ */
+export async function adminActivateStore(
+  request: APIRequestContext,
+  storeId: string
+): Promise<void> {
+  // Use SUSPENDED as intermediate state (DRAFT → SUSPENDED is valid)
+  // Then SUSPENDED → ACTIVE (reactivateStore uses skipValidation)
+  const suspendRes = await adminChangeStoreStatus(
+    request,
+    storeId,
+    "SUSPENDED",
+    "E2E test: intermediate state"
+  );
+  expect(
+    suspendRes.status,
+    `Failed to transition DRAFT→SUSPENDED (${suspendRes.status}): ${JSON.stringify(suspendRes.body)}`
+  ).toBe(200);
+
+  const activateRes = await adminChangeStoreStatus(
+    request,
+    storeId,
+    "ACTIVE",
+    "E2E test: activating store"
+  );
+  expect(
+    activateRes.status,
+    `Failed to transition SUSPENDED→ACTIVE (${activateRes.status}): ${JSON.stringify(activateRes.body)}`
+  ).toBe(200);
+}
+
+/**
+ * Admin: Get store status history (audit trail).
+ */
+export async function getStoreStatusHistory(
+  request: APIRequestContext,
+  storeId: string
+): Promise<any[]> {
+  const res = await request.get(
+    `${API_BASE}/api/v1/admin/stores/${storeId}/status-history`,
+    { headers: adminHeaders() }
+  );
+  expect(res.status()).toBe(200);
+  const body = await res.json();
+  return body.history || body.status_history || [];
+}
+
+/**
+ * POS: Get store status via POS endpoint.
+ */
+export async function getPosStoreStatus(
+  request: APIRequestContext,
+  storeId: string,
+  deviceToken: string
+): Promise<{ status: number; body: any }> {
+  const res = await request.get(
+    `${API_BASE}/api/v1/pos/stores/${storeId}/status`,
+    { headers: posHeaders(deviceToken) }
+  );
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status(), body };
+}
+
+/**
+ * POS: Get ui-status via POS endpoint.
+ */
+export async function getPosUiStatus(
+  request: APIRequestContext,
+  deviceToken: string
+): Promise<{ status: number; body: any }> {
+  const res = await request.get(`${API_BASE}/api/v1/pos/ui-status`, {
+    headers: posHeaders(deviceToken),
+  });
+  const body = await res.json().catch(() => ({}));
+  return { status: res.status(), body };
+}

--- a/e2e-tests/tests/store-suspension/store-suspension.spec.ts
+++ b/e2e-tests/tests/store-suspension/store-suspension.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * SA-P0-001: Store Suspension & Reactivation — E2E Tests
+ * @store_suspension
+ *
+ * Full end-to-end flow:
+ * 1. Create and activate a test store with enrolled POS device
+ * 2. Suspend store with reason → verify status=SUSPENDED
+ * 3. POS store status returns active=false, status=SUSPENDED
+ * 4. POS ui-status returns storeActive=false, storeStatus=SUSPENDED
+ * 5. Reactivate store → verify status=ACTIVE
+ * 6. POS endpoints reflect active=true after reactivation
+ * 7. Audit trail: verify suspension and reactivation logged
+ * 8. Edge cases: invalid transitions, double-suspend
+ *
+ * Run:
+ *   npx playwright test --grep "@store_suspension" --project=chromium
+ *
+ * Prerequisites:
+ *   - Backend running at localhost:3010 (or set API_BASE_URL)
+ *   - Migrations applied (094, 095, 096 for store state machine + audit)
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  setupTestStore,
+  adminActivateStore,
+  adminChangeStoreStatus,
+  getStoreStatusHistory,
+  getPosStoreStatus,
+  getPosUiStatus,
+  TestStoreContext,
+} from "./helpers";
+
+// API-only tests: run sequentially on chromium only
+test.use({ browserName: "chromium" });
+
+test.describe.serial(
+  "@store_suspension SA-P0-001: Store Suspension & Reactivation",
+  () => {
+    // Admin endpoints share a rate limiter; allow extra time
+    test.describe.configure({ timeout: 180_000 });
+
+    let store: TestStoreContext;
+
+    // =========================================================================
+    // SETUP
+    // =========================================================================
+
+    test("0. Setup: register and activate a test store", async ({ request }) => {
+      store = await setupTestStore(request, "susp1");
+
+      // Activate store via admin (DRAFT → SUSPENDED → ACTIVE)
+      await adminActivateStore(request, store.storeId);
+
+      // Verify store is now ACTIVE
+      const posStatus = await getPosStoreStatus(
+        request,
+        store.storeId,
+        store.deviceToken
+      );
+      expect(posStatus.status).toBe(200);
+      expect(posStatus.body.active).toBe(true);
+      expect(posStatus.body.status).toBe("ACTIVE");
+    });
+
+    // =========================================================================
+    // SUSPEND
+    // =========================================================================
+
+    test("1. Admin suspends store with reason", async ({ request }) => {
+      const result = await adminChangeStoreStatus(
+        request,
+        store.storeId,
+        "SUSPENDED",
+        "Fraud investigation - suspicious activity detected"
+      );
+
+      expect(result.status, `Suspend failed: ${JSON.stringify(result.body)}`).toBe(200);
+      expect(result.body.store.status).toBe("SUSPENDED");
+      expect(result.body.previous_status).toBe("ACTIVE");
+    });
+
+    test("2. POS store status returns active=false when SUSPENDED", async ({
+      request,
+    }) => {
+      const posStatus = await getPosStoreStatus(
+        request,
+        store.storeId,
+        store.deviceToken
+      );
+
+      expect(posStatus.status).toBe(200);
+      expect(posStatus.body.active).toBe(false);
+      expect(posStatus.body.status).toBe("SUSPENDED");
+      expect(posStatus.body.statusReason).toContain("Fraud investigation");
+    });
+
+    test("3. POS ui-status returns storeActive=false, storeStatus=SUSPENDED", async ({
+      request,
+    }) => {
+      const uiStatus = await getPosUiStatus(request, store.deviceToken);
+
+      expect(uiStatus.status).toBe(200);
+      expect(uiStatus.body.storeActive).toBe(false);
+      expect(uiStatus.body.storeStatus).toBe("SUSPENDED");
+    });
+
+    // =========================================================================
+    // REACTIVATE
+    // =========================================================================
+
+    test("4. Admin reactivates suspended store", async ({ request }) => {
+      const result = await adminChangeStoreStatus(
+        request,
+        store.storeId,
+        "ACTIVE",
+        "Investigation complete - cleared"
+      );
+
+      expect(result.status, `Reactivate failed: ${JSON.stringify(result.body)}`).toBe(200);
+      expect(result.body.store.status).toBe("ACTIVE");
+      expect(result.body.previous_status).toBe("SUSPENDED");
+    });
+
+    test("5. POS store status returns active=true after reactivation", async ({
+      request,
+    }) => {
+      const posStatus = await getPosStoreStatus(
+        request,
+        store.storeId,
+        store.deviceToken
+      );
+
+      expect(posStatus.status).toBe(200);
+      expect(posStatus.body.active).toBe(true);
+      expect(posStatus.body.status).toBe("ACTIVE");
+    });
+
+    test("6. POS ui-status returns storeActive=true after reactivation", async ({
+      request,
+    }) => {
+      const uiStatus = await getPosUiStatus(request, store.deviceToken);
+
+      expect(uiStatus.status).toBe(200);
+      expect(uiStatus.body.storeActive).toBe(true);
+      expect(uiStatus.body.storeStatus).toBe("ACTIVE");
+    });
+
+    // =========================================================================
+    // AUDIT TRAIL
+    // =========================================================================
+
+    test("7. Audit trail records suspension and reactivation", async ({
+      request,
+    }) => {
+      const history = await getStoreStatusHistory(request, store.storeId);
+
+      // Should have at least: initial→SUSPENDED(setup)→ACTIVE(setup)→SUSPENDED→ACTIVE
+      expect(history.length).toBeGreaterThanOrEqual(4);
+
+      // Find the ACTIVE→SUSPENDED entry (from test 1)
+      const suspendEntry = history.find(
+        (h: any) => h.old_status === "ACTIVE" && h.new_status === "SUSPENDED"
+      );
+      expect(suspendEntry, "Suspend audit entry not found").toBeTruthy();
+      expect(suspendEntry.reason).toContain("Fraud investigation");
+
+      // Find the SUSPENDED→ACTIVE entry (from test 4)
+      const reactivateEntry = history.find(
+        (h: any) =>
+          h.old_status === "SUSPENDED" &&
+          h.new_status === "ACTIVE" &&
+          h.reason?.includes("Investigation complete")
+      );
+      expect(reactivateEntry, "Reactivate audit entry not found").toBeTruthy();
+    });
+
+    // =========================================================================
+    // EDGE CASES
+    // =========================================================================
+
+    test("8. Cannot suspend an already-SUSPENDED store", async ({ request }) => {
+      // First suspend the store
+      const suspendRes = await adminChangeStoreStatus(
+        request,
+        store.storeId,
+        "SUSPENDED",
+        "Suspending again for edge case test"
+      );
+      expect(suspendRes.status).toBe(200);
+
+      // Try to suspend again — should fail (SUSPENDED→SUSPENDED is not a valid transition)
+      const doubleSuspend = await adminChangeStoreStatus(
+        request,
+        store.storeId,
+        "SUSPENDED",
+        "Double suspend attempt"
+      );
+      expect(doubleSuspend.status).toBe(400);
+      expect(doubleSuspend.body.error).toBe("invalid_transition");
+
+      // Clean up: reactivate
+      await adminChangeStoreStatus(
+        request,
+        store.storeId,
+        "ACTIVE",
+        "Cleanup after edge case test"
+      );
+    });
+
+    test("9. Cannot transition ACTIVE to invalid status", async ({
+      request,
+    }) => {
+      // ACTIVE → DRAFT is not a valid transition
+      const result = await adminChangeStoreStatus(
+        request,
+        store.storeId,
+        "DRAFT",
+        "Invalid transition attempt"
+      );
+
+      expect(result.status).toBe(400);
+      expect(result.body.error).toBe("invalid_transition");
+    });
+  }
+);

--- a/retailer-admin/src/components/LimitedModeBanner.tsx
+++ b/retailer-admin/src/components/LimitedModeBanner.tsx
@@ -38,6 +38,14 @@ const STATUS_CONFIG: Record<string, { color: string; bgColor: string; borderColo
     label: 'Action Required',
     message: 'Please update your information and resubmit.',
   },
+  // SA-P0-001: Store suspension display
+  SUSPENDED: {
+    color: '#991b1b',
+    bgColor: '#fee2e2',
+    borderColor: '#f87171',
+    label: 'Suspended',
+    message: 'Your store has been temporarily suspended. Please contact SuperMandi support.',
+  },
   EXPIRED: {
     color: '#374151',
     bgColor: '#f3f4f6',

--- a/src/components/LimitedModeBanner.tsx
+++ b/src/components/LimitedModeBanner.tsx
@@ -57,6 +57,15 @@ const STATUS_CONFIG: Record<string, {
     label: "Action Required",
     message: "Please update your information and resubmit.",
   },
+  // SA-P0-001: Store suspension display
+  SUSPENDED: {
+    color: "#991B1B",
+    bgColor: "#FEE2E2",
+    borderColor: "#EF4444",
+    icon: "store-alert-outline",
+    label: "Suspended",
+    message: "This store has been temporarily suspended by the administrator. Contact support for details.",
+  },
   REJECTED: {
     color: "#991B1B",
     bgColor: "#FEE2E2",

--- a/supermandi-superadmin/src/App.tsx
+++ b/supermandi-superadmin/src/App.tsx
@@ -5,7 +5,7 @@ import { fetchHealth } from "./api/health";
 import { fetchPosEvents, type PosEvent } from "./api/posEvents";
 import { askAi, fetchAiHealth } from "./api/ai";
 import { hasValidSession, logout, refreshSession, sendAdminOtp, verifyAdminOtp, startIdleTimeout, stopIdleTimeout, abortActiveRequests } from "./api/authToken";
-import { createStore, fetchStore, fetchStores, updateStore, type StoreRecord } from "./api/stores";
+import { createStore, fetchStore, fetchStores, updateStore, changeStoreStatus, type StoreRecord } from "./api/stores";
 import { fetchDevices, patchDevice, type DeviceRecord } from "./api/devices";
 import { createDeviceEnrollment, type DeviceEnrollmentResponse } from "./api/deviceEnrollments";
 import {
@@ -749,6 +749,16 @@ export default function App() {
   const [suspendReason, setSuspendReason] = useState("");
   const [supplierSuspendLoading, setSupplierSuspendLoading] = useState(false);
 
+  // SA-P0-001: Store suspension modal state
+  const [pendingStoreSuspend, setPendingStoreSuspend] = useState<{
+    storeId: string;
+    storeName: string;
+    action: "suspend" | "reactivate";
+  } | null>(null);
+  const [storeSuspendReason, setStoreSuspendReason] = useState("");
+  const [storeSuspendLoading, setStoreSuspendLoading] = useState(false);
+  const [storeSuspendError, setStoreSuspendError] = useState("");
+
   // SA-1.3-001 to SA-1.3-003: Product Approval State
   const [pendingProducts, setPendingProducts] = useState<PendingProduct[]>([]);
   const [productActionLoading, setProductActionLoading] = useState<Record<string, boolean>>({});
@@ -1050,6 +1060,37 @@ export default function App() {
       setSupplierActionError(e instanceof Error ? e.message : "Failed to update supplier status");
     } finally {
       setSupplierSuspendLoading(false);
+    }
+  }
+
+  // SA-P0-001: Request store status change (opens confirmation modal)
+  function requestStoreStatusChange(storeId: string, storeName: string, action: "suspend" | "reactivate") {
+    setPendingStoreSuspend({ storeId, storeName, action });
+    setStoreSuspendReason("");
+    setStoreSuspendError("");
+  }
+
+  // SA-P0-001: Execute store status change after confirmation
+  async function executeStoreStatusChange() {
+    if (!pendingStoreSuspend) return;
+    const { storeId, action } = pendingStoreSuspend;
+    const newStatus = action === "suspend" ? "SUSPENDED" : "ACTIVE";
+    setStoreSuspendLoading(true);
+    setStoreSuspendError("");
+    try {
+      await changeStoreStatus(storeId, newStatus, storeSuspendReason || undefined);
+      // Update local state
+      setStoreDirectory((prev) =>
+        prev.map((s) =>
+          s.id === storeId ? { ...s, status: newStatus, active: newStatus === "ACTIVE" } : s
+        )
+      );
+      setPendingStoreSuspend(null);
+      setStoreSuspendReason("");
+    } catch (e: unknown) {
+      setStoreSuspendError(e instanceof Error ? e.message : "Failed to update store status");
+    } finally {
+      setStoreSuspendLoading(false);
     }
   }
 
@@ -3150,11 +3191,44 @@ export default function App() {
                               {isExpanded ? " ▲" : " ▼"}
                             </button>
                           </td>
-                          <td className="mono">{s.active ? "active" : "inactive"}</td>
+                          {/* SA-P0-001: Show raw status with color coding */}
                           <td>
+                            <span className="mono" style={{
+                              padding: "2px 8px",
+                              borderRadius: 4,
+                              fontSize: 12,
+                              fontWeight: 600,
+                              ...(s.status === "SUSPENDED"
+                                ? { background: "#fee2e2", color: "#991b1b" }
+                                : s.status === "ACTIVE"
+                                ? { background: "#dcfce7", color: "#166534" }
+                                : { background: "#f3f4f6", color: "#374151" }),
+                            }}>
+                              {s.status ?? (s.active ? "ACTIVE" : "INACTIVE")}
+                            </span>
+                          </td>
+                          <td style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
                             <button onClick={() => handleStoreNameSave(s.id)} disabled={storeNameSaving[s.id]}>
                               {storeNameSaving[s.id] ? "Saving..." : "Save"}
                             </button>
+                            {/* SA-P0-001: Suspend/Reactivate buttons */}
+                            {s.status === "ACTIVE" && (
+                              <button
+                                className="btnDanger"
+                                style={{ fontSize: 12, padding: "4px 8px" }}
+                                onClick={() => requestStoreStatusChange(s.id, s.name ?? s.storeName ?? s.id, "suspend")}
+                              >
+                                Suspend
+                              </button>
+                            )}
+                            {s.status === "SUSPENDED" && (
+                              <button
+                                style={{ fontSize: 12, padding: "4px 8px", background: "#16a34a", color: "white", border: "none", borderRadius: 6, cursor: "pointer" }}
+                                onClick={() => requestStoreStatusChange(s.id, s.name ?? s.storeName ?? s.id, "reactivate")}
+                              >
+                                Reactivate
+                              </button>
+                            )}
                           </td>
                         </tr>
                         {isExpanded && (
@@ -5697,6 +5771,61 @@ export default function App() {
                   disabled={supplierSuspendLoading}
                 >
                   {supplierSuspendLoading ? "Reactivating..." : "Reactivate Supplier"}
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* SA-P0-001: Store Suspension/Reactivation Confirmation Modal */}
+      {pendingStoreSuspend && (
+        <div className="modalOverlay" onClick={() => { if (!storeSuspendLoading) setPendingStoreSuspend(null); }}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modalHeader">
+              <h3>{pendingStoreSuspend.action === "suspend" ? "Confirm Store Suspension" : "Confirm Store Reactivation"}</h3>
+            </div>
+            <div className="modalBody">
+              {pendingStoreSuspend.action === "suspend" ? (
+                <>
+                  <p>Are you sure you want to suspend <strong>{pendingStoreSuspend.storeName}</strong>?</p>
+                  <p className="muted" style={{ color: "#b45309" }}>This will immediately block all POS transactions for this store. The store's devices will show a "Suspended" screen.</p>
+                  <div className="control" style={{ marginTop: 12 }}>
+                    <label>Reason for suspension (required)</label>
+                    <textarea
+                      value={storeSuspendReason}
+                      onChange={(e) => setStoreSuspendReason(e.target.value)}
+                      placeholder="Enter reason (minimum 10 characters)..."
+                      rows={3}
+                      style={{ width: "100%", resize: "vertical" }}
+                    />
+                  </div>
+                </>
+              ) : (
+                <>
+                  <p>Are you sure you want to reactivate <strong>{pendingStoreSuspend.storeName}</strong>?</p>
+                  <p className="muted">This will restore POS transactions and normal operations for this store.</p>
+                </>
+              )}
+              {storeSuspendError && <p className="errorText" style={{ marginTop: 8 }}>{storeSuspendError}</p>}
+            </div>
+            <div className="modalFooter">
+              <button className="btnGhost" onClick={() => setPendingStoreSuspend(null)} disabled={storeSuspendLoading}>Cancel</button>
+              {pendingStoreSuspend.action === "suspend" ? (
+                <button
+                  className="btnDanger"
+                  onClick={executeStoreStatusChange}
+                  disabled={storeSuspendLoading || storeSuspendReason.trim().length < 10}
+                >
+                  {storeSuspendLoading ? "Suspending..." : "Suspend Store"}
+                </button>
+              ) : (
+                <button
+                  style={{ background: "#16a34a", color: "white", border: "none", borderRadius: 6, padding: "8px 16px", cursor: "pointer" }}
+                  onClick={executeStoreStatusChange}
+                  disabled={storeSuspendLoading}
+                >
+                  {storeSuspendLoading ? "Reactivating..." : "Reactivate Store"}
                 </button>
               )}
             </div>

--- a/supermandi-superadmin/src/api/stores.ts
+++ b/supermandi-superadmin/src/api/stores.ts
@@ -8,6 +8,8 @@ export type StoreRecord = {
   storeName?: string | null;
   upi_vpa?: string | null;
   active?: boolean;
+  status?: string | null; // SA-P0-001: Raw store status (DRAFT, ACTIVE, SUSPENDED, etc.)
+  status_reason?: string | null; // SA-P0-001: Reason for current status
   address?: string | null;
   contact_name?: string | null;
   contact_phone?: string | null;
@@ -148,4 +150,76 @@ export async function updateStore(
 
   const data = await res.json();
   return (data?.store ?? {}) as StoreRecord;
+}
+
+// =============================================================================
+// SA-P0-001: Store Suspension / Reactivation
+// =============================================================================
+
+export type StoreStatusHistoryEntry = {
+  id: string;
+  old_status: string | null;
+  new_status: string;
+  reason: string | null;
+  changed_by: string | null;
+  changed_by_type: string | null;
+  changed_at: string;
+};
+
+/**
+ * Change store status (suspend/reactivate) via state machine
+ */
+export async function changeStoreStatus(
+  storeId: string,
+  status: string,
+  reason?: string
+): Promise<{ store: StoreRecord; previous_status: string; status_history: StoreStatusHistoryEntry[] }> {
+  const base = requireApiBase();
+
+  const res = await fetchWithTimeout(
+    `${base}/api/v1/admin/stores/${encodeURIComponent(storeId)}/status`,
+    {
+      method: "PATCH",
+      headers: {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+        ...getAuthHeaders(),
+      },
+      body: JSON.stringify({ status, reason }),
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(await parseError(res));
+  }
+
+  return res.json();
+}
+
+/**
+ * Fetch store status change history (audit trail)
+ */
+export async function fetchStoreStatusHistory(
+  storeId: string
+): Promise<StoreStatusHistoryEntry[]> {
+  const base = requireApiBase();
+
+  const res = await fetchWithTimeout(
+    `${base}/api/v1/admin/stores/${encodeURIComponent(storeId)}/status-history`,
+    {
+      method: "GET",
+      cache: "no-store",
+      headers: {
+        Accept: "application/json",
+        ...getAuthHeaders(),
+      },
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(await parseError(res));
+  }
+
+  const data = await res.json();
+  return Array.isArray(data?.history) ? data.history : [];
 }


### PR DESCRIPTION
## Summary
- **Store state machine**: Admin can suspend/reactivate stores via SuperAdmin UI with confirmation modal + reason input
- **POS impact**: Suspended stores immediately enter LIMITED MODE with red "Suspended" banner (POS + Retailer Portal)
- **Backend hardening**: PG16 type cast fixes, UUID validation for changedBy, skipValidation for admin reactivation
- **E2E proof**: 10 Playwright tests covering full cycle + edge cases, 2x PASS against Docker local-prod stack

## Files Changed (12)
| Area | Files | Change |
|------|-------|--------|
| Backend | `storeStateMachine.ts`, `admin/stores.ts`, `pos/store.ts` | PG16 fix, skipValidation, raw status endpoint |
| SuperAdmin | `App.tsx`, `api/stores.ts` | Suspend/Reactivate UI + API |
| POS | `LimitedModeBanner.tsx` | SUSPENDED status config |
| Retailer | `LimitedModeBanner.tsx` | SUSPENDED status config |
| E2E | `store-suspension/helpers.ts`, `store-suspension.spec.ts` | 10 tests |
| Docs | `MASTER_PLAN.md`, `RESUME_ANCHOR.md`, `SUPERADMIN_IMPLEMENTATION_TICKETS.md` | Status updates |

## Test plan
- [x] `pnpm -r typecheck` — 22/22 PASS
- [x] Docker local-prod stack (17 containers, NODE_ENV=production, PG 16.11)
- [x] E2E Run 1: 10/10 PASS (2.9s)
- [x] E2E Run 2: 10/10 PASS (2.2s) — zero flakes
- [ ] CI check-suites triggered
- [ ] Staging deploy + same E2E spec

## Rollback
`git revert <merge-sha>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)