### PR TITLE
fix(AUDIT-SUP-001/002/015/037): auth guard, dead link, basePath redirect

### DIFF
--- a/supplier-portal/src/app/(auth)/login/page.tsx
+++ b/supplier-portal/src/app/(auth)/login/page.tsx
@@ -505,14 +505,7 @@ export default function LoginPage() {
               Register
             </Link>
           </p>
-          <p>
-            <Link
-              href="/forgot-password"
-              className="text-sm text-slate-500 hover:text-slate-700"
-            >
-              Forgot Password?
-            </Link>
-          </p>
+          {/* AUDIT-SUP-002: Removed dead forgot-password link — portal uses OTP-based login */}
         </div>
       )}
     </>

--- a/supplier-portal/src/app/(auth)/onboard/page.tsx
+++ b/supplier-portal/src/app/(auth)/onboard/page.tsx
@@ -13,6 +13,7 @@ import {
   verifySupplierOtp,
   submitSupplierKyc,
   uploadSupplierDocument,
+  getAuthToken,
   ApiError,
 } from '@/lib/api';
 import { setupRecaptcha, sendOtp, verifyOtp, isFirebaseReady, cleanup } from '@/lib/firebase';
@@ -38,6 +39,13 @@ function validatePincode(pincode: string): string | null {
 
 export default function SupplierOnboardingPage() {
   const router = useRouter();
+
+  // AUDIT-SUP-001: Redirect authenticated users to dashboard
+  useEffect(() => {
+    if (getAuthToken()) {
+      router.replace('/dashboard');
+    }
+  }, [router]);
 
   // Form state
   const [step, setStep] = useState<Step>('business');

--- a/supplier-portal/src/lib/api.ts
+++ b/supplier-portal/src/lib/api.ts
@@ -151,7 +151,8 @@ function handle401Response(): void {
     // Use replace to prevent back button returning to protected page
     // Use setTimeout to ensure token is cleared before redirect
     setTimeout(() => {
-      window.location.replace('/login');
+      // AUDIT-SUP-015/037: Include basePath — portal is served at /supplier/
+      window.location.replace('/supplier/login');
     }, 0);
   }
 }


### PR DESCRIPTION
## AUDIT-SUP-001/002/005/015/037: Supplier Portal Phase 2 Fixes

**Phase**: 2 | **Priority**: P0/P1 | **Risk Class**: A/D

### Changes
- `supplier-portal/src/app/(auth)/onboard/page.tsx`: Auth redirect for authenticated users
- `supplier-portal/src/app/(auth)/login/page.tsx`: Removed dead forgot-password link
- `supplier-portal/src/lib/api.ts`: Fixed 401 redirect to use /supplier/login basePath

### Evidence
- Gate results: build ✅
- AUDIT-SUP-005: Verified false positive — Next.js router.replace auto-prepends basePath

### Risk
- Low — only changes redirect behavior and removes dead link
- Rollback: revert this commit

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>