### PR TITLE
fix(AUDIT-API-005): Add auth guard to demo seed endpoint

### DIFF
--- a/backend/src/routes/v1/demo.ts
+++ b/backend/src/routes/v1/demo.ts
@@ -145,7 +145,7 @@ const DEMO_PRODUCTS = [
  *
  * Body: { storeId: string }
  */
-demoRouter.post("/seed", async (req: Request, res: Response) => {
+demoRouter.post("/seed", devOnlyMiddleware(), async (req: Request, res: Response) => {
   const pool = getPool();
   if (!pool) {
     return res.status(503).json({ error: { code: "DB_UNAVAILABLE", message: "Database unavailable" } });


### PR DESCRIPTION
## AUDIT-API-005: Add auth to demo seed endpoint

**Phase**: 1 (Security) | **Priority**: P0 | **Risk Class**: B (API/logic)

### Changes
- `backend/src/routes/v1/demo.ts:148`: Added `devOnlyMiddleware()` to `/seed` POST handler

### Evidence
- Gate results: typecheck ✅
- `/token` already had devOnlyMiddleware, `/seed` was missing it

### Risk
- What could break: Demo seed will now be blocked in production (intentional)
- Rollback: revert this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)