### PR TITLE
fix(AUDIT-API-009/011): phone format validation, stock-in idempotency key

### DIFF
--- a/backend/src/routes/v1/pos/stockIn.ts
+++ b/backend/src/routes/v1/pos/stockIn.ts
@@ -124,7 +124,23 @@ posStockInRouter.post("/stock-in", requireDeviceToken, requirePosStaff, requireR
 
   // AUD-074-A FIX: Accept supplierId for proper FK tracking
   // SA-P0-004: Accept supplierGstin for GSTIN tracking on stock-in
-  const { items, supplierId, supplierName, supplierGstin, notes, totalAmount } = req.body;
+  const { items, supplierId, supplierName, supplierGstin, notes, totalAmount, idempotencyKey } = req.body;
+
+  // AUDIT-API-011: Idempotency check — prevent duplicate stock-in on double-submit
+  if (idempotencyKey && typeof idempotencyKey === "string") {
+    const dupCheck = await pool.query(
+      `SELECT id FROM inventory.inventory_ledger
+       WHERE store_id = $1 AND reference_id = $2 AND transaction_type = 'purchase_received'
+       LIMIT 1`,
+      [storeId, idempotencyKey]
+    );
+    if (dupCheck.rows.length > 0) {
+      return res.json({
+        success: true,
+        data: { ledgerEntryId: idempotencyKey, itemsProcessed: 0, duplicate: true },
+      });
+    }
+  }
 
   // SA-P0-004: Validate GSTIN format if provided
   if (supplierGstin && typeof supplierGstin === "string" && supplierGstin.trim()) {
@@ -138,7 +154,8 @@ posStockInRouter.post("/stock-in", requireDeviceToken, requirePosStaff, requireR
     return res.status(400).json({ success: false, error: "items array is required" });
   }
 
-  const ledgerEntryId = randomUUID();
+  // AUDIT-API-011: Use client-provided idempotency key as ledger reference for dedup
+  const ledgerEntryId = (idempotencyKey && typeof idempotencyKey === "string") ? idempotencyKey : randomUUID();
   const client = await pool.connect();
 
   try {

--- a/backend/src/routes/v1/supplier/registration.ts
+++ b/backend/src/routes/v1/supplier/registration.ts
@@ -422,6 +422,15 @@ router.post("/create", registrationRateLimiter, async (req: Request, res: Respon
     const gstinNormalized = gstin.trim().toUpperCase();
     const phoneNormalized = normalizePhoneNumber(phone);
 
+    // AUDIT-API-009: Validate phone format (must resolve to valid Indian mobile: +91 + 10 digits starting with 6-9)
+    const phoneDigits = phoneNormalized.replace(/\D/g, "");
+    if (!/^91[6-9]\d{9}$/.test(phoneDigits)) {
+      res.status(400).json({
+        error: { code: "INVALID_PHONE", message: "Please enter a valid 10-digit Indian mobile number" }
+      });
+      return;
+    }
+
     // Validate GSTIN format
     if (!validateGSTIN(gstinNormalized)) {
       res.status(400).json({


### PR DESCRIPTION
## Phase 3 — Data Integrity (Backend)

### Tickets Fixed
| Ticket | Issue | Fix |
|--------|-------|-----|
| API-009 | Supplier registration accepts any phone string | Validate Indian mobile format: +91 + 10 digits starting 6-9 |
| API-011 | Stock-in double-submit creates duplicate stock | Accept idempotencyKey, check existing ledger entry before insert |

### Files Changed
- `backend/src/routes/v1/supplier/registration.ts` — Phone format validation after normalization
- `backend/src/routes/v1/pos/stockIn.ts` — Idempotency key dedup check + use as ledger reference

### Evidence
- Risk Class: B (API/logic)
- `npx tsc --noEmit` PASS