### PR TITLE
fix(AUDIT-API-004): Remove hardcoded payout API key fallback

### DIFF
--- a/backend/src/routes/v1/webhooks.ts
+++ b/backend/src/routes/v1/webhooks.ts
@@ -331,7 +331,10 @@ webhooksRouter.post("/payouts/process", async (req: Request, res: Response) => {
 
   // Simple API key protection (should use proper auth in production)
   const apiKey = req.headers["x-api-key"] as string | undefined;
-  const expectedKey = process.env.PAYOUT_PROCESS_API_KEY || "sm_payout_dev_key";
+  const expectedKey = process.env.PAYOUT_PROCESS_API_KEY;
+  if (!expectedKey) {
+    return res.status(503).json({ error: "Payout API key not configured" });
+  }
 
   if (apiKey !== expectedKey) {
     return res.status(401).json({ error: "Unauthorized" });
@@ -371,7 +374,10 @@ webhooksRouter.get("/payouts/pending", async (req: Request, res: Response) => {
 
   // Simple API key protection
   const apiKey = req.headers["x-api-key"] as string | undefined;
-  const expectedKey = process.env.PAYOUT_PROCESS_API_KEY || "sm_payout_dev_key";
+  const expectedKey = process.env.PAYOUT_PROCESS_API_KEY;
+  if (!expectedKey) {
+    return res.status(503).json({ error: "Payout API key not configured" });
+  }
 
   if (apiKey !== expectedKey) {
     return res.status(401).json({ error: "Unauthorized" });


### PR DESCRIPTION
## AUDIT-API-004: Remove hardcoded payout key fallback

**Phase**: 1 (Security) | **Priority**: P0 | **Risk Class**: B (API/logic)

### Changes
- `backend/src/routes/v1/webhooks.ts`: Removed `|| "sm_payout_dev_key"` fallback on both payout endpoints (line 334, 374). Now returns 503 if PAYOUT_PROCESS_API_KEY env var is not set.

### Evidence
- Gate results: typecheck ✅
- Both `/payouts/process` and `/payouts/pending` endpoints now fail-fast without env var

### Risk
- What could break: Payout processing will 503 if env var not set (intentional — better than accepting hardcoded key)
- Rollback: revert this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)