### PR TITLE
fix(staging): proxy Host header + landing CTA + supplier forgot-password

### DIFF
--- a/backend/services/api-gateway/src/routes/proxy.ts
+++ b/backend/services/api-gateway/src/routes/proxy.ts
@@ -40,6 +40,15 @@ function createProxyOptions(service: ServiceConfig): Options {
     proxyTimeout: 30000,
     timeout: 30000,
     onProxyReq: (proxyReq: ClientRequest, req: Request) => {
+      // STAGING-FIX-001: Explicitly set Host header for Cloud Run-to-Cloud Run proxying.
+      // Cloud Run's front-end (Google Front End) validates that the Host header matches
+      // the target service URL. If mismatched, it returns a Google 400 HTML error page.
+      // changeOrigin: true alone is insufficient — we must set it in onProxyReq.
+      try {
+        const targetHost = new URL(service.url).host;
+        proxyReq.setHeader('host', targetHost);
+      } catch { /* keep existing host if URL parse fails */ }
+
       // Forward correlation ID to backend service
       if (req.correlationId) {
         proxyReq.setHeader(CORRELATION_ID_HEADER, req.correlationId);

--- a/supermandi-landing/index.html
+++ b/supermandi-landing/index.html
@@ -232,33 +232,6 @@
             color: var(--foreground);
         }
 
-        /* DR-007: Hero CTA */
-        .hero-cta {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            margin-top: 40px;
-            padding: 14px 28px;
-            font-size: 16px;
-            font-weight: 600;
-            color: var(--background);
-            background: var(--foreground);
-            border-radius: 8px;
-            text-decoration: none;
-            transition: all 0.15s ease;
-            animation: fadeInUp 0.6s ease-out 0.3s both;
-        }
-
-        .hero-cta:hover {
-            background: #333;
-            transform: translateY(-1px);
-        }
-
-        .hero-cta svg {
-            width: 18px;
-            height: 18px;
-        }
-
         /* Footer */
         footer {
             border-top: 1px solid var(--border);
@@ -452,14 +425,7 @@
                     <strong>Not a feature. Not optional.</strong> The backbone that powers commerce at scale.
                 </p>
 
-                <!-- DR-007: Prominent Register CTA for retailer discoverability -->
-                <a href="/retailer/register" class="hero-cta">
-                    Register Your Store
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <line x1="5" y1="12" x2="19" y2="12"/>
-                        <polyline points="12 5 19 12 12 19"/>
-                    </svg>
-                </a>
+                <!-- STAGING-FIX: Register CTA removed — registration not yet public -->
             </section>
         </main>
 

--- a/supplier-portal/src/app/(auth)/login/page.tsx
+++ b/supplier-portal/src/app/(auth)/login/page.tsx
@@ -468,7 +468,7 @@ export default function LoginPage() {
 
       {/* GO-LIVE-AUTH-FIX: Single register link at bottom - shown on phone/otp steps only */}
       {(step === 'phone' || step === 'otp') && (
-        <div className="mt-6 text-center">
+        <div className="mt-6 text-center space-y-2">
           <p className="text-slate-600">
             Don't have an account?{' '}
             <Link
@@ -476,6 +476,14 @@ export default function LoginPage() {
               className="text-primary-600 hover:text-primary-700 font-medium"
             >
               Register
+            </Link>
+          </p>
+          <p>
+            <Link
+              href="/forgot-password"
+              className="text-sm text-slate-500 hover:text-slate-700"
+            >
+              Forgot Password?
             </Link>
           </p>
         </div>


### PR DESCRIPTION
## Summary
- **P0-1/P0-2**: Fix Cloud Run proxy 400 errors — explicit Host header in `onProxyReq` (STAGING-FIX-001)
- **P1-A**: Remove "Register Your Store" CTA from landing page (not yet public)
- **P1-B**: Add "Forgot Password?" link to supplier login page
- **P0-3**: Gmail SMTP already configured on main-backend via `gcloud` env vars (no code change)

## Root Cause (P0-1/P0-2)
Cloud Run's Google Front End validates the HTTP Host header matches the target service URL. `http-proxy-middleware`'s `changeOrigin: true` alone is insufficient for Cloud Run-to-Cloud Run proxying — an explicit `proxyReq.setHeader('host', targetHost)` in the `onProxyReq` handler is required.

## Files Changed
- `backend/services/api-gateway/src/routes/proxy.ts` — Host header fix
- `supermandi-landing/index.html` — CTA removal
- `supplier-portal/src/app/(auth)/login/page.tsx` — Forgot password link

## Gates
- typecheck: PASS
- unit tests: 8/8 PASS
- builds: api-gateway + supplier-portal + landing PASS

## E2E DEFERRED — requires staging deploy to verify proxy fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)