### PR TITLE
fix(AUDIT-API-003): Remove JWT secret preview from debug log

### DIFF
--- a/backend/services/api-gateway/src/middleware/jwtAuth.ts
+++ b/backend/services/api-gateway/src/middleware/jwtAuth.ts
@@ -165,7 +165,7 @@ export function jwtAuthMiddleware(req: Request, res: Response, next: NextFunctio
   }
 
   try {
-    console.log(`[JWT-DEBUG] Verifying token (len=${token.length}), secret preview: ${JWT_SECRET.substring(0, 10)}..., issuer: ${JWT_ISSUER}`);
+    console.log(`[JWT-DEBUG] Verifying token (len=${token.length}), issuer: ${JWT_ISSUER}`);
 
     // Verify and decode the token
     const decoded = jwt.verify(token, JWT_SECRET, {


### PR DESCRIPTION
## AUDIT-API-003: Remove JWT secret from logs

**Phase**: 1 (Security) | **Priority**: P0 | **Risk Class**: C (Auth)

### Changes
- `backend/services/api-gateway/src/middleware/jwtAuth.ts:168`: Removed `JWT_SECRET.substring(0, 10)` from console.log debug output

### Evidence
- Gate results: typecheck ✅ build ✅
- The log still outputs token length and issuer (useful for debugging) but no secret material

### Risk
- What could break: Nothing — only removed secret from log string, no logic change
- Rollback: revert this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)