### PR TITLE
chore: archive stash backups before new plan cut

### DIFF
--- a/RELEASES/stash-0-trace-2026-01-15.patch
+++ b/RELEASES/stash-0-trace-2026-01-15.patch
@@ -1,0 +1,948 @@
+diff --git a/backend/src/routes/v1/pos/storeProducts.ts b/backend/src/routes/v1/pos/storeProducts.ts
+index 0f3d78d..21ef82a 100644
+--- a/backend/src/routes/v1/pos/storeProducts.ts
++++ b/backend/src/routes/v1/pos/storeProducts.ts
+@@ -2,25 +2,34 @@ import { Router } from "express";
+ import { requireDeviceToken } from "../../../middleware/deviceToken";
+ import {
+   createStoreProductFromDigitisation,
+-  type CreateStoreProductInput
++  type CreateStoreProductInput,
++  type DigitisationMode
+ } from "../../../services/storeProductDigitisationService";
+ 
+ export const posStoreProductsRouter = Router();
+ 
+ /**
+  * POST /api/v1/pos/store-products
+- * Create a store product during digitisation flow
++ * Create a store product during digitisation flow (SD-ONBOARD-002)
++ *
++ * Supports two modes:
++ * - FAST_SELL: Quick add with minimal fields
++ * - DIGITISATION: Full product capture
+  *
+  * Request body:
+  * {
+  *   "barcode": "8901030000000",
+- *   "name": "Parle-G",
+- *   "sellPrice": 10,       // Minor units (paise) - REQUIRED
+- *   "mrp": 10,             // Minor units (paise) - optional
+- *   "initialStockQty": 48, // REQUIRED
+- *   "unit": "pcs",         // optional
+- *   "description": "",     // optional
+- *   "brand": ""            // optional
++ *   "mode": "FAST_SELL" | "DIGITISATION",  // optional, defaults to FAST_SELL
++ *   "name": "Parle-G",                      // optional for FAST_SELL, required for DIGITISATION
++ *   "sellPrice": 1000,                      // Minor units (paise) - REQUIRED
++ *   "mrp": 1000,                            // Minor units (paise) - optional
++ *   "purchasePrice": 800,                   // Minor units (paise) - required for DIGITISATION
++ *   "initialStockQty": 48,                  // REQUIRED (0 allowed for "stock unknown")
++ *   "unit": "pcs",                          // optional, defaults to "pcs"
++ *   "variant": "Red",                       // optional
++ *   "packSize": "500g",                     // optional
++ *   "description": "",                      // optional
++ *   "brand": ""                             // optional
+  * }
+  *
+  * Response (201 Created):
+@@ -29,13 +38,16 @@ export const posStoreProductsRouter = Router();
+  *     "storeProductId": "...",
+  *     "name": "Parle-G",
+  *     "barcode": "8901030000000",
+- *     "sellPrice": 10,
+- *     "mrp": 10,
++ *     "sellPrice": 1000,
++ *     "mrp": 1000,
++ *     "purchasePrice": 800,
+  *     "stock": { "isKnown": true, "qty": 48 },
+  *     "unit": "pcs",
+  *     "brand": "",
+  *     "description": "",
+- *     "imageUrl": ""
++ *     "imageUrl": "",
++ *     "variant": "",
++ *     "packSize": ""
+  *   }
+  * }
+  *
+@@ -57,14 +69,18 @@ posStoreProductsRouter.post("/store-products", requireDeviceToken, async (req, r
+ 
+   const {
+     barcode,
++    mode,
+     name,
+     sellPrice,
+     mrp,
++    purchasePrice,
+     initialStockQty,
+     unit,
++    variant,
++    packSize,
+     description,
+     brand
+-  } = req.body as Partial<CreateStoreProductInput>;
++  } = req.body as Partial<CreateStoreProductInput & { mode?: DigitisationMode }>;
+ 
+   // Basic validation
+   if (typeof barcode !== "string" || barcode.trim().length === 0) {
+@@ -74,6 +90,9 @@ posStoreProductsRouter.post("/store-products", requireDeviceToken, async (req, r
+     });
+   }
+ 
++  // Validate mode if provided
++  const digitisationMode: DigitisationMode = mode === "DIGITISATION" ? "DIGITISATION" : "FAST_SELL";
++
+   if (typeof sellPrice !== "number" || !Number.isFinite(sellPrice) || sellPrice <= 0) {
+     return res.status(422).json({
+       error: "VALIDATION_ERROR",
+@@ -88,14 +107,28 @@ posStoreProductsRouter.post("/store-products", requireDeviceToken, async (req, r
+     });
+   }
+ 
++  // Mode-specific validation
++  if (digitisationMode === "DIGITISATION") {
++    if (typeof purchasePrice !== "number" || !Number.isFinite(purchasePrice) || purchasePrice < 0) {
++      return res.status(422).json({
++        error: "VALIDATION_ERROR",
++        message: "Purchase price is required for DIGITISATION mode"
++      });
++    }
++  }
++
+   try {
+     const result = await createStoreProductFromDigitisation(storeId, {
+       barcode,
++      mode: digitisationMode,
+       name: name || "",
+       sellPrice,
+       mrp,
++      purchasePrice,
+       initialStockQty,
+       unit,
++      variant,
++      packSize,
+       description,
+       brand
+     });
+diff --git a/backend/src/services/storeProductDigitisationService.ts b/backend/src/services/storeProductDigitisationService.ts
+index 03f94b6..3d8c55c 100644
+--- a/backend/src/services/storeProductDigitisationService.ts
++++ b/backend/src/services/storeProductDigitisationService.ts
+@@ -1,22 +1,27 @@
+ /**
+  * Store Product Digitisation Service
+- * SD-ONBOARD-001B: Handles brand barcode digitisation during onboarding
++ * SD-ONBOARD-002: Two-Speed Product Capture + Internal Prefill
+  *
+  * Provides:
+- * - scan/resolve with FOUND/NEEDS_CREATE/NOT_FOUND contract
+- * - create store product with initial stock (INWARD ledger)
++ * - scan/resolve with FOUND/NEEDS_CREATE contract (no more NOT_FOUND)
++ * - internal prefill from platform catalog
++ * - FAST_SELL mode (minimal fields) vs DIGITISATION mode (full details)
+  * - store-scoped barcode mapping
+  */
+ 
+ import { randomUUID } from "crypto";
+ import { getPool } from "../db/client";
+-import { lookupBarcodeExternal, type BarcodeProductPrefill } from "./barcodeLookupProvider";
+ 
+ // =============================================================================
+ // Types (matching API contract)
+ // =============================================================================
+ 
+-export type ScanResolveStatus = "FOUND" | "NEEDS_CREATE" | "NOT_FOUND";
++export type ScanResolveStatus = "FOUND" | "NEEDS_CREATE";
++
++export type DigitisationMode = "FAST_SELL" | "DIGITISATION";
++
++export type PrefillSource = "platform_catalog" | "external_lookup";
++export type PrefillConfidence = "high" | "medium" | "low";
+ 
+ export interface StoreProductStock {
+   isKnown: boolean;
+@@ -29,11 +34,14 @@ export interface StoreProductResponse {
+   barcode: string;
+   sellPrice: number | null;
+   mrp: number | null;
++  purchasePrice: number | null;
+   stock: StoreProductStock;
+   unit: string;
+   brand: string;
+   description: string;
+   imageUrl: string;
++  variant: string;
++  packSize: string;
+ }
+ 
+ export interface ScanResolvePrefill {
+@@ -43,22 +51,30 @@ export interface ScanResolvePrefill {
+   unit: string;
+   imageUrl: string;
+   brand: string;
++  variant: string;
++  packSize: string;
++  source: PrefillSource;
++  confidence: PrefillConfidence;
++  productId: string | null; // Platform product ID if from platform_catalog
+ }
+ 
+ export type ScanResolveResult =
+   | { status: "FOUND"; storeProduct: StoreProductResponse }
+-  | { status: "NEEDS_CREATE"; prefill: ScanResolvePrefill }
+-  | { status: "NOT_FOUND"; barcode: string };
++  | { status: "NEEDS_CREATE"; barcode: string; prefill?: ScanResolvePrefill };
+ 
+ export interface CreateStoreProductInput {
+   barcode: string;
+-  name: string;
++  mode: DigitisationMode;
++  name?: string;
+   sellPrice: number; // Minor units (paise)
+   mrp?: number; // Minor units (paise)
++  purchasePrice?: number; // Minor units (paise)
+   initialStockQty: number;
+   unit?: string;
+   description?: string;
+   brand?: string;
++  variant?: string;
++  packSize?: string;
+ }
+ 
+ export type CreateStoreProductResult =
+@@ -92,10 +108,13 @@ async function lookupStoreProductByBarcode(
+       spb.barcode AS barcode,
+       sp.sell_price,
+       sp.mrp,
++      sp.purchase_price,
+       sp.current_stock,
+       p.unit,
+       p.brand,
+-      p.description
++      p.description,
++      p.variant,
++      p.pack_size::TEXT AS pack_size
+     FROM catalog.store_product_barcodes spb
+     JOIN catalog.store_products sp ON sp.id = spb.store_product_id AND sp.store_id = spb.store_id
+     JOIN catalog.products p ON p.id = sp.product_id
+@@ -113,6 +132,7 @@ async function lookupStoreProductByBarcode(
+       barcode: row.barcode,
+       sellPrice: row.sell_price,
+       mrp: row.mrp,
++      purchasePrice: row.purchase_price,
+       stock: {
+         isKnown: row.current_stock !== null && row.current_stock >= 0,
+         qty: row.current_stock ?? 0
+@@ -120,7 +140,9 @@ async function lookupStoreProductByBarcode(
+       unit: row.unit || "pcs",
+       brand: row.brand || "",
+       description: row.description || "",
+-      imageUrl: ""
++      imageUrl: "",
++      variant: row.variant || "",
++      packSize: row.pack_size || ""
+     };
+   }
+ 
+@@ -134,10 +156,13 @@ async function lookupStoreProductByBarcode(
+       p.primary_barcode AS barcode,
+       sp.sell_price,
+       sp.mrp,
++      sp.purchase_price,
+       sp.current_stock,
+       p.unit,
+       p.brand,
+-      p.description
++      p.description,
++      p.variant,
++      p.pack_size::TEXT AS pack_size
+     FROM catalog.products p
+     JOIN catalog.store_products sp ON sp.product_id = p.id AND sp.store_id = $1
+     WHERE p.primary_barcode = $2 AND sp.is_active = true
+@@ -154,6 +179,7 @@ async function lookupStoreProductByBarcode(
+       barcode: row.barcode,
+       sellPrice: row.sell_price,
+       mrp: row.mrp,
++      purchasePrice: row.purchase_price,
+       stock: {
+         isKnown: row.current_stock !== null && row.current_stock >= 0,
+         qty: row.current_stock ?? 0
+@@ -161,7 +187,9 @@ async function lookupStoreProductByBarcode(
+       unit: row.unit || "pcs",
+       brand: row.brand || "",
+       description: row.description || "",
+-      imageUrl: ""
++      imageUrl: "",
++      variant: row.variant || "",
++      packSize: row.pack_size || ""
+     };
+   }
+ 
+@@ -169,56 +197,91 @@ async function lookupStoreProductByBarcode(
+ }
+ 
+ /**
+- * Get current stock for a store product from inventory ledger
++ * Lookup barcode in platform catalog (catalog.product_barcodes)
++ * Returns prefill data if found (internal prefill)
+  */
+-async function getCurrentStock(storeId: string, productId: string): Promise<{ isKnown: boolean; qty: number }> {
++async function lookupPlatformCatalog(
++  barcode: string
++): Promise<ScanResolvePrefill | null> {
+   const pool = getPool();
+-  if (!pool) return { isKnown: false, qty: 0 };
++  if (!pool) return null;
++
++  const normalizedBarcode = barcode.trim();
+ 
+-  // Check stock_balances first (faster)
+-  const balanceResult = await pool.query(
++  // Check catalog.product_barcodes for platform-wide barcode mapping
++  const result = await pool.query(
+     `
+-    SELECT current_qty FROM inventory.stock_balances
+-    WHERE store_id = $1 AND product_id = $2
++    SELECT
++      p.id AS product_id,
++      p.name,
++      p.description,
++      p.unit,
++      p.brand,
++      p.variant,
++      p.pack_size::TEXT AS pack_size,
++      pb.barcode
++    FROM catalog.product_barcodes pb
++    JOIN catalog.products p ON p.id = pb.product_id
++    WHERE pb.barcode = $1 AND p.is_active = true
++    LIMIT 1
+     `,
+-    [storeId, productId]
++    [normalizedBarcode]
+   );
+ 
+-  if (balanceResult.rows[0]) {
++  if (result.rows[0]) {
++    const row = result.rows[0];
+     return {
+-      isKnown: true,
+-      qty: balanceResult.rows[0].current_qty
++      barcode: row.barcode,
++      name: row.name || "",
++      description: row.description || "",
++      unit: row.unit || "pcs",
++      imageUrl: "",
++      brand: row.brand || "",
++      variant: row.variant || "",
++      packSize: row.pack_size || "",
++      source: "platform_catalog",
++      confidence: "high",
++      productId: row.product_id
+     };
+   }
+ 
+-  // Check if there are any ledger entries (means stock was recorded at some point)
+-  const ledgerResult = await pool.query(
++  // Also check primary_barcode on catalog.products
++  const fallbackResult = await pool.query(
+     `
+-    SELECT 1 FROM inventory.inventory_ledger
+-    WHERE store_id = $1 AND product_id = $2
++    SELECT
++      id AS product_id,
++      name,
++      description,
++      unit,
++      brand,
++      variant,
++      pack_size::TEXT AS pack_size,
++      primary_barcode AS barcode
++    FROM catalog.products
++    WHERE primary_barcode = $1 AND is_active = true
+     LIMIT 1
+     `,
+-    [storeId, productId]
++    [normalizedBarcode]
+   );
+ 
+-  if (ledgerResult.rows[0]) {
+-    // Has ledger entries but no balance record - compute from ledger
+-    const sumResult = await pool.query(
+-      `
+-      SELECT COALESCE(SUM(delta_qty), 0)::INTEGER AS total
+-      FROM inventory.inventory_ledger
+-      WHERE store_id = $1 AND product_id = $2
+-      `,
+-      [storeId, productId]
+-    );
++  if (fallbackResult.rows[0]) {
++    const row = fallbackResult.rows[0];
+     return {
+-      isKnown: true,
+-      qty: sumResult.rows[0]?.total ?? 0
++      barcode: row.barcode,
++      name: row.name || "",
++      description: row.description || "",
++      unit: row.unit || "pcs",
++      imageUrl: "",
++      brand: row.brand || "",
++      variant: row.variant || "",
++      packSize: row.pack_size || "",
++      source: "platform_catalog",
++      confidence: "high",
++      productId: row.product_id
+     };
+   }
+ 
+-  // No ledger entries = stock unknown
+-  return { isKnown: false, qty: 0 };
++  return null;
+ }
+ 
+ // =============================================================================
+@@ -226,13 +289,14 @@ async function getCurrentStock(storeId: string, productId: string): Promise<{ is
+ // =============================================================================
+ 
+ /**
+- * Resolve barcode scan for digitisation flow
++ * Resolve barcode scan for digitisation flow (SD-ONBOARD-002)
+  *
+  * Resolution order:
+- * 1. Store-scoped barcode mapping (catalog.store_product_barcodes)
+- * 2. Catalog primary barcode with store_product link
+- * 3. External provider lookup (returns NEEDS_CREATE with prefill)
+- * 4. NOT_FOUND
++ * 1. Store-scoped barcode mapping -> FOUND
++ * 2. Platform catalog (catalog.product_barcodes) -> NEEDS_CREATE with prefill
++ * 3. Unknown barcode -> NEEDS_CREATE without prefill
++ *
++ * Note: No more NOT_FOUND - unknown barcodes always get NEEDS_CREATE
+  */
+ export async function resolveScanForDigitisation(
+   storeId: string,
+@@ -241,7 +305,7 @@ export async function resolveScanForDigitisation(
+   const normalizedBarcode = barcode.trim();
+ 
+   if (!normalizedBarcode) {
+-    return { status: "NOT_FOUND", barcode: "" };
++    return { status: "NEEDS_CREATE", barcode: "" };
+   }
+ 
+   // Step 1: Check store-scoped barcode mapping
+@@ -252,35 +316,36 @@ export async function resolveScanForDigitisation(
+     return { status: "FOUND", storeProduct };
+   }
+ 
+-  // Step 2: Not in store - try external lookup for prefill
+-  console.log("[digitisation] Barcode not in store catalog, trying external lookup:", normalizedBarcode);
++  // Step 2: Check platform catalog for internal prefill
++  console.log("[digitisation] Barcode not in store catalog, checking platform catalog:", normalizedBarcode);
+ 
+-  const externalData = await lookupBarcodeExternal(normalizedBarcode);
++  const platformPrefill = await lookupPlatformCatalog(normalizedBarcode);
+ 
+-  if (externalData) {
+-    // External lookup found data - return NEEDS_CREATE with prefill
++  if (platformPrefill) {
++    console.log("[digitisation] Found in platform catalog:", platformPrefill.name);
+     return {
+       status: "NEEDS_CREATE",
+-      prefill: {
+-        barcode: normalizedBarcode,
+-        name: externalData.name,
+-        description: externalData.description,
+-        unit: externalData.unit || "pcs",
+-        imageUrl: externalData.imageUrl,
+-        brand: externalData.brand
+-      }
++      barcode: normalizedBarcode,
++      prefill: platformPrefill
+     };
+   }
+ 
+-  // Step 3: Nothing found - return NOT_FOUND (user enters manually)
+-  return { status: "NOT_FOUND", barcode: normalizedBarcode };
++  // Step 3: Nothing found - return NEEDS_CREATE without prefill
++  // User will enter product details manually
++  console.log("[digitisation] Barcode not found anywhere, user will enter manually:", normalizedBarcode);
++  return { status: "NEEDS_CREATE", barcode: normalizedBarcode };
+ }
+ 
+ /**
+- * Create store product from digitisation flow
++ * Create store product from digitisation flow (SD-ONBOARD-002)
++ *
++ * Supports two modes:
++ * - FAST_SELL: Minimal fields (name, sellPrice, initialStockQty)
++ * - DIGITISATION: Full details (all fields)
+  *
+  * Creates:
+  * - catalog.products (if barcode not in global catalog)
++ * - catalog.product_barcodes (global barcode mapping)
+  * - catalog.store_products (store-specific pricing/stock)
+  * - catalog.store_product_barcodes (store-scoped barcode binding)
+  * - inventory.inventory_ledger (initial stock INWARD)
+@@ -303,12 +368,32 @@ export async function createStoreProductFromDigitisation(
+     return { success: false, error: "VALIDATION", message: "Barcode is required" };
+   }
+ 
+-  if (typeof input.sellPrice !== "number" || input.sellPrice <= 0) {
+-    return { success: false, error: "VALIDATION", message: "Sell price must be positive" };
+-  }
++  const mode = input.mode || "FAST_SELL";
+ 
+-  if (typeof input.initialStockQty !== "number" || input.initialStockQty < 0) {
+-    return { success: false, error: "VALIDATION", message: "Initial stock quantity must be >= 0" };
++  // Mode-specific validation
++  if (mode === "FAST_SELL") {
++    // FAST_SELL requires: sellPrice
++    if (typeof input.sellPrice !== "number" || input.sellPrice <= 0) {
++      return { success: false, error: "VALIDATION", message: "Sell price must be positive" };
++    }
++    // initialStockQty can be 0 for "stock unknown"
++    if (typeof input.initialStockQty !== "number" || input.initialStockQty < 0) {
++      return { success: false, error: "VALIDATION", message: "Initial stock quantity must be >= 0" };
++    }
++  } else if (mode === "DIGITISATION") {
++    // DIGITISATION requires: name, unit, purchasePrice, sellPrice, initialStockQty
++    if (!input.name?.trim()) {
++      return { success: false, error: "VALIDATION", message: "Product name is required for digitisation" };
++    }
++    if (typeof input.sellPrice !== "number" || input.sellPrice <= 0) {
++      return { success: false, error: "VALIDATION", message: "Sell price must be positive" };
++    }
++    if (typeof input.purchasePrice !== "number" || input.purchasePrice < 0) {
++      return { success: false, error: "VALIDATION", message: "Purchase price must be >= 0 for digitisation" };
++    }
++    if (typeof input.initialStockQty !== "number" || input.initialStockQty < 0) {
++      return { success: false, error: "VALIDATION", message: "Initial stock quantity must be >= 0" };
++    }
+   }
+ 
+   const productName = input.name?.trim() || `Item ${normalizedBarcode.slice(-4)}`;
+@@ -330,59 +415,103 @@ export async function createStoreProductFromDigitisation(
+ 
+     // Step 1: Find or create catalog.products entry
+     let productId: string;
++    let isNewProduct = false;
+ 
+-    // Check if barcode exists in global catalog
+-    const existingProductResult = await client.query(
++    // Check if barcode exists in global catalog (product_barcodes)
++    const existingBarcodeResult = await client.query(
+       `
+-      SELECT id FROM catalog.products
+-      WHERE primary_barcode = $1
++      SELECT product_id FROM catalog.product_barcodes
++      WHERE barcode = $1
+       LIMIT 1
+       `,
+       [normalizedBarcode]
+     );
+ 
+-    if (existingProductResult.rows[0]) {
+-      productId = existingProductResult.rows[0].id;
+-      console.log("[digitisation] Using existing catalog product:", productId);
++    if (existingBarcodeResult.rows[0]) {
++      productId = existingBarcodeResult.rows[0].product_id;
++      console.log("[digitisation] Using existing product from product_barcodes:", productId);
+     } else {
+-      // Create new catalog product
+-      productId = randomUUID();
+-      await client.query(
++      // Check primary_barcode fallback
++      const existingProductResult = await client.query(
+         `
+-        INSERT INTO catalog.products (id, name, brand, description, unit, primary_barcode, is_active)
+-        VALUES ($1, $2, $3, $4, $5, $6, true)
++        SELECT id FROM catalog.products
++        WHERE primary_barcode = $1
++        LIMIT 1
+         `,
+-        [
+-          productId,
+-          productName,
+-          input.brand || null,
+-          input.description || null,
+-          input.unit || "pcs",
+-          normalizedBarcode
+-        ]
++        [normalizedBarcode]
+       );
+-      console.log("[digitisation] Created new catalog product:", productId);
++
++      if (existingProductResult.rows[0]) {
++        productId = existingProductResult.rows[0].id;
++        console.log("[digitisation] Using existing catalog product:", productId);
++      } else {
++        // Create new catalog product
++        productId = randomUUID();
++        isNewProduct = true;
++        await client.query(
++          `
++          INSERT INTO catalog.products (id, name, brand, description, unit, variant, primary_barcode, is_active)
++          VALUES ($1, $2, $3, $4, $5, $6, $7, true)
++          `,
++          [
++            productId,
++            productName,
++            input.brand || null,
++            input.description || null,
++            input.unit || "pcs",
++            input.variant || null,
++            normalizedBarcode
++          ]
++        );
++        console.log("[digitisation] Created new catalog product:", productId);
++
++        // Also create product_barcodes entry for future lookups
++        await client.query(
++          `
++          INSERT INTO catalog.product_barcodes (product_id, barcode, barcode_type, is_primary, source, created_by_store_id)
++          VALUES ($1, $2, 'ean13', true, 'retailer_digitisation', $3)
++          ON CONFLICT (barcode) DO NOTHING
++          `,
++          [productId, normalizedBarcode, storeId]
++        );
++      }
+     }
+ 
+     // Step 2: Create or update catalog.store_products
+     const storeProductId = randomUUID();
+     const sellPriceMinor = Math.round(input.sellPrice);
+     const mrpMinor = input.mrp ? Math.round(input.mrp) : sellPriceMinor;
++    const purchasePriceMinor = input.purchasePrice ? Math.round(input.purchasePrice) : null;
+ 
+     await client.query(
+       `
+-      INSERT INTO catalog.store_products (id, store_id, product_id, sell_price, mrp, display_name, is_active, current_stock)
+-      VALUES ($1, $2, $3, $4, $5, $6, true, $7)
++      INSERT INTO catalog.store_products (
++        id, store_id, product_id, sell_price, mrp, purchase_price,
++        display_name, is_active, current_stock, digitisation_mode
++      )
++      VALUES ($1, $2, $3, $4, $5, $6, $7, true, $8, $9)
+       ON CONFLICT (store_id, product_id) DO UPDATE SET
+         sell_price = EXCLUDED.sell_price,
+         mrp = EXCLUDED.mrp,
++        purchase_price = COALESCE(EXCLUDED.purchase_price, catalog.store_products.purchase_price),
+         display_name = EXCLUDED.display_name,
+         current_stock = EXCLUDED.current_stock,
++        digitisation_mode = COALESCE(EXCLUDED.digitisation_mode, catalog.store_products.digitisation_mode),
+         is_active = true,
+         updated_at = NOW()
+       RETURNING id
+       `,
+-      [storeProductId, storeId, productId, sellPriceMinor, mrpMinor, productName, input.initialStockQty]
++      [
++        storeProductId,
++        storeId,
++        productId,
++        sellPriceMinor,
++        mrpMinor,
++        purchasePriceMinor,
++        productName,
++        input.initialStockQty,
++        mode
++      ]
+     );
+ 
+     // Get the actual store_product_id (might be existing if ON CONFLICT triggered)
+@@ -403,6 +532,11 @@ export async function createStoreProductFromDigitisation(
+     );
+ 
+     // Step 4: Create INWARD ledger entry for initial stock
++    const stockKnown = input.initialStockQty > 0;
++    const ledgerNotes = mode === "FAST_SELL"
++      ? "Initial stock from FAST_SELL"
++      : "Initial stock from DIGITISATION";
++
+     if (input.initialStockQty > 0) {
+       const ledgerId = randomUUID();
+       await client.query(
+@@ -411,9 +545,9 @@ export async function createStoreProductFromDigitisation(
+           id, store_id, product_id, delta_qty, transaction_type,
+           reference_type, reference_id, stock_before, stock_after, notes
+         )
+-        VALUES ($1, $2, $3, $4, 'adjustment', 'manual', $5, 0, $4, 'Initial stock from digitisation')
++        VALUES ($1, $2, $3, $4, 'adjustment', 'manual', $5, 0, $4, $6)
+         `,
+-        [ledgerId, storeId, productId, input.initialStockQty, `digitisation:${actualStoreProductId}`]
++        [ledgerId, storeId, productId, input.initialStockQty, `digitisation:${actualStoreProductId}`, ledgerNotes]
+       );
+ 
+       // Step 5: Create or update stock balance
+@@ -432,7 +566,7 @@ export async function createStoreProductFromDigitisation(
+ 
+     await client.query("COMMIT");
+ 
+-    console.log("[digitisation] Successfully created store product:", actualStoreProductId, "for store:", storeId);
++    console.log(`[digitisation] Successfully created store product via ${mode}:`, actualStoreProductId, "for store:", storeId);
+ 
+     // Return the created store product
+     return {
+@@ -443,14 +577,17 @@ export async function createStoreProductFromDigitisation(
+         barcode: normalizedBarcode,
+         sellPrice: sellPriceMinor,
+         mrp: mrpMinor,
++        purchasePrice: purchasePriceMinor,
+         stock: {
+-          isKnown: true,
++          isKnown: stockKnown,
+           qty: input.initialStockQty
+         },
+         unit: input.unit || "pcs",
+         brand: input.brand || "",
+         description: input.description || "",
+-        imageUrl: ""
++        imageUrl: "",
++        variant: input.variant || "",
++        packSize: input.packSize || ""
+       }
+     };
+   } catch (error) {
+diff --git a/src/screens/OrderDetailScreen.tsx b/src/screens/OrderDetailScreen.tsx
+index 8b6ef19..0f5d4b9 100644
+--- a/src/screens/OrderDetailScreen.tsx
++++ b/src/screens/OrderDetailScreen.tsx
+@@ -113,7 +113,9 @@ export default function OrderDetailScreen({
+             setCancelling(true);
+             try {
+               const result = await orderApi.cancelOrder(storeId, orderId);
+-              setOrder((prev) => (prev ? { ...prev, status: result.data.status } : prev));
++              if (result.data) {
++                setOrder((prev) => (prev ? { ...prev, status: result.data!.status } : prev));
++              }
+               // Reload events
+               const eventsData = await orderApi.getOrderEvents(storeId, orderId);
+               setEvents(eventsData);
+diff --git a/src/screens/SellScanScreen.tsx b/src/screens/SellScanScreen.tsx
+index 25fb847..dfc606b 100644
+--- a/src/screens/SellScanScreen.tsx
++++ b/src/screens/SellScanScreen.tsx
+@@ -235,7 +235,13 @@ function CartItemRow({
+     typeof availableStock === "number" && Number.isFinite(availableStock)
+       ? Math.max(0, Math.floor(availableStock))
+       : null;
+-  const stockLabel = stockValue === null ? "Unknown" : String(stockValue);
++  // SD-ONBOARD-001B: Check if stock is known from item metadata
++  const stockIsKnown = item.metadata?.stockKnown === true;
++  const stockLabel = stockValue === null
++    ? "Unknown"
++    : stockIsKnown
++      ? `${stockValue} (known)`
++      : String(stockValue);
+ 
+   useEffect(() => {
+     setPriceInput(formatPriceInput(item.priceMinor));
+diff --git a/src/services/scan/handleScan.ts b/src/services/scan/handleScan.ts
+index 8e4f4b7..106c72a 100644
+--- a/src/services/scan/handleScan.ts
++++ b/src/services/scan/handleScan.ts
+@@ -6,7 +6,14 @@ import {
+   lookupStoreProductPreviewByScan,
+   type StoreLookupProduct
+ } from "../api/productsApi";
+-import { lookupProductByBarcode, resolveScan, type ScanProduct } from "../api/scanApi";
++import {
++  lookupProductByBarcode,
++  resolveScan,
++  resolveScanForDigitisation,
++  type ScanProduct,
++  type StoreProductResponse,
++  type ScanResolvePrefill
++} from "../api/scanApi";
+ import { isOnline } from "../networkStatus";
+ import { resolveOfflineScan, setLocalPrice, upsertLocalProduct } from "../offline/scan";
+ import { useCartStore } from "../../stores/cartStore";
+@@ -28,14 +35,25 @@ export type SellFirstOnboardingRequest = {
+   product: StoreLookupProduct;
+ };
+ 
++// SD-ONBOARD-001B: New digitisation flow request type
++export type AddStoreProductRequest = {
++  barcode: string;
++  prefill?: ScanResolvePrefill | null;
++};
++
+ type ScanRuntime = {
+   intent: ScanIntent;
+   mode: ScanMode;
+   storeActive?: boolean | null;
+   scanLookupV2Enabled?: boolean;
++  // SD-ONBOARD-001B: Enable new digitisation flow (takes precedence over scanLookupV2)
++  digitisationFlowEnabled?: boolean;
+   onNotice?: (notice: ScanNotice | null) => void;
+   onSellFirstOnboarding?: (request: SellFirstOnboardingRequest) => void;
+   sellFirstOnboardingActive?: boolean;
++  // SD-ONBOARD-001B: Callback for add store product modal
++  onAddStoreProduct?: (request: AddStoreProductRequest) => void;
++  addStoreProductActive?: boolean;
+   onDeviceAuthError?: (error: ApiError) => Promise<boolean> | boolean;
+   onStoreInactive?: () => void;
+ };
+@@ -188,6 +206,58 @@ function addToSellCart(product: CartScanProduct, priceMinor: number, flags?: str
+   }
+ }
+ 
++/**
++ * SD-ONBOARD-001B: Add newly created store product to cart
++ * Called from AddStoreProductModal after successful product creation
++ */
++export function addStoreProductToCart(product: StoreProductResponse): boolean {
++  try {
++    console.log(`[SD-ONBOARD-001B] Adding to cart: ${product.name}, price=${product.sellPrice}`);
++
++    upsertStockEntries([
++      { key: product.storeProductId, stock: product.stock.qty },
++      { key: product.barcode, stock: product.stock.qty }
++    ]);
++
++    const added = addToSellCart(
++      {
++        id: product.storeProductId,
++        name: product.name,
++        barcode: product.barcode,
++        priceMinor: product.sellPrice ?? 0,
++        currency: "INR",
++        metadata: {
++          storeProductId: product.storeProductId,
++          unit: product.unit,
++          brand: product.brand,
++          stockKnown: product.stock.isKnown,
++          stockQty: product.stock.qty
++        }
++      },
++      product.sellPrice ?? 0
++    );
++
++    if (added) {
++      // Cache locally for offline use
++      cacheLocalProduct({
++        barcode: product.barcode,
++        name: product.name,
++        currency: "INR",
++        priceMinor: product.sellPrice
++      });
++
++      if (Platform.OS === "android") {
++        ToastAndroid.show("Added to store & cart", ToastAndroid.SHORT);
++      }
++    }
++
++    return added;
++  } catch (err) {
++    console.error("[SD-ONBOARD-001B] addStoreProductToCart error:", err);
++    return false;
++  }
++}
++
+ async function cacheLocalProduct(product: {
+   barcode: string;
+   name: string;
+@@ -275,6 +345,8 @@ async function handleScan(
+   const trimmed = barcode.trim();
+   if (!trimmed) return;
+   if (runtime.sellFirstOnboardingActive) return;
++  // SD-ONBOARD-001B: Block scan while add store product modal is open
++  if (runtime.addStoreProductActive) return;
+ 
+   const intent = intentOverride ?? runtime.intent;
+   const mode = runtime.mode;
+@@ -292,8 +364,95 @@ async function handleScan(
+ 
+   notify(null);
+   const useScanLookupV2 = runtime.scanLookupV2Enabled === true;
++  const useDigitisationFlow = runtime.digitisationFlowEnabled === true;
+ 
+   try {
++    // =========================================================================
++    // SD-ONBOARD-002: Two-Speed Product Capture + Internal Prefill
++    // Uses resolveScanForDigitisation API with FOUND/NEEDS_CREATE contract
++    // No more NOT_FOUND - unknown barcodes always get NEEDS_CREATE
++    // =========================================================================
++    if (intent === "SELL" && mode === "SELL" && useDigitisationFlow) {
++      if (await isOnline()) {
++        console.log(`[SD-ONBOARD-002] Resolving barcode: ${trimmed}`);
++        const result = await resolveScanForDigitisation(trimmed);
++
++        if (result.status === "FOUND") {
++          // Product exists in store - add to cart
++          const sp = result.storeProduct;
++          console.log(`[SD-ONBOARD-002] FOUND: ${sp.name}, price=${sp.sellPrice}`);
++
++          upsertStockEntries([
++            { key: sp.storeProductId, stock: sp.stock.qty },
++            { key: sp.barcode, stock: sp.stock.qty }
++          ]);
++
++          const added = addToSellCart(
++            {
++              id: sp.storeProductId,
++              name: sp.name,
++              barcode: sp.barcode,
++              priceMinor: sp.sellPrice ?? 0,
++              currency: "INR",
++              metadata: {
++                storeProductId: sp.storeProductId,
++                unit: sp.unit,
++                brand: sp.brand,
++                stockKnown: sp.stock.isKnown,
++                stockQty: sp.stock.qty
++              }
++            },
++            sp.sellPrice ?? 0
++          );
++
++          if (added) {
++            await cacheLocalProduct({
++              barcode: sp.barcode,
++              name: sp.name,
++              currency: "INR",
++              priceMinor: sp.sellPrice
++            });
++          }
++          return;
++        }
++
++        if (result.status === "NEEDS_CREATE") {
++          // Show modal - with or without prefill from platform catalog
++          const prefillName = result.prefill?.name ?? "manual entry";
++          console.log(`[SD-ONBOARD-002] NEEDS_CREATE: ${trimmed}, prefill=${prefillName}`);
++          runtime.onAddStoreProduct?.({
++            barcode: trimmed,
++            prefill: result.prefill ?? null
++          });
++          return;
++        }
++      }
++
++      // Offline fallback: use legacy offline scan
++      const offline = await resolveOfflineScan(trimmed, "SELL");
++      if (offline.action === "ADD_TO_CART") {
++        const priceMinor = offline.product.priceMinor ?? 0;
++        addToSellCart(
++          {
++            id: offline.product.barcode,
++            name: offline.product.name || offline.product.barcode,
++            barcode: offline.product.barcode,
++            priceMinor: offline.product.priceMinor,
++            currency: offline.product.currency ?? "INR"
++          },
++          priceMinor
++        );
++        return;
++      }
++
++      // Offline: show add product modal
++      runtime.onAddStoreProduct?.({
++        barcode: trimmed,
++        prefill: null
++      });
++      return;
++    }
++
+     if (intent === "SELL" && mode === "SELL" && useScanLookupV2) {
+       if (await isOnline()) {
+         const fallbackName = buildFallbackName(trimmed);

--- a/RELEASES/stash-1-main-local-wip.patch
+++ b/RELEASES/stash-1-main-local-wip.patch
@@ -1,0 +1,3035 @@
+diff --git a/.gitignore b/.gitignore
+index 8a61a3d..0618070 100644
+--- a/.gitignore
++++ b/.gitignore
+@@ -50,6 +50,9 @@ fastlane/test_output
+ dist/
+ web-build/
+ 
++# Tooling artifacts (do not commit)
++screenshots/
++
+ # @generated expo-cli sync
+ /.expo/
+ 
+diff --git a/backend/.env.example b/backend/.env.example
+index 1b795b8..a524eb7 100644
+--- a/backend/.env.example
++++ b/backend/.env.example
+@@ -1,7 +1,13 @@
+ PORT=3001
+ 
+-# SQLite for local dev
+-DATABASE_URL="file:./dev.db"
++# PostgreSQL connection string (VM local Postgres or Cloud SQL)
++# Example:
++# DATABASE_URL="postgres://USER:PASSWORD@127.0.0.1:5432/supermandi?sslmode=disable"
++DATABASE_URL=""
++
++# Optional: protect /api/v1/admin/* endpoints.
++# If set, SuperAdmin must send `X-Admin-Token: <value>` (VITE_ADMIN_TOKEN).
++ADMIN_TOKEN=""
+ 
+ # Change this in production
+ JWT_SECRET="supermandi-dev-secret-change-me"
+diff --git a/backend/package-lock.json b/backend/package-lock.json
+index 956ab79..deba170 100644
+--- a/backend/package-lock.json
++++ b/backend/package-lock.json
+@@ -9,12 +9,14 @@
+       "version": "1.0.0",
+       "license": "ISC",
+       "dependencies": {
+-        "@prisma/client": "5.22.0",
+         "bcryptjs": "^2.4.3",
+         "cors": "^2.8.5",
+         "dotenv": "^16.4.5",
++        "drizzle-orm": "^0.44.3",
+         "express": "^4.19.2",
+-        "jsonwebtoken": "^9.0.2"
++        "jsonwebtoken": "^9.0.2",
++        "openai": "^4.104.0",
++        "pg": "^8.13.1"
+       },
+       "devDependencies": {
+         "@types/bcryptjs": "^2.4.6",
+@@ -22,8 +24,9 @@
+         "@types/express": "^4.17.21",
+         "@types/jsonwebtoken": "^9.0.7",
+         "@types/node": "^20.11.30",
++        "@types/pg": "^8.11.10",
++        "drizzle-kit": "^0.31.4",
+         "nodemon": "^3.0.3",
+-        "prisma": "5.22.0",
+         "ts-node": "^10.9.2",
+         "typescript": "^5.4.5"
+       }
+@@ -41,6 +44,891 @@
+         "node": ">=12"
+       }
+     },
++    "node_modules/@drizzle-team/brocli": {
++      "version": "0.10.2",
++      "resolved": "https://registry.npmjs.org/@drizzle-team/brocli/-/brocli-0.10.2.tgz",
++      "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
++      "dev": true,
++      "license": "Apache-2.0"
++    },
++    "node_modules/@esbuild-kit/core-utils": {
++      "version": "3.3.2",
++      "resolved": "https://registry.npmjs.org/@esbuild-kit/core-utils/-/core-utils-3.3.2.tgz",
++      "integrity": "sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==",
++      "deprecated": "Merged into tsx: https://tsx.is",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "esbuild": "~0.18.20",
++        "source-map-support": "^0.5.21"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
++      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
++      "cpu": [
++        "arm"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "android"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-arm64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
++      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "android"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/android-x64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
++      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "android"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-arm64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
++      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "darwin"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/darwin-x64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
++      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "darwin"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-arm64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
++      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "freebsd"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/freebsd-x64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
++      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "freebsd"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
++      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
++      "cpu": [
++        "arm"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-arm64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
++      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ia32": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
++      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
++      "cpu": [
++        "ia32"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-loong64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
++      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
++      "cpu": [
++        "loong64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-mips64el": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
++      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
++      "cpu": [
++        "mips64el"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-ppc64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
++      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
++      "cpu": [
++        "ppc64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-riscv64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
++      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
++      "cpu": [
++        "riscv64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-s390x": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
++      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
++      "cpu": [
++        "s390x"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/linux-x64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
++      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/netbsd-x64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
++      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "netbsd"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/openbsd-x64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
++      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "openbsd"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/sunos-x64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
++      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "sunos"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-arm64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
++      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-ia32": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
++      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
++      "cpu": [
++        "ia32"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/@esbuild/win32-x64": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
++      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "engines": {
++        "node": ">=12"
++      }
++    },
++    "node_modules/@esbuild-kit/core-utils/node_modules/esbuild": {
++      "version": "0.18.20",
++      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.18.20.tgz",
++      "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
++      "dev": true,
++      "hasInstallScript": true,
++      "license": "MIT",
++      "bin": {
++        "esbuild": "bin/esbuild"
++      },
++      "engines": {
++        "node": ">=12"
++      },
++      "optionalDependencies": {
++        "@esbuild/android-arm": "0.18.20",
++        "@esbuild/android-arm64": "0.18.20",
++        "@esbuild/android-x64": "0.18.20",
++        "@esbuild/darwin-arm64": "0.18.20",
++        "@esbuild/darwin-x64": "0.18.20",
++        "@esbuild/freebsd-arm64": "0.18.20",
++        "@esbuild/freebsd-x64": "0.18.20",
++        "@esbuild/linux-arm": "0.18.20",
++        "@esbuild/linux-arm64": "0.18.20",
++        "@esbuild/linux-ia32": "0.18.20",
++        "@esbuild/linux-loong64": "0.18.20",
++        "@esbuild/linux-mips64el": "0.18.20",
++        "@esbuild/linux-ppc64": "0.18.20",
++        "@esbuild/linux-riscv64": "0.18.20",
++        "@esbuild/linux-s390x": "0.18.20",
++        "@esbuild/linux-x64": "0.18.20",
++        "@esbuild/netbsd-x64": "0.18.20",
++        "@esbuild/openbsd-x64": "0.18.20",
++        "@esbuild/sunos-x64": "0.18.20",
++        "@esbuild/win32-arm64": "0.18.20",
++        "@esbuild/win32-ia32": "0.18.20",
++        "@esbuild/win32-x64": "0.18.20"
++      }
++    },
++    "node_modules/@esbuild-kit/esm-loader": {
++      "version": "2.6.5",
++      "resolved": "https://registry.npmjs.org/@esbuild-kit/esm-loader/-/esm-loader-2.6.5.tgz",
++      "integrity": "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==",
++      "deprecated": "Merged into tsx: https://tsx.is",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "@esbuild-kit/core-utils": "^3.3.2",
++        "get-tsconfig": "^4.7.0"
++      }
++    },
++    "node_modules/@esbuild/aix-ppc64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
++      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
++      "cpu": [
++        "ppc64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "aix"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/android-arm": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
++      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
++      "cpu": [
++        "arm"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "android"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/android-arm64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
++      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "android"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/android-x64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
++      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "android"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/darwin-arm64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
++      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "darwin"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/darwin-x64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
++      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "darwin"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/freebsd-arm64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
++      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "freebsd"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/freebsd-x64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
++      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "freebsd"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/linux-arm": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
++      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
++      "cpu": [
++        "arm"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/linux-arm64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
++      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/linux-ia32": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
++      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
++      "cpu": [
++        "ia32"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/linux-loong64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
++      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
++      "cpu": [
++        "loong64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/linux-mips64el": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
++      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
++      "cpu": [
++        "mips64el"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/linux-ppc64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
++      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
++      "cpu": [
++        "ppc64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/linux-riscv64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
++      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
++      "cpu": [
++        "riscv64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/linux-s390x": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
++      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
++      "cpu": [
++        "s390x"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/linux-x64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
++      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "linux"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/netbsd-arm64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
++      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "netbsd"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/netbsd-x64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
++      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "netbsd"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/openbsd-arm64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
++      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "openbsd"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/openbsd-x64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
++      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "openbsd"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/openharmony-arm64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
++      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "openharmony"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/sunos-x64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
++      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "sunos"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/win32-arm64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
++      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
++      "cpu": [
++        "arm64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/win32-ia32": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
++      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
++      "cpu": [
++        "ia32"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
++    "node_modules/@esbuild/win32-x64": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
++      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
++      "cpu": [
++        "x64"
++      ],
++      "dev": true,
++      "license": "MIT",
++      "optional": true,
++      "os": [
++        "win32"
++      ],
++      "engines": {
++        "node": ">=18"
++      }
++    },
+     "node_modules/@jridgewell/resolve-uri": {
+       "version": "3.1.2",
+       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+@@ -75,6 +963,8 @@
+       "integrity": "sha512-M0SVXfyHnQREBKxCgyo7sffrKttwE6R8PMq330MIUF0pTwjUhLbW84pFDlf06B27XyCR++VtjugEnIHdr07SVA==",
+       "hasInstallScript": true,
+       "license": "Apache-2.0",
++      "optional": true,
++      "peer": true,
+       "engines": {
+         "node": ">=16.13"
+       },
+@@ -91,16 +981,18 @@
+       "version": "5.22.0",
+       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
+       "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
+-      "devOptional": true,
+-      "license": "Apache-2.0"
++      "license": "Apache-2.0",
++      "optional": true,
++      "peer": true
+     },
+     "node_modules/@prisma/engines": {
+       "version": "5.22.0",
+       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
+       "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
+-      "devOptional": true,
+       "hasInstallScript": true,
+       "license": "Apache-2.0",
++      "optional": true,
++      "peer": true,
+       "dependencies": {
+         "@prisma/debug": "5.22.0",
+         "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+@@ -112,15 +1004,17 @@
+       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
+       "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
+-      "devOptional": true,
+-      "license": "Apache-2.0"
++      "license": "Apache-2.0",
++      "optional": true,
++      "peer": true
+     },
+     "node_modules/@prisma/fetch-engine": {
+       "version": "5.22.0",
+       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
+       "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
+-      "devOptional": true,
+       "license": "Apache-2.0",
++      "optional": true,
++      "peer": true,
+       "dependencies": {
+         "@prisma/debug": "5.22.0",
+         "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
+@@ -131,8 +1025,9 @@
+       "version": "5.22.0",
+       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
+       "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
+-      "devOptional": true,
+       "license": "Apache-2.0",
++      "optional": true,
++      "peer": true,
+       "dependencies": {
+         "@prisma/debug": "5.22.0"
+       }
+@@ -265,12 +1160,33 @@
+       "version": "20.19.27",
+       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.27.tgz",
+       "integrity": "sha512-N2clP5pJhB2YnZJ3PIHFk5RkygRX5WO/5f0WC08tp0wd+sv0rsJk3MqWn3CbNmT2J505a5336jaQj4ph1AdMug==",
+-      "dev": true,
+       "license": "MIT",
+       "dependencies": {
+         "undici-types": "~6.21.0"
+       }
+     },
++    "node_modules/@types/node-fetch": {
++      "version": "2.6.13",
++      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
++      "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
++      "license": "MIT",
++      "dependencies": {
++        "@types/node": "*",
++        "form-data": "^4.0.4"
++      }
++    },
++    "node_modules/@types/pg": {
++      "version": "8.16.0",
++      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.16.0.tgz",
++      "integrity": "sha512-RmhMd/wD+CF8Dfo+cVIy3RR5cl8CyfXQ0tGgW6XBL8L4LM/UTEbNXYRbLwU6w+CgrKBNbrQWt4FUtTfaU5jSYQ==",
++      "devOptional": true,
++      "license": "MIT",
++      "dependencies": {
++        "@types/node": "*",
++        "pg-protocol": "*",
++        "pg-types": "^2.2.0"
++      }
++    },
+     "node_modules/@types/qs": {
+       "version": "6.14.0",
+       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+@@ -318,6 +1234,18 @@
+         "@types/node": "*"
+       }
+     },
++    "node_modules/abort-controller": {
++      "version": "3.0.0",
++      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
++      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
++      "license": "MIT",
++      "dependencies": {
++        "event-target-shim": "^5.0.0"
++      },
++      "engines": {
++        "node": ">=6.5"
++      }
++    },
+     "node_modules/accepts": {
+       "version": "1.3.8",
+       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+@@ -357,6 +1285,18 @@
+         "node": ">=0.4.0"
+       }
+     },
++    "node_modules/agentkeepalive": {
++      "version": "4.6.0",
++      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
++      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
++      "license": "MIT",
++      "dependencies": {
++        "humanize-ms": "^1.2.1"
++      },
++      "engines": {
++        "node": ">= 8.0.0"
++      }
++    },
+     "node_modules/anymatch": {
+       "version": "3.1.3",
+       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+@@ -384,6 +1324,12 @@
+       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+       "license": "MIT"
+     },
++    "node_modules/asynckit": {
++      "version": "0.4.0",
++      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
++      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
++      "license": "MIT"
++    },
+     "node_modules/balanced-match": {
+       "version": "1.0.2",
+       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+@@ -479,6 +1425,13 @@
+       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+       "license": "BSD-3-Clause"
+     },
++    "node_modules/buffer-from": {
++      "version": "1.1.2",
++      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
++      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
++      "dev": true,
++      "license": "MIT"
++    },
+     "node_modules/bytes": {
+       "version": "3.1.2",
+       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+@@ -517,6 +1470,18 @@
+         "url": "https://github.com/sponsors/ljharb"
+       }
+     },
++    "node_modules/combined-stream": {
++      "version": "1.0.8",
++      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
++      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
++      "license": "MIT",
++      "dependencies": {
++        "delayed-stream": "~1.0.0"
++      },
++      "engines": {
++        "node": ">= 0.8"
++      }
++    },
+     "node_modules/concat-map": {
+       "version": "0.0.1",
+       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+@@ -598,6 +1563,15 @@
+         }
+       }
+     },
++    "node_modules/delayed-stream": {
++      "version": "1.0.0",
++      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
++      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=0.4.0"
++      }
++    },
+     "node_modules/depd": {
+       "version": "2.0.0",
+       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+@@ -639,6 +1613,147 @@
+         "url": "https://dotenvx.com"
+       }
+     },
++    "node_modules/drizzle-kit": {
++      "version": "0.31.8",
++      "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.8.tgz",
++      "integrity": "sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg==",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "@drizzle-team/brocli": "^0.10.2",
++        "@esbuild-kit/esm-loader": "^2.5.5",
++        "esbuild": "^0.25.4",
++        "esbuild-register": "^3.5.0"
++      },
++      "bin": {
++        "drizzle-kit": "bin.cjs"
++      }
++    },
++    "node_modules/drizzle-orm": {
++      "version": "0.44.7",
++      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.44.7.tgz",
++      "integrity": "sha512-quIpnYznjU9lHshEOAYLoZ9s3jweleHlZIAWR/jX9gAWNg/JhQ1wj0KGRf7/Zm+obRrYd9GjPVJg790QY9N5AQ==",
++      "license": "Apache-2.0",
++      "peerDependencies": {
++        "@aws-sdk/client-rds-data": ">=3",
++        "@cloudflare/workers-types": ">=4",
++        "@electric-sql/pglite": ">=0.2.0",
++        "@libsql/client": ">=0.10.0",
++        "@libsql/client-wasm": ">=0.10.0",
++        "@neondatabase/serverless": ">=0.10.0",
++        "@op-engineering/op-sqlite": ">=2",
++        "@opentelemetry/api": "^1.4.1",
++        "@planetscale/database": ">=1.13",
++        "@prisma/client": "*",
++        "@tidbcloud/serverless": "*",
++        "@types/better-sqlite3": "*",
++        "@types/pg": "*",
++        "@types/sql.js": "*",
++        "@upstash/redis": ">=1.34.7",
++        "@vercel/postgres": ">=0.8.0",
++        "@xata.io/client": "*",
++        "better-sqlite3": ">=7",
++        "bun-types": "*",
++        "expo-sqlite": ">=14.0.0",
++        "gel": ">=2",
++        "knex": "*",
++        "kysely": "*",
++        "mysql2": ">=2",
++        "pg": ">=8",
++        "postgres": ">=3",
++        "sql.js": ">=1",
++        "sqlite3": ">=5"
++      },
++      "peerDependenciesMeta": {
++        "@aws-sdk/client-rds-data": {
++          "optional": true
++        },
++        "@cloudflare/workers-types": {
++          "optional": true
++        },
++        "@electric-sql/pglite": {
++          "optional": true
++        },
++        "@libsql/client": {
++          "optional": true
++        },
++        "@libsql/client-wasm": {
++          "optional": true
++        },
++        "@neondatabase/serverless": {
++          "optional": true
++        },
++        "@op-engineering/op-sqlite": {
++          "optional": true
++        },
++        "@opentelemetry/api": {
++          "optional": true
++        },
++        "@planetscale/database": {
++          "optional": true
++        },
++        "@prisma/client": {
++          "optional": true
++        },
++        "@tidbcloud/serverless": {
++          "optional": true
++        },
++        "@types/better-sqlite3": {
++          "optional": true
++        },
++        "@types/pg": {
++          "optional": true
++        },
++        "@types/sql.js": {
++          "optional": true
++        },
++        "@upstash/redis": {
++          "optional": true
++        },
++        "@vercel/postgres": {
++          "optional": true
++        },
++        "@xata.io/client": {
++          "optional": true
++        },
++        "better-sqlite3": {
++          "optional": true
++        },
++        "bun-types": {
++          "optional": true
++        },
++        "expo-sqlite": {
++          "optional": true
++        },
++        "gel": {
++          "optional": true
++        },
++        "knex": {
++          "optional": true
++        },
++        "kysely": {
++          "optional": true
++        },
++        "mysql2": {
++          "optional": true
++        },
++        "pg": {
++          "optional": true
++        },
++        "postgres": {
++          "optional": true
++        },
++        "prisma": {
++          "optional": true
++        },
++        "sql.js": {
++          "optional": true
++        },
++        "sqlite3": {
++          "optional": true
++        }
++      }
++    },
+     "node_modules/dunder-proto": {
+       "version": "1.0.1",
+       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+@@ -707,6 +1822,76 @@
+         "node": ">= 0.4"
+       }
+     },
++    "node_modules/es-set-tostringtag": {
++      "version": "2.1.0",
++      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
++      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
++      "license": "MIT",
++      "dependencies": {
++        "es-errors": "^1.3.0",
++        "get-intrinsic": "^1.2.6",
++        "has-tostringtag": "^1.0.2",
++        "hasown": "^2.0.2"
++      },
++      "engines": {
++        "node": ">= 0.4"
++      }
++    },
++    "node_modules/esbuild": {
++      "version": "0.25.12",
++      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
++      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
++      "dev": true,
++      "hasInstallScript": true,
++      "license": "MIT",
++      "bin": {
++        "esbuild": "bin/esbuild"
++      },
++      "engines": {
++        "node": ">=18"
++      },
++      "optionalDependencies": {
++        "@esbuild/aix-ppc64": "0.25.12",
++        "@esbuild/android-arm": "0.25.12",
++        "@esbuild/android-arm64": "0.25.12",
++        "@esbuild/android-x64": "0.25.12",
++        "@esbuild/darwin-arm64": "0.25.12",
++        "@esbuild/darwin-x64": "0.25.12",
++        "@esbuild/freebsd-arm64": "0.25.12",
++        "@esbuild/freebsd-x64": "0.25.12",
++        "@esbuild/linux-arm": "0.25.12",
++        "@esbuild/linux-arm64": "0.25.12",
++        "@esbuild/linux-ia32": "0.25.12",
++        "@esbuild/linux-loong64": "0.25.12",
++        "@esbuild/linux-mips64el": "0.25.12",
++        "@esbuild/linux-ppc64": "0.25.12",
++        "@esbuild/linux-riscv64": "0.25.12",
++        "@esbuild/linux-s390x": "0.25.12",
++        "@esbuild/linux-x64": "0.25.12",
++        "@esbuild/netbsd-arm64": "0.25.12",
++        "@esbuild/netbsd-x64": "0.25.12",
++        "@esbuild/openbsd-arm64": "0.25.12",
++        "@esbuild/openbsd-x64": "0.25.12",
++        "@esbuild/openharmony-arm64": "0.25.12",
++        "@esbuild/sunos-x64": "0.25.12",
++        "@esbuild/win32-arm64": "0.25.12",
++        "@esbuild/win32-ia32": "0.25.12",
++        "@esbuild/win32-x64": "0.25.12"
++      }
++    },
++    "node_modules/esbuild-register": {
++      "version": "3.6.0",
++      "resolved": "https://registry.npmjs.org/esbuild-register/-/esbuild-register-3.6.0.tgz",
++      "integrity": "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "debug": "^4.3.4"
++      },
++      "peerDependencies": {
++        "esbuild": ">=0.12 <1"
++      }
++    },
+     "node_modules/escape-html": {
+       "version": "1.0.3",
+       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+@@ -722,6 +1907,15 @@
+         "node": ">= 0.6"
+       }
+     },
++    "node_modules/event-target-shim": {
++      "version": "5.0.1",
++      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
++      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=6"
++      }
++    },
+     "node_modules/express": {
+       "version": "4.22.1",
+       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+@@ -829,6 +2023,41 @@
+       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+       "license": "MIT"
+     },
++    "node_modules/form-data": {
++      "version": "4.0.5",
++      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
++      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
++      "license": "MIT",
++      "dependencies": {
++        "asynckit": "^0.4.0",
++        "combined-stream": "^1.0.8",
++        "es-set-tostringtag": "^2.1.0",
++        "hasown": "^2.0.2",
++        "mime-types": "^2.1.12"
++      },
++      "engines": {
++        "node": ">= 6"
++      }
++    },
++    "node_modules/form-data-encoder": {
++      "version": "1.7.2",
++      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
++      "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
++      "license": "MIT"
++    },
++    "node_modules/formdata-node": {
++      "version": "4.4.1",
++      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
++      "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
++      "license": "MIT",
++      "dependencies": {
++        "node-domexception": "1.0.0",
++        "web-streams-polyfill": "4.0.0-beta.3"
++      },
++      "engines": {
++        "node": ">= 12.20"
++      }
++    },
+     "node_modules/forwarded": {
+       "version": "0.2.0",
+       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+@@ -851,7 +2080,6 @@
+       "version": "2.3.3",
+       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+-      "dev": true,
+       "hasInstallScript": true,
+       "license": "MIT",
+       "optional": true,
+@@ -908,6 +2136,19 @@
+         "node": ">= 0.4"
+       }
+     },
++    "node_modules/get-tsconfig": {
++      "version": "4.13.0",
++      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
++      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "resolve-pkg-maps": "^1.0.0"
++      },
++      "funding": {
++        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
++      }
++    },
+     "node_modules/glob-parent": {
+       "version": "5.1.2",
+       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+@@ -955,6 +2196,21 @@
+         "url": "https://github.com/sponsors/ljharb"
+       }
+     },
++    "node_modules/has-tostringtag": {
++      "version": "1.0.2",
++      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
++      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
++      "license": "MIT",
++      "dependencies": {
++        "has-symbols": "^1.0.3"
++      },
++      "engines": {
++        "node": ">= 0.4"
++      },
++      "funding": {
++        "url": "https://github.com/sponsors/ljharb"
++      }
++    },
+     "node_modules/hasown": {
+       "version": "2.0.2",
+       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+@@ -987,6 +2243,15 @@
+         "url": "https://opencollective.com/express"
+       }
+     },
++    "node_modules/humanize-ms": {
++      "version": "1.2.1",
++      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
++      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
++      "license": "MIT",
++      "dependencies": {
++        "ms": "^2.0.0"
++      }
++    },
+     "node_modules/iconv-lite": {
+       "version": "0.4.24",
+       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+@@ -1256,6 +2521,46 @@
+         "node": ">= 0.6"
+       }
+     },
++    "node_modules/node-domexception": {
++      "version": "1.0.0",
++      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
++      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
++      "deprecated": "Use your platform's native DOMException instead",
++      "funding": [
++        {
++          "type": "github",
++          "url": "https://github.com/sponsors/jimmywarting"
++        },
++        {
++          "type": "github",
++          "url": "https://paypal.me/jimmywarting"
++        }
++      ],
++      "license": "MIT",
++      "engines": {
++        "node": ">=10.5.0"
++      }
++    },
++    "node_modules/node-fetch": {
++      "version": "2.7.0",
++      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
++      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
++      "license": "MIT",
++      "dependencies": {
++        "whatwg-url": "^5.0.0"
++      },
++      "engines": {
++        "node": "4.x || >=6.0.0"
++      },
++      "peerDependencies": {
++        "encoding": "^0.1.0"
++      },
++      "peerDependenciesMeta": {
++        "encoding": {
++          "optional": true
++        }
++      }
++    },
+     "node_modules/nodemon": {
+       "version": "3.1.11",
+       "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.11.tgz",
+@@ -1366,6 +2671,51 @@
+         "node": ">= 0.8"
+       }
+     },
++    "node_modules/openai": {
++      "version": "4.104.0",
++      "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
++      "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
++      "license": "Apache-2.0",
++      "dependencies": {
++        "@types/node": "^18.11.18",
++        "@types/node-fetch": "^2.6.4",
++        "abort-controller": "^3.0.0",
++        "agentkeepalive": "^4.2.1",
++        "form-data-encoder": "1.7.2",
++        "formdata-node": "^4.3.2",
++        "node-fetch": "^2.6.7"
++      },
++      "bin": {
++        "openai": "bin/cli"
++      },
++      "peerDependencies": {
++        "ws": "^8.18.0",
++        "zod": "^3.23.8"
++      },
++      "peerDependenciesMeta": {
++        "ws": {
++          "optional": true
++        },
++        "zod": {
++          "optional": true
++        }
++      }
++    },
++    "node_modules/openai/node_modules/@types/node": {
++      "version": "18.19.130",
++      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
++      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
++      "license": "MIT",
++      "dependencies": {
++        "undici-types": "~5.26.4"
++      }
++    },
++    "node_modules/openai/node_modules/undici-types": {
++      "version": "5.26.5",
++      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
++      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
++      "license": "MIT"
++    },
+     "node_modules/parseurl": {
+       "version": "1.3.3",
+       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+@@ -1381,6 +2731,95 @@
+       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+       "license": "MIT"
+     },
++    "node_modules/pg": {
++      "version": "8.16.3",
++      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
++      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
++      "license": "MIT",
++      "dependencies": {
++        "pg-connection-string": "^2.9.1",
++        "pg-pool": "^3.10.1",
++        "pg-protocol": "^1.10.3",
++        "pg-types": "2.2.0",
++        "pgpass": "1.0.5"
++      },
++      "engines": {
++        "node": ">= 16.0.0"
++      },
++      "optionalDependencies": {
++        "pg-cloudflare": "^1.2.7"
++      },
++      "peerDependencies": {
++        "pg-native": ">=3.0.1"
++      },
++      "peerDependenciesMeta": {
++        "pg-native": {
++          "optional": true
++        }
++      }
++    },
++    "node_modules/pg-cloudflare": {
++      "version": "1.2.7",
++      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
++      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
++      "license": "MIT",
++      "optional": true
++    },
++    "node_modules/pg-connection-string": {
++      "version": "2.9.1",
++      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
++      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
++      "license": "MIT"
++    },
++    "node_modules/pg-int8": {
++      "version": "1.0.1",
++      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
++      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
++      "license": "ISC",
++      "engines": {
++        "node": ">=4.0.0"
++      }
++    },
++    "node_modules/pg-pool": {
++      "version": "3.10.1",
++      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
++      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
++      "license": "MIT",
++      "peerDependencies": {
++        "pg": ">=8.0"
++      }
++    },
++    "node_modules/pg-protocol": {
++      "version": "1.10.3",
++      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
++      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
++      "license": "MIT"
++    },
++    "node_modules/pg-types": {
++      "version": "2.2.0",
++      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
++      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
++      "license": "MIT",
++      "dependencies": {
++        "pg-int8": "1.0.1",
++        "postgres-array": "~2.0.0",
++        "postgres-bytea": "~1.0.0",
++        "postgres-date": "~1.0.4",
++        "postgres-interval": "^1.1.0"
++      },
++      "engines": {
++        "node": ">=4"
++      }
++    },
++    "node_modules/pgpass": {
++      "version": "1.0.5",
++      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
++      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
++      "license": "MIT",
++      "dependencies": {
++        "split2": "^4.1.0"
++      }
++    },
+     "node_modules/picomatch": {
+       "version": "2.3.1",
+       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+@@ -1394,13 +2833,53 @@
+         "url": "https://github.com/sponsors/jonschlinkert"
+       }
+     },
++    "node_modules/postgres-array": {
++      "version": "2.0.0",
++      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
++      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=4"
++      }
++    },
++    "node_modules/postgres-bytea": {
++      "version": "1.0.1",
++      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.1.tgz",
++      "integrity": "sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=0.10.0"
++      }
++    },
++    "node_modules/postgres-date": {
++      "version": "1.0.7",
++      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
++      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=0.10.0"
++      }
++    },
++    "node_modules/postgres-interval": {
++      "version": "1.2.0",
++      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
++      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
++      "license": "MIT",
++      "dependencies": {
++        "xtend": "^4.0.0"
++      },
++      "engines": {
++        "node": ">=0.10.0"
++      }
++    },
+     "node_modules/prisma": {
+       "version": "5.22.0",
+       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
+       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
+-      "devOptional": true,
+       "hasInstallScript": true,
+       "license": "Apache-2.0",
++      "optional": true,
++      "peer": true,
+       "dependencies": {
+         "@prisma/engines": "5.22.0"
+       },
+@@ -1473,6 +2952,16 @@
+         "node": ">= 0.8"
+       }
+     },
++    "node_modules/resolve-pkg-maps": {
++      "version": "1.0.0",
++      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
++      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
++      "dev": true,
++      "license": "MIT",
++      "funding": {
++        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
++      }
++    },
+     "node_modules/safe-buffer": {
+       "version": "5.2.1",
+       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+@@ -1656,6 +3145,36 @@
+         "node": ">=10"
+       }
+     },
++    "node_modules/source-map": {
++      "version": "0.6.1",
++      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
++      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
++      "dev": true,
++      "license": "BSD-3-Clause",
++      "engines": {
++        "node": ">=0.10.0"
++      }
++    },
++    "node_modules/source-map-support": {
++      "version": "0.5.21",
++      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
++      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
++      "dev": true,
++      "license": "MIT",
++      "dependencies": {
++        "buffer-from": "^1.0.0",
++        "source-map": "^0.6.0"
++      }
++    },
++    "node_modules/split2": {
++      "version": "4.2.0",
++      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
++      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
++      "license": "ISC",
++      "engines": {
++        "node": ">= 10.x"
++      }
++    },
+     "node_modules/statuses": {
+       "version": "2.0.2",
+       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+@@ -1710,6 +3229,12 @@
+         "nodetouch": "bin/nodetouch.js"
+       }
+     },
++    "node_modules/tr46": {
++      "version": "0.0.3",
++      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
++      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
++      "license": "MIT"
++    },
+     "node_modules/ts-node": {
+       "version": "10.9.2",
+       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+@@ -1792,7 +3317,6 @@
+       "version": "6.21.0",
+       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+-      "dev": true,
+       "license": "MIT"
+     },
+     "node_modules/unpipe": {
+@@ -1829,6 +3353,40 @@
+         "node": ">= 0.8"
+       }
+     },
++    "node_modules/web-streams-polyfill": {
++      "version": "4.0.0-beta.3",
++      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
++      "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
++      "license": "MIT",
++      "engines": {
++        "node": ">= 14"
++      }
++    },
++    "node_modules/webidl-conversions": {
++      "version": "3.0.1",
++      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
++      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
++      "license": "BSD-2-Clause"
++    },
++    "node_modules/whatwg-url": {
++      "version": "5.0.0",
++      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
++      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
++      "license": "MIT",
++      "dependencies": {
++        "tr46": "~0.0.3",
++        "webidl-conversions": "^3.0.0"
++      }
++    },
++    "node_modules/xtend": {
++      "version": "4.0.2",
++      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
++      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
++      "license": "MIT",
++      "engines": {
++        "node": ">=0.4"
++      }
++    },
+     "node_modules/yn": {
+       "version": "3.1.1",
+       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+diff --git a/backend/package.json b/backend/package.json
+index 7a7b1de..9260b8c 100644
+--- a/backend/package.json
++++ b/backend/package.json
+@@ -6,21 +6,20 @@
+   "scripts": {
+     "dev": "nodemon --exec ts-node src/server.ts",
+     "build": "tsc",
+-    "start": "node dist/server.js",
+-    "prisma:generate": "prisma generate",
+-    "prisma:migrate": "prisma migrate dev",
+-    "seed": "ts-node src/seed.ts"
++    "start": "node dist/server.js"
+   },
+   "keywords": [],
+   "author": "",
+   "license": "ISC",
+   "dependencies": {
+-    "@prisma/client": "5.22.0",
+     "bcryptjs": "^2.4.3",
+     "cors": "^2.8.5",
++    "drizzle-orm": "^0.44.3",
+     "dotenv": "^16.4.5",
+     "express": "^4.19.2",
+-    "jsonwebtoken": "^9.0.2"
++    "jsonwebtoken": "^9.0.2",
++    "openai": "^4.104.0",
++    "pg": "^8.13.1"
+   },
+   "devDependencies": {
+     "@types/bcryptjs": "^2.4.6",
+@@ -28,8 +27,9 @@
+     "@types/express": "^4.17.21",
+     "@types/jsonwebtoken": "^9.0.7",
+     "@types/node": "^20.11.30",
++    "@types/pg": "^8.11.10",
++    "drizzle-kit": "^0.31.4",
+     "nodemon": "^3.0.3",
+-    "prisma": "5.22.0",
+     "ts-node": "^10.9.2",
+     "typescript": "^5.4.5"
+   }
+diff --git a/backend/prisma/dev.db b/backend/prisma/dev.db
+deleted file mode 100644
+index 19e287f..0000000
+Binary files a/backend/prisma/dev.db and /dev/null differ
+diff --git a/backend/prisma/migrations/20251226185440_init/migration.sql b/backend/prisma/migrations/20251226185440_init/migration.sql
+deleted file mode 100644
+index c2642f8..0000000
+--- a/backend/prisma/migrations/20251226185440_init/migration.sql
++++ /dev/null
+@@ -1,82 +0,0 @@
+--- CreateTable
+-CREATE TABLE "User" (
+-    "id" TEXT NOT NULL PRIMARY KEY,
+-    "email" TEXT NOT NULL,
+-    "name" TEXT,
+-    "passwordHash" TEXT NOT NULL,
+-    "role" TEXT NOT NULL DEFAULT 'CASHIER',
+-    "isActive" BOOLEAN NOT NULL DEFAULT true,
+-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+-    "updatedAt" DATETIME NOT NULL
+-);
+-
+--- CreateTable
+-CREATE TABLE "Product" (
+-    "id" TEXT NOT NULL PRIMARY KEY,
+-    "name" TEXT NOT NULL,
+-    "barcode" TEXT,
+-    "sku" TEXT,
+-    "price" INTEGER NOT NULL,
+-    "currency" TEXT NOT NULL DEFAULT 'AED',
+-    "stock" INTEGER NOT NULL DEFAULT 0,
+-    "isActive" BOOLEAN NOT NULL DEFAULT true,
+-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+-    "updatedAt" DATETIME NOT NULL
+-);
+-
+--- CreateTable
+-CREATE TABLE "Transaction" (
+-    "id" TEXT NOT NULL PRIMARY KEY,
+-    "receiptNo" TEXT NOT NULL,
+-    "paymentMethod" TEXT NOT NULL,
+-    "subtotal" INTEGER NOT NULL,
+-    "total" INTEGER NOT NULL,
+-    "currency" TEXT NOT NULL DEFAULT 'AED',
+-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+-    "updatedAt" DATETIME NOT NULL,
+-    "cashierId" TEXT NOT NULL,
+-    CONSTRAINT "Transaction_cashierId_fkey" FOREIGN KEY ("cashierId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+-);
+-
+--- CreateTable
+-CREATE TABLE "TransactionItem" (
+-    "id" TEXT NOT NULL PRIMARY KEY,
+-    "transactionId" TEXT NOT NULL,
+-    "productId" TEXT NOT NULL,
+-    "quantity" INTEGER NOT NULL,
+-    "unitPrice" INTEGER NOT NULL,
+-    "lineTotal" INTEGER NOT NULL,
+-    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+-    CONSTRAINT "TransactionItem_transactionId_fkey" FOREIGN KEY ("transactionId") REFERENCES "Transaction" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+-    CONSTRAINT "TransactionItem_productId_fkey" FOREIGN KEY ("productId") REFERENCES "Product" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+-);
+-
+--- CreateIndex
+-CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+-
+--- CreateIndex
+-CREATE UNIQUE INDEX "Product_barcode_key" ON "Product"("barcode");
+-
+--- CreateIndex
+-CREATE UNIQUE INDEX "Product_sku_key" ON "Product"("sku");
+-
+--- CreateIndex
+-CREATE INDEX "Product_name_idx" ON "Product"("name");
+-
+--- CreateIndex
+-CREATE INDEX "Product_barcode_idx" ON "Product"("barcode");
+-
+--- CreateIndex
+-CREATE UNIQUE INDEX "Transaction_receiptNo_key" ON "Transaction"("receiptNo");
+-
+--- CreateIndex
+-CREATE INDEX "Transaction_createdAt_idx" ON "Transaction"("createdAt");
+-
+--- CreateIndex
+-CREATE INDEX "Transaction_cashierId_idx" ON "Transaction"("cashierId");
+-
+--- CreateIndex
+-CREATE INDEX "TransactionItem_transactionId_idx" ON "TransactionItem"("transactionId");
+-
+--- CreateIndex
+-CREATE INDEX "TransactionItem_productId_idx" ON "TransactionItem"("productId");
+diff --git a/backend/prisma/migrations/migration_lock.toml b/backend/prisma/migrations/migration_lock.toml
+deleted file mode 100644
+index e5e5c47..0000000
+--- a/backend/prisma/migrations/migration_lock.toml
++++ /dev/null
+@@ -1,3 +0,0 @@
+-# Please do not edit this file manually
+-# It should be added in your version-control system (i.e. Git)
+-provider = "sqlite"
+\ No newline at end of file
+diff --git a/backend/prisma/schema.prisma b/backend/prisma/schema.prisma
+deleted file mode 100644
+index ca4e383..0000000
+--- a/backend/prisma/schema.prisma
++++ /dev/null
+@@ -1,82 +0,0 @@
+-// Prisma schema for SuperMandi POS backend
+-// SQLite by default for local development.
+-
+-generator client {
+-  provider = "prisma-client-js"
+-}
+-
+-datasource db {
+-  provider = "sqlite"
+-  url      = env("DATABASE_URL")
+-}
+-
+-model User {
+-  id           String    @id @default(cuid())
+-  email        String    @unique
+-  name         String?
+-  passwordHash String
+-  // SQLite doesn't have a native enum type. Store as string.
+-  role         String    @default("CASHIER")
+-  isActive     Boolean   @default(true)
+-  createdAt    DateTime  @default(now())
+-  updatedAt    DateTime  @updatedAt
+-
+-  transactions Transaction[]
+-}
+-
+-model Product {
+-  id          String            @id @default(cuid())
+-  name        String
+-  barcode     String?           @unique
+-  sku         String?           @unique
+-  price       Int               // stored in minor units (e.g. fils/cents)
+-  currency    String            @default("AED")
+-  stock       Int               @default(0)
+-  isActive    Boolean           @default(true)
+-  createdAt   DateTime          @default(now())
+-  updatedAt   DateTime          @updatedAt
+-
+-  items       TransactionItem[]
+-
+-  @@index([name])
+-  @@index([barcode])
+-}
+-
+-model Transaction {
+-  id            String            @id @default(cuid())
+-  receiptNo     String            @unique
+-  // SQLite doesn't have a native enum type. Store as string.
+-  paymentMethod String
+-  subtotal      Int
+-  total         Int
+-  currency      String            @default("AED")
+-  createdAt     DateTime          @default(now())
+-  updatedAt     DateTime          @updatedAt
+-
+-  cashierId     String
+-  cashier       User              @relation(fields: [cashierId], references: [id])
+-
+-  items         TransactionItem[]
+-
+-  @@index([createdAt])
+-  @@index([cashierId])
+-}
+-
+-model TransactionItem {
+-  id            String       @id @default(cuid())
+-  transactionId String
+-  transaction   Transaction  @relation(fields: [transactionId], references: [id], onDelete: Cascade)
+-
+-  productId     String
+-  product       Product      @relation(fields: [productId], references: [id])
+-
+-  quantity      Int
+-  unitPrice     Int
+-  lineTotal     Int
+-
+-  createdAt     DateTime     @default(now())
+-
+-  @@index([transactionId])
+-  @@index([productId])
+-}
+-
+diff --git a/backend/src/app.ts b/backend/src/app.ts
+index f13cea5..0ec3f62 100644
+--- a/backend/src/app.ts
++++ b/backend/src/app.ts
+@@ -15,11 +15,8 @@ app.use(cors());
+ app.use(express.json());
+ 
+ app.get("/health", (_req, res) => {
+-  res.json({
+-    status: "OK",
+-    service: "SuperMandi Backend",
+-    time: new Date().toISOString()
+-  });
++  // Cloud health-check contract: must be JSON { status: "ok" }
++  res.json({ status: "ok" });
+ });
+ 
+ app.use("/api", apiRouter);
+diff --git a/backend/src/lib/prisma.ts b/backend/src/lib/prisma.ts
+deleted file mode 100644
+index 8b57bc5..0000000
+--- a/backend/src/lib/prisma.ts
++++ /dev/null
+@@ -1,23 +0,0 @@
+-import { PrismaClient } from "@prisma/client";
+-import path from "path";
+-
+-declare global {
+-  // eslint-disable-next-line no-var
+-  var __prisma: PrismaClient | undefined;
+-}
+-
+-// Prisma runtime stability:
+-// If DATABASE_URL is missing in the server environment, Prisma throws at query time.
+-// To avoid breaking the mobile app session bootstrap, fall back to the bundled SQLite DB.
+-// This does NOT change the schema datasource (still uses env("DATABASE_URL") in schema.prisma).
+-const databaseUrl =
+-  process.env.DATABASE_URL?.trim() ||
+-  `file:${path.resolve(__dirname, "..", "..", "prisma", "dev.db")}`;
+-
+-export const prisma: PrismaClient =
+-  global.__prisma ?? new PrismaClient({ datasources: { db: { url: databaseUrl } } });
+-
+-if (process.env.NODE_ENV !== "production") {
+-  global.__prisma = prisma;
+-}
+-
+diff --git a/backend/src/middleware/auth.ts b/backend/src/middleware/auth.ts
+deleted file mode 100644
+index 615602a..0000000
+--- a/backend/src/middleware/auth.ts
++++ /dev/null
+@@ -1,43 +0,0 @@
+-import type { NextFunction, Request, Response } from "express";
+-import jwt from "jsonwebtoken";
+-import { requireEnv } from "../lib/env";
+-import { prisma } from "../lib/prisma";
+-import { HttpError } from "../lib/httpError";
+-
+-export type AuthenticatedRequest = Request & {
+-  user?: { id: string; email: string; role: string };
+-};
+-
+-type JwtPayload = { sub: string };
+-
+-export async function requireAuth(
+-  req: AuthenticatedRequest,
+-  _res: Response,
+-  next: NextFunction
+-): Promise<void> {
+-  try {
+-    const header = req.headers.authorization;
+-    if (!header?.startsWith("Bearer ")) {
+-      throw new HttpError(401, "Missing Authorization header");
+-    }
+-
+-    const token = header.slice("Bearer ".length);
+-    const secret = requireEnv("JWT_SECRET");
+-    const decoded = jwt.verify(token, secret) as JwtPayload;
+-
+-    const userId = decoded.sub;
+-    if (!userId) throw new HttpError(401, "Invalid token");
+-
+-    const user = await prisma.user.findUnique({
+-      where: { id: userId },
+-      select: { id: true, email: true, role: true, isActive: true }
+-    });
+-    if (!user || !user.isActive) throw new HttpError(401, "User not found or inactive");
+-
+-    req.user = { id: user.id, email: user.email, role: user.role };
+-    next();
+-  } catch (e) {
+-    next(e);
+-  }
+-}
+-
+diff --git a/backend/src/routes/auth.ts b/backend/src/routes/auth.ts
+deleted file mode 100644
+index ad8eea8..0000000
+--- a/backend/src/routes/auth.ts
++++ /dev/null
+@@ -1,83 +0,0 @@
+-import { Router } from "express";
+-import bcrypt from "bcryptjs";
+-import jwt from "jsonwebtoken";
+-import { prisma } from "../lib/prisma";
+-import { requireEnv } from "../lib/env";
+-import { HttpError } from "../lib/httpError";
+-import { requireAuth, type AuthenticatedRequest } from "../middleware/auth";
+-
+-export const authRouter = Router();
+-
+-authRouter.post("/register", async (req, res, next) => {
+-  try {
+-    const { email, password, name, role } = (req.body ?? {}) as {
+-      email?: string;
+-      password?: string;
+-      name?: string;
+-      role?: "ADMIN" | "CASHIER";
+-    };
+-
+-    if (!email || !password) {
+-      throw new HttpError(400, "email and password are required");
+-    }
+-
+-    const existing = await prisma.user.findUnique({ where: { email } });
+-    if (existing) throw new HttpError(409, "User already exists");
+-
+-    const passwordHash = await bcrypt.hash(password, 10);
+-    const user = await prisma.user.create({
+-      data: {
+-        email,
+-        name: name?.trim() ? name.trim() : undefined,
+-        passwordHash,
+-        role: role ?? "CASHIER"
+-      },
+-      select: { id: true, email: true, name: true, role: true, createdAt: true }
+-    });
+-
+-    res.status(201).json({ user });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+-authRouter.post("/login", async (req, res, next) => {
+-  try {
+-    const { email, password } = (req.body ?? {}) as {
+-      email?: string;
+-      password?: string;
+-    };
+-    if (!email || !password) throw new HttpError(400, "email and password are required");
+-
+-    const user = await prisma.user.findUnique({ where: { email } });
+-    if (!user || !user.isActive) throw new HttpError(401, "Invalid credentials");
+-
+-    const ok = await bcrypt.compare(password, user.passwordHash);
+-    if (!ok) throw new HttpError(401, "Invalid credentials");
+-
+-    const secret = requireEnv("JWT_SECRET");
+-    const token = jwt.sign({ sub: user.id }, secret, { expiresIn: "7d" });
+-
+-    res.json({
+-      token,
+-      user: { id: user.id, email: user.email, name: user.name, role: user.role }
+-    });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+-authRouter.get("/me", requireAuth, async (req: AuthenticatedRequest, res, next) => {
+-  try {
+-    const userId = req.user!.id;
+-    const user = await prisma.user.findUnique({
+-      where: { id: userId },
+-      select: { id: true, email: true, name: true, role: true, createdAt: true }
+-    });
+-    if (!user) throw new HttpError(404, "User not found");
+-    res.json({ user });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+diff --git a/backend/src/routes/index.ts b/backend/src/routes/index.ts
+index 242990f..00f851e 100644
+--- a/backend/src/routes/index.ts
++++ b/backend/src/routes/index.ts
+@@ -1,12 +1,7 @@
+ import { Router } from "express";
+-import { authRouter } from "./auth";
+-import { productsRouter } from "./products";
+-import { transactionsRouter } from "./transactions";
+-import { usersRouter } from "./users";
++import { v1Router } from "./v1";
+ 
+ export const apiRouter = Router();
+ 
+-apiRouter.use("/auth", authRouter);
+-apiRouter.use("/products", productsRouter);
+-apiRouter.use("/transactions", transactionsRouter);
+-apiRouter.use("/users", usersRouter);
++// Cloud API surface (no Prisma).
++apiRouter.use("/v1", v1Router);
+diff --git a/backend/src/routes/products.ts b/backend/src/routes/products.ts
+deleted file mode 100644
+index b11623b..0000000
+--- a/backend/src/routes/products.ts
++++ /dev/null
+@@ -1,123 +0,0 @@
+-import { Router } from "express";
+-import { prisma } from "../lib/prisma";
+-import { HttpError } from "../lib/httpError";
+-import { requireAuth } from "../middleware/auth";
+-
+-export const productsRouter = Router();
+-
+-// All product endpoints require auth for now.
+-productsRouter.use(requireAuth);
+-
+-productsRouter.get("/", async (req, res, next) => {
+-  try {
+-    const barcode = typeof req.query.barcode === "string" ? req.query.barcode : undefined;
+-    const q = typeof req.query.q === "string" ? req.query.q : undefined;
+-
+-    const products = await prisma.product.findMany({
+-      where: {
+-        isActive: true,
+-        ...(barcode ? { barcode } : {}),
+-        ...(q
+-          ? {
+-              OR: [
+-                { name: { contains: q } },
+-                { sku: { contains: q } },
+-                { barcode: { contains: q } }
+-              ]
+-            }
+-          : {})
+-      },
+-      orderBy: { name: "asc" }
+-    });
+-
+-    res.json({ products });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+-productsRouter.post("/", async (req, res, next) => {
+-  try {
+-    const { name, barcode, sku, price, currency, stock } = (req.body ?? {}) as {
+-      name?: string;
+-      barcode?: string | null;
+-      sku?: string | null;
+-      price?: number;
+-      currency?: string;
+-      stock?: number;
+-    };
+-
+-    if (!name?.trim()) throw new HttpError(400, "name is required");
+-    const priceInt = Number.isInteger(price) ? price : undefined;
+-    if (priceInt === undefined) throw new HttpError(400, "price must be an integer (minor units)");
+-
+-    const product = await prisma.product.create({
+-      data: {
+-        name: name.trim(),
+-        barcode: barcode ?? undefined,
+-        sku: sku ?? undefined,
+-        price: priceInt,
+-        currency: currency?.trim() ? currency.trim().toUpperCase() : "AED",
+-        stock: Number.isInteger(stock) ? stock : 0
+-      }
+-    });
+-    res.status(201).json({ product });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+-productsRouter.get("/:id", async (req, res, next) => {
+-  try {
+-    const product = await prisma.product.findUnique({ where: { id: req.params.id } });
+-    if (!product) throw new HttpError(404, "Product not found");
+-    res.json({ product });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+-productsRouter.patch("/:id", async (req, res, next) => {
+-  try {
+-    const { name, barcode, sku, price, currency, stock, isActive } = (req.body ?? {}) as {
+-      name?: string;
+-      barcode?: string | null;
+-      sku?: string | null;
+-      price?: number;
+-      currency?: string;
+-      stock?: number;
+-      isActive?: boolean;
+-    };
+-
+-    const product = await prisma.product.update({
+-      where: { id: req.params.id },
+-      data: {
+-        ...(typeof name === "string" ? { name: name.trim() } : {}),
+-        ...(barcode !== undefined ? { barcode: barcode ?? null } : {}),
+-        ...(sku !== undefined ? { sku: sku ?? null } : {}),
+-        ...(Number.isInteger(price) ? { price } : {}),
+-        ...(typeof currency === "string" ? { currency: currency.trim().toUpperCase() } : {}),
+-        ...(Number.isInteger(stock) ? { stock } : {}),
+-        ...(typeof isActive === "boolean" ? { isActive } : {})
+-      }
+-    });
+-
+-    res.json({ product });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+-productsRouter.delete("/:id", async (req, res, next) => {
+-  try {
+-    // Soft-delete
+-    const product = await prisma.product.update({
+-      where: { id: req.params.id },
+-      data: { isActive: false }
+-    });
+-    res.json({ product });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+diff --git a/backend/src/routes/transactions.ts b/backend/src/routes/transactions.ts
+deleted file mode 100644
+index f58f978..0000000
+--- a/backend/src/routes/transactions.ts
++++ /dev/null
+@@ -1,120 +0,0 @@
+-import { Router } from "express";
+-import { prisma } from "../lib/prisma";
+-import { HttpError } from "../lib/httpError";
+-import { requireAuth, type AuthenticatedRequest } from "../middleware/auth";
+-
+-export const transactionsRouter = Router();
+-
+-transactionsRouter.use(requireAuth);
+-
+-function generateReceiptNo(): string {
+-  // Example: SM-20251226-184955-AB12
+-  const now = new Date();
+-  const y = String(now.getUTCFullYear());
+-  const m = String(now.getUTCMonth() + 1).padStart(2, "0");
+-  const d = String(now.getUTCDate()).padStart(2, "0");
+-  const hh = String(now.getUTCHours()).padStart(2, "0");
+-  const mm = String(now.getUTCMinutes()).padStart(2, "0");
+-  const ss = String(now.getUTCSeconds()).padStart(2, "0");
+-  const rand = Math.random().toString(36).slice(2, 6).toUpperCase();
+-  return `SM-${y}${m}${d}-${hh}${mm}${ss}-${rand}`;
+-}
+-
+-transactionsRouter.get("/", async (req: AuthenticatedRequest, res, next) => {
+-  try {
+-    const take = Math.min(100, Math.max(1, Number(req.query.take ?? 50)));
+-    const transactions = await prisma.transaction.findMany({
+-      take,
+-      orderBy: { createdAt: "desc" },
+-      include: { items: { include: { product: true } }, cashier: true }
+-    });
+-
+-    res.json({ transactions });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+-transactionsRouter.post("/", async (req: AuthenticatedRequest, res, next) => {
+-  try {
+-    const { items, paymentMethod, currency } = (req.body ?? {}) as {
+-      items?: Array<{ productId?: string; quantity?: number }>;
+-      paymentMethod?: "CASH" | "CARD" | "OTHER";
+-      currency?: string;
+-    };
+-
+-    if (!items?.length) throw new HttpError(400, "items are required");
+-    if (!paymentMethod) throw new HttpError(400, "paymentMethod is required");
+-
+-    const userId = req.user!.id;
+-    const receiptNo = generateReceiptNo();
+-    const txCurrency = currency?.trim() ? currency.trim().toUpperCase() : "AED";
+-
+-    const result = await prisma.$transaction(async (db) => {
+-      // Fetch products and validate quantities
+-      const productIds = items
+-        .map((i) => i.productId)
+-        .filter((id): id is string => typeof id === "string" && id.length > 0);
+-      if (productIds.length !== items.length) throw new HttpError(400, "Each item must include productId");
+-
+-      const products = await db.product.findMany({
+-        where: { id: { in: productIds }, isActive: true }
+-      });
+-      if (products.length !== productIds.length) throw new HttpError(400, "One or more products not found");
+-
+-      const byId = new Map(products.map((p) => [p.id, p] as const));
+-
+-      const normalized = items.map((i) => {
+-        const qty = i.quantity;
+-        if (!Number.isInteger(qty) || (qty as number) <= 0) {
+-          throw new HttpError(400, "quantity must be a positive integer");
+-        }
+-        const p = byId.get(i.productId!);
+-        if (!p) throw new HttpError(400, "Product not found");
+-        if (p.stock < (qty as number)) throw new HttpError(409, `Insufficient stock for ${p.name}`);
+-        const unitPrice = p.price;
+-        const lineTotal = unitPrice * (qty as number);
+-        return {
+-          productId: p.id,
+-          quantity: qty as number,
+-          unitPrice,
+-          lineTotal
+-        };
+-      });
+-
+-      const subtotal = normalized.reduce((sum, i) => sum + i.lineTotal, 0);
+-      const total = subtotal;
+-
+-      // Create transaction + items
+-      const created = await db.transaction.create({
+-        data: {
+-          receiptNo,
+-          paymentMethod,
+-          subtotal,
+-          total,
+-          currency: txCurrency,
+-          cashierId: userId,
+-          items: {
+-            create: normalized
+-          }
+-        },
+-        include: { items: { include: { product: true } }, cashier: true }
+-      });
+-
+-      // Decrement stock
+-      for (const item of normalized) {
+-        await db.product.update({
+-          where: { id: item.productId },
+-          data: { stock: { decrement: item.quantity } }
+-        });
+-      }
+-
+-      return created;
+-    });
+-
+-    res.status(201).json({ transaction: result });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+diff --git a/backend/src/routes/users.ts b/backend/src/routes/users.ts
+deleted file mode 100644
+index dae3a8a..0000000
+--- a/backend/src/routes/users.ts
++++ /dev/null
+@@ -1,23 +0,0 @@
+-import { Router } from "express";
+-import { prisma } from "../lib/prisma";
+-import { HttpError } from "../lib/httpError";
+-import { requireAuth, type AuthenticatedRequest } from "../middleware/auth";
+-
+-export const usersRouter = Router();
+-
+-usersRouter.use(requireAuth);
+-
+-usersRouter.get("/me", async (req: AuthenticatedRequest, res, next) => {
+-  try {
+-    const userId = req.user!.id;
+-    const user = await prisma.user.findUnique({
+-      where: { id: userId },
+-      select: { id: true, email: true, name: true, role: true, isActive: true, createdAt: true }
+-    });
+-    if (!user) throw new HttpError(404, "User not found");
+-    res.json({ user });
+-  } catch (e) {
+-    next(e);
+-  }
+-});
+-
+diff --git a/backend/src/seed.ts b/backend/src/seed.ts
+deleted file mode 100644
+index acc70b8..0000000
+--- a/backend/src/seed.ts
++++ /dev/null
+@@ -1,61 +0,0 @@
+-import { PrismaClient } from "@prisma/client";
+-
+-const prisma = new PrismaClient();
+-
+-async function main() {
+-  console.log("🌱 Starting database seed...");
+-
+-  // Clear existing products
+-  const deletedCount = await prisma.product.deleteMany({});
+-  console.log(`✅ Cleared ${deletedCount.count} existing products`);
+-
+-  // Insert test products with exact barcodes used by frontend
+-  const testProducts = [
+-    {
+-      name: "Test Barcode Product",
+-      barcode: "0987654321",
+-      price: 1500, // 15.00 AED in fils (minor units)
+-      currency: "AED",
+-      stock: 100,
+-      isActive: true,
+-    },
+-    {
+-      name: "Test QR Product C",
+-      barcode: "QR_PRODUCT_C",
+-      price: 2500, // 25.00 AED in fils
+-      currency: "AED",
+-      stock: 50,
+-      isActive: true,
+-    },
+-    {
+-      name: "Test Barcode Product D",
+-      barcode: "BAR_PRODUCT_D",
+-      price: 3000, // 30.00 AED in fils
+-      currency: "AED",
+-      stock: 75,
+-      isActive: true,
+-    },
+-  ];
+-
+-  for (const productData of testProducts) {
+-    const product = await prisma.product.create({
+-      data: productData,
+-    });
+-    console.log(`✅ Created product: ${product.name} (barcode: ${product.barcode})`);
+-  }
+-
+-  console.log("\n🎉 Database seeding completed successfully!");
+-  console.log("\nTest products available:");
+-  console.log("  1. Barcode: 0987654321 → Test Barcode Product (15.00 AED)");
+-  console.log("  2. Barcode: QR_PRODUCT_C → Test QR Product C (25.00 AED)");
+-  console.log("  3. Barcode: BAR_PRODUCT_D → Test Barcode Product D (30.00 AED)");
+-}
+-
+-main()
+-  .catch((e) => {
+-    console.error("❌ Error during seeding:", e);
+-    process.exit(1);
+-  })
+-  .finally(async () => {
+-    await prisma.$disconnect();
+-  });
+diff --git a/backend/tsconfig.json b/backend/tsconfig.json
+index 38dbad8..0d3acf9 100644
+--- a/backend/tsconfig.json
++++ b/backend/tsconfig.json
+@@ -10,5 +10,9 @@
+     "strict": true,
+     "skipLibCheck": true,
+     "verbatimModuleSyntax": false
+-  }
++  },
++  "exclude": [
++    "node_modules",
++    "**/*.prisma_disabled.ts"
++  ]
+ }
+diff --git a/src/constants/store.ts b/src/constants/store.ts
+index 5264f44..016682e 100644
+--- a/src/constants/store.ts
++++ b/src/constants/store.ts
+@@ -1 +1,4 @@
++// Store identity used for cloud event logging.
++// Keep this stable per pilot; later this can be provisioned from backend.
++export const STORE_ID = "store-1";
+ export const STORE_NAME = "Sharma Kirana Store";
+diff --git a/src/screens/PaymentScreen.tsx b/src/screens/PaymentScreen.tsx
+index aeb9498..3eea0f3 100644
+--- a/src/screens/PaymentScreen.tsx
++++ b/src/screens/PaymentScreen.tsx
+@@ -1,4 +1,4 @@
+-import React, { useState, useEffect } from "react";
++import React, { useState, useEffect, useRef } from "react";
+ import {
+   View,
+   Text,
+@@ -15,6 +15,7 @@ import * as Clipboard from 'expo-clipboard';
+ import { formatMoney, minorToMajor } from "../utils/money";
+ import { createTransaction } from "../services/api/transactionsApi";
+ import { enqueueTransaction } from "../services/syncService";
++import { logPaymentEvent } from "../services/cloudEventLogger";
+ 
+ type RootStackParamList = {
+   Splash: undefined;
+@@ -22,6 +23,8 @@ type RootStackParamList = {
+   Payment: undefined;
+   SuccessPrint: {
+     paymentMode: 'UPI' | 'CASH' | 'DUE';
++    transactionId: string;
++    billId: string;
+   };
+ };
+ 
+@@ -39,6 +42,28 @@ const PaymentScreen = () => {
+   const [selectedMode, setSelectedMode] = useState<PaymentMode>('UPI');
+   const [upiString, setUpiString] = useState<string>('');
+ 
++  // Stable IDs for payment observability (used across all payment lifecycle events)
++  const transactionId = useRef(`${Date.now()}-${Math.random().toString(16).slice(2)}`).current;
++  const billId = useRef(Date.now().toString().slice(-6)).current;
++  const finalized = useRef(false);
++
++  // Payment timeout watchdog (UPI/QR often isn't instant).
++  useEffect(() => {
++    const id = setTimeout(() => {
++      if (!finalized.current) {
++        void logPaymentEvent("PAYMENT_TIMEOUT", {
++          transactionId,
++          billId,
++          paymentMode: selectedMode,
++          amountMinor: total,
++          currency: items[0]?.currency ?? "INR",
++          timeoutMs: 120_000
++        });
++      }
++    }, 120_000);
++    return () => clearTimeout(id);
++  }, [billId, items, selectedMode, total, transactionId]);
++
+   // Generate UPI payment string
+   const generateUPIString = (amount: number): string => {
+     const billNumber = Date.now().toString().slice(-6);
+@@ -53,8 +78,54 @@ const PaymentScreen = () => {
+     setUpiString(upiStr);
+     console.log("Generated UPI string:", upiStr);
+     console.log("📱 UPI QR code generated for amount:", minorToMajor(total).toFixed(2));
++
++    // Payment lifecycle events (cloud): init -> (UPI) QR created -> pending
++    void logPaymentEvent("PAYMENT_INIT", {
++      transactionId,
++      billId,
++      paymentMode: selectedMode,
++      amountMinor: total,
++      currency: items[0]?.currency ?? "INR",
++      itemCount: items.length
++    });
++
++    if (selectedMode === "UPI") {
++      void logPaymentEvent("PAYMENT_QR_CREATED", {
++        transactionId,
++        billId,
++        paymentMode: "UPI",
++        retailerUpiId: RETAILER_UPI_ID,
++        upiString: upiStr,
++        amountMinor: total,
++        currency: items[0]?.currency ?? "INR"
++      });
++    }
++
++    void logPaymentEvent("PAYMENT_PENDING", {
++      transactionId,
++      billId,
++      paymentMode: selectedMode,
++      amountMinor: total,
++      currency: items[0]?.currency ?? "INR"
++    });
+   }, [total]);
+ 
++  // If user backs out without finishing, mark as cancelled.
++  useEffect(() => {
++    return () => {
++      if (!finalized.current) {
++        void logPaymentEvent("PAYMENT_CANCELLED", {
++          transactionId,
++          billId,
++          paymentMode: selectedMode,
++          amountMinor: total,
++          currency: items[0]?.currency ?? "INR"
++        });
++      }
++    };
++    // eslint-disable-next-line react-hooks/exhaustive-deps
++  }, []);
++
+   const handlePaymentSelect = (mode: PaymentMode) => {
+     setSelectedMode(mode);
+   };
+@@ -69,6 +140,9 @@ const PaymentScreen = () => {
+   const handleCompletePayment = async () => {
+     console.log(`Completing payment with mode: ${selectedMode}`);
+ 
++    // Idempotency guard: don't double-log success/failure.
++    if (finalized.current) return;
++
+     const paymentMethod = selectedMode === "CASH" ? "CASH" : selectedMode === "UPI" ? "CARD" : "OTHER";
+     const currency = items[0]?.currency ?? "INR";
+ 
+@@ -81,11 +155,38 @@ const PaymentScreen = () => {
+ 
+     try {
+       await createTransaction(payload);
++
++      // Payment confirmed in POS.
++      finalized.current = true;
++      void logPaymentEvent("PAYMENT_CONFIRMED", {
++        transactionId,
++        billId,
++        paymentMode: selectedMode,
++        amountMinor: total,
++        currency
++      });
++      void logPaymentEvent("PAYMENT_SUCCESS", {
++        transactionId,
++        billId,
++        paymentMode: selectedMode,
++        amountMinor: total,
++        currency
++      });
+     } catch (e) {
+       await enqueueTransaction(payload);
++
++      // Don't block the sale; record as failed-to-submit.
++      void logPaymentEvent("PAYMENT_FAILED", {
++        transactionId,
++        billId,
++        paymentMode: selectedMode,
++        amountMinor: total,
++        currency,
++        reason: "backend_unreachable_or_error"
++      });
+     }
+ 
+-    navigation.navigate('SuccessPrint', { paymentMode: selectedMode });
++    navigation.navigate('SuccessPrint', { paymentMode: selectedMode, transactionId, billId });
+   };
+ 
+   const renderPaymentOption = (mode: PaymentMode, title: string, icon: string) => (
+diff --git a/src/screens/SellScanScreen.tsx b/src/screens/SellScanScreen.tsx
+index addb3a7..f3f8395 100644
+--- a/src/screens/SellScanScreen.tsx
++++ b/src/screens/SellScanScreen.tsx
+@@ -17,6 +17,7 @@ import PosStatusStrip from "../components/PosStatusStrip";
+ import { useCartStore } from "../stores/cartStore";
+ import { useProductsStore } from "../stores/productsStore";
+ import { formatMoney } from "../utils/money";
++import { logPosEvent } from "../services/cloudEventLogger";
+ 
+ type RootStackParamList = {
+   Splash: undefined;
+@@ -57,6 +58,8 @@ export default function SellScanScreen() {
+     setScanned(true);
+     setLastScannedCode(data);
+ 
++    // Fire-and-forget scan event
++    void logPosEvent("SCAN_BARCODE", { barcode: data, source: "camera" });
+     handleScan(data);
+ 
+     setTimeout(() => {
+@@ -84,6 +87,9 @@ export default function SellScanScreen() {
+ 
+     if (!barcode.trim()) return;
+ 
++    // For test buttons / manual scans
++    void logPosEvent("SCAN_BARCODE", { barcode, source: "manual_or_test" });
++
+     const product = getProductByBarcode(barcode);
+ 
+     if (!product) {
+diff --git a/src/screens/SplashScreen.tsx b/src/screens/SplashScreen.tsx
+index 8a14177..97b4988 100644
+--- a/src/screens/SplashScreen.tsx
++++ b/src/screens/SplashScreen.tsx
+@@ -4,6 +4,7 @@ import { useNavigation } from "@react-navigation/native";
+ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+ import { theme } from "../theme";
+ import { eventLogger } from "../services/eventLogger";
++import { logPosEvent, startCloudEventLogger } from "../services/cloudEventLogger";
+ import { printerService } from "../services/printerService";
+ import { useProductsStore } from "../stores/productsStore";
+ import { ensureSession } from "../services/sessionService";
+@@ -24,7 +25,12 @@ export default function SplashScreen() {
+ 
+   useEffect(() => {
+     const initializeApp = async () => {
++      // Start cloud logger early so offline/online transitions are captured.
++      startCloudEventLogger();
++
++      // Local + cloud events (fire-and-forget; never block UI).
+       eventLogger.log("APP_START", { screen: "Splash" });
++      void logPosEvent("APP_START", { screen: "Splash" });
+ 
+       // Initialize services in parallel
+       const initPromises = [
+diff --git a/src/screens/SuccessPrintScreenV2.tsx b/src/screens/SuccessPrintScreenV2.tsx
+index 26c3cd4..fe14828 100644
+--- a/src/screens/SuccessPrintScreenV2.tsx
++++ b/src/screens/SuccessPrintScreenV2.tsx
+@@ -6,6 +6,7 @@ import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+ import { theme } from "../theme";
+ import { useCartStore } from "../stores/cartStore";
+ import { eventLogger } from "../services/eventLogger";
++import { logPaymentEvent, logPosEvent } from "../services/cloudEventLogger";
+ import { printerService } from "../services/printerService";
+ import { formatMoney } from "../utils/money";
+ 
+@@ -13,7 +14,7 @@ type RootStackParamList = {
+   Splash: undefined;
+   SellScan: undefined;
+   Payment: undefined;
+-  SuccessPrint: { paymentMode: "UPI" | "CASH" | "DUE" };
++  SuccessPrint: { paymentMode: "UPI" | "CASH" | "DUE"; transactionId: string; billId: string };
+ };
+ 
+ type Nav = NativeStackNavigationProp<RootStackParamList, "SuccessPrint">;
+@@ -26,9 +27,12 @@ export default function SuccessPrintScreenV2() {
+ 
+   const currency = items[0]?.currency ?? "INR";
+   const paymentMode = route.params?.paymentMode ?? "CASH";
+-  const billNumber = useRef(Date.now().toString().slice(-6)).current;
++  const billNumber = route.params?.billId ?? useRef(Date.now().toString().slice(-6)).current;
+   const toastOpacity = useRef(new Animated.Value(0)).current;
+ 
++  // For reconciliation: tie receipt/print outcomes to a bill id.
++  const transactionId = route.params?.transactionId ?? useRef(`${Date.now()}-${Math.random().toString(16).slice(2)}`).current;
++
+   const [printStatus, setPrintStatus] = useState<"printing" | "success" | "failed">("printing");
+   const [showToast, setShowToast] = useState(false);
+ 
+@@ -67,11 +71,24 @@ export default function SuccessPrintScreenV2() {
+         itemCount: items.length
+       });
+ 
++      // Cloud events: record payment success at the point the POS considers the sale done.
++      // If upstream payment confirmation is added later, those events will also carry the same transactionId.
++      void logPaymentEvent("PAYMENT_SUCCESS", {
++        transactionId,
++        billId: billNumber,
++        paymentMode,
++        amountMinor: total,
++        currency
++      });
++
+       try {
+         await printerService.printReceipt(generateReceiptContent());
+         setPrintStatus("success");
+       } catch {
+         setPrintStatus("failed");
++
++        // Cloud event (required)
++        void logPosEvent("PRINTER_ERROR", { billId: billNumber, transactionId, reason: "print_failed" });
+       }
+ 
+       setShowToast(true);
+diff --git a/src/services/printerService.ts b/src/services/printerService.ts
+index cee4965..892f5a2 100644
+--- a/src/services/printerService.ts
++++ b/src/services/printerService.ts
+@@ -1,4 +1,5 @@
+ import { eventLogger } from './eventLogger';
++import { logPosEvent } from "./cloudEventLogger";
+ 
+ export interface PrintJob {
+   id: string;
+@@ -60,6 +61,9 @@ class PrinterService {
+       await eventLogger.log('PRINT_FAILED', {
+         reason: 'Printer not connected',
+       });
++
++      // Cloud event (required)
++      void logPosEvent("PRINTER_ERROR", { reason: "not_connected" });
+       throw new Error('Printer not connected');
+     }
+ 
+@@ -67,6 +71,9 @@ class PrinterService {
+       await eventLogger.log('PRINT_FAILED', {
+         reason: 'Paper not available',
+       });
++
++      // Cloud event (required)
++      void logPosEvent("PRINTER_ERROR", { reason: "paper_not_available" });
+       throw new Error('Paper not available');
+     }
+ 
+diff --git a/src/stores/cartStore.ts b/src/stores/cartStore.ts
+index 7144b06..3d960ac 100644
+--- a/src/stores/cartStore.ts
++++ b/src/stores/cartStore.ts
+@@ -1,5 +1,6 @@
+ import { create } from 'zustand';
+ import { eventLogger } from '../services/eventLogger';
++import { logPosEvent } from "../services/cloudEventLogger";
+ 
+ export interface CartItem {
+   id: string;
+@@ -85,6 +86,16 @@ export const useCartStore = create<CartState>((set, get) => ({
+       quantity: item.quantity || 1,
+       priceMinor: item.priceMinor,
+     });
++
++    // Cloud event (required): ADD_TO_CART
++    void logPosEvent("ADD_TO_CART", {
++      productId: item.id,
++      name: item.name,
++      quantity: item.quantity || 1,
++      priceMinor: item.priceMinor,
++      currency: item.currency ?? undefined,
++      barcode: item.barcode ?? undefined
++    });
+   },
+   
+   removeItem: (itemId) => {
+@@ -99,6 +110,16 @@ export const useCartStore = create<CartState>((set, get) => ({
+         itemId: item.id,
+         itemName: item.name,
+       });
++
++      // Cloud event (required): REMOVE_FROM_CART
++      void logPosEvent("REMOVE_FROM_CART", {
++        productId: item.id,
++        name: item.name,
++        quantity: item.quantity,
++        priceMinor: item.priceMinor,
++        currency: item.currency ?? undefined,
++        barcode: item.barcode ?? undefined
++      });
+     }
+   },
+   


### PR DESCRIPTION
## Summary
- Exported 2 stash entries as `.patch` files before dropping them
- Stash 0: scan/digitisation WIP (5 files, 948 lines)
- Stash 1: prisma removal + payment refactor (25 files, 3035 lines)
- Cut-point tag: `pre-new-plan-2026-02-10_IST` on `5dbaa19`

## Context
Cleaning git state before starting new plan. All old branches (34 local, 34 remote) already deleted. These patch files preserve the stash contents for reference.

## Test plan
- [ ] No code changes — patch files only
- [ ] CI should pass (no source files modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)