### PR TITLE
fix(AUDIT-SA-032): gate error sanitizer console.warn behind DEV

### DIFF
--- a/supermandi-superadmin/src/api/errorSanitizer.ts
+++ b/supermandi-superadmin/src/api/errorSanitizer.ts
@@ -61,8 +61,10 @@ export function sanitizeErrorMessage(rawError: string | undefined | null, fallba
   // Check if error contains sensitive information
   for (const pattern of SENSITIVE_PATTERNS) {
     if (pattern.test(errorStr)) {
-      // Log for debugging but return generic message
-      console.warn("[GL-CRIT-0055] Sensitive error filtered:", errorStr.substring(0, 100));
+      // AUDIT-SA-032: Only log in dev — browser console.warn leaks filtered content
+      if (import.meta.env.DEV) {
+        console.warn("[GL-CRIT-0055] Sensitive error filtered:", errorStr.substring(0, 100));
+      }
       return fallback;
     }
   }
@@ -81,7 +83,10 @@ export function sanitizeErrorMessage(rawError: string | undefined | null, fallba
 
   // If error is very long (>200 chars), it likely contains sensitive info
   if (errorStr.length > 200) {
-    console.warn("[GL-CRIT-0055] Long error filtered:", errorStr.substring(0, 100));
+    // AUDIT-SA-032: Only log in dev — browser console.warn leaks filtered content
+    if (import.meta.env.DEV) {
+      console.warn("[GL-CRIT-0055] Long error filtered:", errorStr.substring(0, 100));
+    }
     return fallback;
   }
 


### PR DESCRIPTION
## AUDIT-SA-032: Gate error sanitizer console.warn behind import.meta.env.DEV

**Phase**: 1 (Security) | **Priority**: P1 | **Risk Class**: A (UI-only)

### Changes
- `supermandi-superadmin/src/api/errorSanitizer.ts`: Wrapped both console.warn calls (L65, L84) in `import.meta.env.DEV` check

### Problem
The error sanitizer correctly filters sensitive errors (SQL, stack traces) from the UI, but then logs the filtered content via `console.warn`. In production builds, this leaks sensitive content to browser dev tools — undermining the sanitizer.

### Evidence
- Gate results: typecheck ✅ build ✅
- Vite tree-shakes `import.meta.env.DEV` branches in production builds

### Risk
- Minimal — only changes logging behavior, not error handling logic
- Rollback: revert this commit

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>