### PR TITLE
fix(AUDIT-API-015): redact PII from audit log responses

### DIFF
--- a/backend/src/routes/v1/admin/audit.ts
+++ b/backend/src/routes/v1/admin/audit.ts
@@ -9,6 +9,30 @@ export const adminAuditRouter = Router();
 
 adminAuditRouter.use(requireAdminToken);
 
+// AUDIT-API-015: PII fields to redact from request_body before returning
+const PII_FIELDS = new Set([
+  "pan_number", "pan", "aadhaar", "aadhaar_number",
+  "password", "new_password", "old_password", "confirm_password",
+  "otp", "otp_code", "verification_code",
+  "bank_account", "account_number", "ifsc",
+  "device_token", "token", "id_token", "refresh_token",
+]);
+
+function redactPII(body: Record<string, unknown> | null): Record<string, unknown> | null {
+  if (!body || typeof body !== "object") return body;
+  const redacted: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(body)) {
+    if (PII_FIELDS.has(key.toLowerCase())) {
+      redacted[key] = "[REDACTED]";
+    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+      redacted[key] = redactPII(value as Record<string, unknown>);
+    } else {
+      redacted[key] = value;
+    }
+  }
+  return redacted;
+}
+
 export interface AuditLogRecord {
   id: string;
   actor_user_id: string | null;
@@ -107,8 +131,14 @@ adminAuditRouter.get("/audit", async (req, res) => {
       values.slice(0, -2) // Remove limit and offset
     );
 
+    // AUDIT-API-015: Redact PII from request_body before returning
+    const redactedLogs = result.rows.map((row) => ({
+      ...row,
+      request_body: redactPII(row.request_body),
+    }));
+
     return res.json({
-      logs: result.rows,
+      logs: redactedLogs,
       total: parseInt(countResult.rows[0]?.total || "0", 10),
       limit: limitNum,
       offset: offsetNum,


### PR DESCRIPTION
## AUDIT-API-015: Redact PII from audit log request_body

**Phase**: 1 (Security) | **Priority**: P1 | **Risk Class**: B (API/logic)

### Changes
- `backend/src/routes/v1/admin/audit.ts`: Added `redactPII()` function that recursively replaces sensitive fields (PAN, Aadhaar, passwords, OTP codes, bank details, tokens) with `[REDACTED]` before returning audit log entries

### Problem
`GET /api/v1/admin/audit` returned `request_body` JSONB column raw from the database. Audit logs capture full request bodies, which may contain PII (PAN numbers, Aadhaar, passwords, OTP codes, bank account numbers). Even SuperAdmin users should not see raw PII in audit trails.

### Evidence
- Gate results: typecheck ✅ build ✅
- Redaction is applied at the API response layer (DB still stores full data for forensic needs)

### Risk
- Low — only filters output, doesn't change audit data storage
- SuperAdmin UI will show `[REDACTED]` instead of raw PII values
- Rollback: revert this commit

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>