### PR TITLE
fix(AUDIT-API-019): Reject gateway headers without JWT

### DIFF
--- a/backend/src/middleware/validateGatewayHeaders.ts
+++ b/backend/src/middleware/validateGatewayHeaders.ts
@@ -62,20 +62,10 @@ export function validateGatewayHeaders(req: Request, res: Response, next: NextFu
   const authHeader = req.headers.authorization;
 
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    // Check if we have gateway headers without JWT
-    // This means request came from gateway after JWT validation
-    const gatewayUserId = req.headers['x-user-id'];
-    const gatewayActorId = req.headers['x-actor-id'];
-
-    // If we have gateway headers, trust them (requests coming from gateway)
-    // The gateway already validated the JWT
-    if (gatewayUserId && gatewayActorId) {
-      console.log(`[ValidateGateway] Trusted gateway headers - userId: ${gatewayUserId}, actorId: ${gatewayActorId}`);
-      return next();
-    }
-
-    // No authorization at all
-    console.log('[ValidateGateway] No authorization provided');
+    // AUDIT-API-019: Never trust x-user-id/x-actor-id headers without JWT.
+    // If backend is accessed directly (bypassing gateway), these headers
+    // can be spoofed. Always require Bearer token for defense-in-depth.
+    console.log('[ValidateGateway] No authorization provided (gateway headers alone are not trusted)');
     res.status(401).json({
       error: {
         code: 'UNAUTHORIZED',


### PR DESCRIPTION
## AUDIT-API-019: Validate gateway trust model

**Phase**: 1 (Security) | **Priority**: P1 | **Risk Class**: C (Auth)

### Changes
- `backend/src/middleware/validateGatewayHeaders.ts`: Removed path that trusted x-user-id/x-actor-id headers without JWT verification

### Evidence
- Gate results: typecheck ✅
- Gateway already passes JWT through to backend; the header-only path was only reachable by direct backend access

### Risk
- What could break: Any request reaching backend without JWT will now be rejected (was already expected behavior via gateway)
- Rollback: revert this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)