### PR TITLE
fix(AUDIT-API-006): Enforce store isolation on voice endpoints

### DIFF
--- a/backend/src/routes/v1/pos/voice.ts
+++ b/backend/src/routes/v1/pos/voice.ts
@@ -142,9 +142,9 @@ voiceRouter.post(
         });
       }
 
-      // Get store context from device token
+      // Get store context from device token (AUDIT-API-006: never trust client-sent storeId)
       const device = (req as any).device;
-      const storeId = req.body.storeId || device?.storeId || device?.store_id;
+      const storeId = device?.storeId || device?.store_id;
 
       if (!storeId) {
         return res.status(400).json({
@@ -273,8 +273,9 @@ voiceRouter.post(
         });
       }
 
+      // AUDIT-API-006: derive storeId from device token only (never trust client-sent)
       const device = (req as any).device;
-      const storeId = req.body.storeId || device?.storeId || device?.store_id;
+      const storeId = device?.storeId || device?.store_id;
 
       if (!storeId) {
         return res.status(400).json({


### PR DESCRIPTION
## AUDIT-API-006: Fix voice endpoint store isolation

**Phase**: 1 (Security) | **Priority**: P0 | **Risk Class**: B (API/logic)

### Changes
- `backend/src/routes/v1/pos/voice.ts`: Removed `req.body.storeId` from storeId derivation in both `/interpret` (line 147) and `/parse` (line 277). StoreId now comes exclusively from device token.

### Evidence
- Gate results: typecheck ✅
- Store isolation rule: "Server derives storeId ONLY from JWT/device token, client-sent storeId is NEVER trusted"

### Risk
- What could break: Any client that was relying on sending storeId in request body to override device context (this was incorrect behavior)
- Rollback: revert this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)