### PR TITLE
fix(AUDIT-API-017/018): Add store_id to BNPL/payment UPDATE queries

### DIFF
--- a/backend/src/routes/v1/pos/bnpl.ts
+++ b/backend/src/routes/v1/pos/bnpl.ts
@@ -275,15 +275,15 @@ posBnplRouter.post("/bnpl/:drawdownId/pay", requireDeviceToken, async (req: Requ
       await client.query(`
         UPDATE payments.bnpl_drawdowns
         SET status = 'paid', paid_at = NOW(), paid_amount_minor = $1
-        WHERE id = $2
-      `, [payAmount, drawdownId]);
+        WHERE id = $2 AND store_id = $3
+      `, [payAmount, drawdownId, storeId]);
 
       // Update the original buy_payment
       await client.query(`
         UPDATE payments.buy_payments
         SET status = 'completed', completed_at = NOW()
-        WHERE bnpl_drawdown_id = $1
-      `, [drawdownId]);
+        WHERE bnpl_drawdown_id = $1 AND store_id = $2
+      `, [drawdownId, storeId]);
 
       // Create a cash payment record
       const repaymentId = randomUUID();
@@ -395,15 +395,15 @@ posBnplRouter.post("/bnpl/:drawdownId/pay/confirm", requireDeviceToken, async (r
     await client.query(`
       UPDATE payments.bnpl_drawdowns
       SET status = 'paid', paid_at = NOW(), paid_amount_minor = $1
-      WHERE id = $2
-    `, [repayment.amount_minor, drawdownId]);
+      WHERE id = $2 AND store_id = $3
+    `, [repayment.amount_minor, drawdownId, storeId]);
 
     // Update the original BNPL buy_payment
     await client.query(`
       UPDATE payments.buy_payments
       SET status = 'completed', completed_at = NOW()
-      WHERE bnpl_drawdown_id = $1 AND mode = 'BNPL'
-    `, [drawdownId]);
+      WHERE bnpl_drawdown_id = $1 AND store_id = $2 AND mode = 'BNPL'
+    `, [drawdownId, storeId]);
 
     await client.query("COMMIT");
 

--- a/backend/src/routes/v1/pos/payments.ts
+++ b/backend/src/routes/v1/pos/payments.ts
@@ -646,11 +646,11 @@ posPaymentsRouter.post(
         return res.status(400).json({ error: "Payment already completed" });
       }
 
-      // Check if UPI portion is completed
+      // Check if UPI portion is completed (AUDIT-API-018: include store_id)
       const upiCheck = await client.query(
         `SELECT id, status FROM payments.sell_payments
-         WHERE sale_id = $1 AND mode = 'UPI' AND is_split = true`,
-        [payment.sale_id]
+         WHERE sale_id = $1 AND store_id = $2 AND mode = 'UPI' AND is_split = true`,
+        [payment.sale_id, storeId]
       );
 
       if (upiCheck.rowCount && upiCheck.rows[0]) {


### PR DESCRIPTION
## AUDIT-API-017/018: Store isolation on BNPL/payment mutations

**Phase**: 1 (Security) | **Priority**: P1 | **Risk Class**: E (DB)

### Changes
- `backend/src/routes/v1/pos/bnpl.ts`: Added `AND store_id = $N` to 4 UPDATE queries on bnpl_drawdowns and buy_payments
- `backend/src/routes/v1/pos/payments.ts`: Added `AND store_id = $N` to UPI split payment status check

### Evidence
- Gate results: typecheck ✅
- Defense-in-depth: prior SELECTs already check store_id, but mutations should independently enforce

### Risk
- What could break: None — adds stricter filtering on UPDATE queries, functionally equivalent
- Rollback: revert this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)