### PR TITLE
fix(AUDIT-API-010/016/020): BNPL partial pay, DUE phone, serialization retry

### DIFF
--- a/backend/src/routes/v1/pos/bnpl.ts
+++ b/backend/src/routes/v1/pos/bnpl.ts
@@ -271,19 +271,26 @@ posBnplRouter.post("/bnpl/:drawdownId/pay", requireDeviceToken, async (req: Requ
 
     // For CASH mode, mark as paid immediately (cashier confirms)
     if (mode === 'CASH') {
-      // Mark drawdown as paid
+      // AUDIT-API-010: Distinguish partial vs full payment
+      const isFullPayment = payAmount >= drawdown.principal_minor;
+
+      // Update drawdown — only mark 'paid' if fully covered
       await client.query(`
         UPDATE payments.bnpl_drawdowns
-        SET status = 'paid', paid_at = NOW(), paid_amount_minor = $1
+        SET status = CASE WHEN $1 >= principal_minor THEN 'paid' ELSE status END,
+            paid_at = CASE WHEN $1 >= principal_minor THEN NOW() ELSE paid_at END,
+            paid_amount_minor = COALESCE(paid_amount_minor, 0) + $1
         WHERE id = $2 AND store_id = $3
       `, [payAmount, drawdownId, storeId]);
 
-      // Update the original buy_payment
-      await client.query(`
-        UPDATE payments.buy_payments
-        SET status = 'completed', completed_at = NOW()
-        WHERE bnpl_drawdown_id = $1 AND store_id = $2
-      `, [drawdownId, storeId]);
+      // Only mark original buy_payment completed if fully paid
+      if (isFullPayment) {
+        await client.query(`
+          UPDATE payments.buy_payments
+          SET status = 'completed', completed_at = NOW()
+          WHERE bnpl_drawdown_id = $1 AND store_id = $2
+        `, [drawdownId, storeId]);
+      }
 
       // Create a cash payment record
       const repaymentId = randomUUID();

--- a/backend/src/routes/v1/pos/payments.ts
+++ b/backend/src/routes/v1/pos/payments.ts
@@ -459,6 +459,16 @@ posPaymentsRouter.post(
         });
       }
 
+      // AUDIT-API-016: Validate customer_phone for DUE payments — unrecoverable without it
+      const hasDue = payments.some(p => p.mode === 'DUE');
+      if (hasDue && !sale.customer_phone) {
+        await client.query("ROLLBACK");
+        return res.status(400).json({
+          error: "Customer phone is required for DUE payments",
+          code: "CUSTOMER_PHONE_REQUIRED"
+        });
+      }
+
       // 4. Create payment records
       const paymentIds: string[] = [];
       let upiPayment: { paymentId: string; orderId: string; qrData: string; expiresAt: string } | null = null;

--- a/backend/src/routes/v1/pos/sales.ts
+++ b/backend/src/routes/v1/pos/sales.ts
@@ -1152,6 +1152,15 @@ posSalesRouter.post("/sales", requireDeviceToken, requireActiveStore, salesRateL
     if (error instanceof Error && error.message === "sale_id_conflict") {
       return res.status(409).json({ error: "sale_id_conflict" });
     }
+    // AUDIT-API-020: Handle SERIALIZABLE transaction conflicts with retryable error
+    if ((error as any)?.code === "40001") {
+      console.warn("[POS/sales] Serialization conflict — client should retry:", (error as Error).message);
+      return res.status(409).json({
+        error: "serialization_conflict",
+        message: "Transaction conflict — please retry",
+        retryable: true
+      });
+    }
     console.error("[POS/sales] Unhandled sale creation error:", error instanceof Error ? error.message : error, error instanceof Error ? error.stack : "");
     return res.status(500).json({ error: "failed to create sale" });
   } finally {


### PR DESCRIPTION
## AUDIT-API-010/016/020: Phase 2 Backend Fixes

**Phase**: 2 (Broken Functionality) | **Priority**: P1 | **Risk Class**: B (API/logic)

### Changes
- `backend/src/routes/v1/pos/bnpl.ts`: Partial vs full BNPL payment detection
- `backend/src/routes/v1/pos/payments.ts`: DUE payment requires customer_phone
- `backend/src/routes/v1/pos/sales.ts`: Serialization conflict returns retryable 409

### Evidence
- Gate results: typecheck ✅ build ✅

### Risk
- BNPL: Partial payments now accumulate instead of falsely marking paid
- DUE: New validation may reject DUE payments that previously succeeded with null phone
- Sales: 409 instead of 500 for serialization conflicts — client retry needed
- Rollback: revert this commit

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>