### PR TITLE
fix(AUDIT-API-001/002): Replace SQL template literals with parameterized queries

### DIFF
--- a/backend/src/middleware/tokenSecurity.ts
+++ b/backend/src/middleware/tokenSecurity.ts
@@ -337,7 +337,8 @@ export async function cleanupOldAuditLogs(daysToKeep: number = 90): Promise<numb
 
   try {
     const result = await pool.query(
-      `DELETE FROM pos_token_audit_log WHERE created_at < NOW() - INTERVAL '${daysToKeep} days'`
+      `DELETE FROM pos_token_audit_log WHERE created_at < NOW() - ($1 * INTERVAL '1 day')`,
+      [daysToKeep]
     );
     return result.rowCount || 0;
   } catch (err) {

--- a/backend/src/routes/v1/pos/enroll.ts
+++ b/backend/src/routes/v1/pos/enroll.ts
@@ -388,7 +388,7 @@ posEnrollRouter.post("/enroll", enrollmentBurstLimiter, enrollmentLimiter, async
                 updated_at = NOW(),
                 re_enrolled = true,
                 re_enrolled_at = NOW(),
-                token_expires_at = NOW() + INTERVAL '${TOKEN_EXPIRY_DAYS} days',
+                token_expires_at = NOW() + ($11 * INTERVAL '1 day'),
                 token_refreshed_at = NOW()
             WHERE id = $10
             `,
@@ -402,7 +402,8 @@ posEnrollRouter.post("/enroll", enrollmentBurstLimiter, enrollmentLimiter, async
               appVersion,
               printingMode,
               deviceFingerprint,
-              deviceId
+              deviceId,
+              TOKEN_EXPIRY_DAYS
             ]
           );
 
@@ -449,7 +450,7 @@ posEnrollRouter.post("/enroll", enrollmentBurstLimiter, enrollmentLimiter, async
               token_expires_at,
               token_refreshed_at
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW(), NOW() + INTERVAL '${TOKEN_EXPIRY_DAYS} days', NOW())
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, NOW(), NOW(), NOW() + ($12 * INTERVAL '1 day'), NOW())
             `,
             [
               deviceId,
@@ -462,7 +463,8 @@ posEnrollRouter.post("/enroll", enrollmentBurstLimiter, enrollmentLimiter, async
               androidVersion,
               appVersion,
               printingMode,
-              deviceFingerprint
+              deviceFingerprint,
+              TOKEN_EXPIRY_DAYS
             ]
           );
 


### PR DESCRIPTION
## AUDIT-API-001/002: Fix SQL template literal interpolation

**Phase**: 1 (Security) | **Priority**: P0 | **Risk Class**: E (DB/schema)

### Changes
- `backend/src/routes/v1/pos/enroll.ts`: Replaced `${TOKEN_EXPIRY_DAYS}` in INTERVAL SQL with `$N * INTERVAL '1 day'` parameterized approach (2 locations: UPDATE line 391, INSERT line 452)
- `backend/src/middleware/tokenSecurity.ts`: Replaced `${daysToKeep}` function parameter in DELETE query with parameterized `$1 * INTERVAL '1 day'` — this was a real injection vector since daysToKeep is a function argument

### Evidence
- Gate results: typecheck ✅ build ✅
- `TOKEN_EXPIRY_DAYS` was a constant (low risk but bad practice)
- `daysToKeep` was a function parameter accepting `number` — callers could pass crafted values

### Risk
- What could break: INTERVAL arithmetic change — PostgreSQL `$1 * INTERVAL '1 day'` is equivalent to `INTERVAL 'N days'` for integer N
- Rollback: revert this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)