### PR TITLE
fix(AUDIT-RET-046/051): unified UPI VPA regex, registration credentials

### DIFF
--- a/retailer-admin/src/lib/api.ts
+++ b/retailer-admin/src/lib/api.ts
@@ -231,9 +231,11 @@ export interface ApplicationResponse {
 export async function createRetailerApplication(
   data: CreateRetailerApplicationInput
 ): Promise<ApplicationResponse> {
+  // AUDIT-RET-051: Include credentials for cookie-based auth
   const response = await fetch(`${REGISTRATION_BASE}/create`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
     body: JSON.stringify(data),
   });
   const json = await response.json();
@@ -247,9 +249,11 @@ export async function verifyRetailerOtp(data: {
   idToken: string;
   applicationId: string;
 }): Promise<{ success: boolean; nextStep: string; message: string }> {
+  // AUDIT-RET-051: Include credentials for cookie-based auth
   const response = await fetch(`${REGISTRATION_BASE}/verify-otp`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
     body: JSON.stringify(data),
   });
   const json = await response.json();
@@ -271,9 +275,11 @@ export async function uploadDocument(
   formData.append('entity_type', entityType);
   formData.append('entity_id', entityId);
 
+  // AUDIT-RET-051: Include credentials for cookie-based auth
   const response = await fetch(`${DOCUMENTS_BASE}/upload`, {
     method: 'POST',
     headers: { 'X-Requested-With': 'XMLHttpRequest' },
+    credentials: 'include',
     body: formData,
   });
   const json = await response.json();
@@ -286,9 +292,11 @@ export async function uploadDocument(
 export async function submitRetailerKyc(
   applicationId: string
 ): Promise<{ success: boolean; application: { id: string; status: string }; message: string }> {
+  // AUDIT-RET-051: Include credentials for cookie-based auth
   const response = await fetch(`${REGISTRATION_BASE}/submit-kyc`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
     body: JSON.stringify({ applicationId }),
   });
   const json = await response.json();
@@ -301,7 +309,10 @@ export async function submitRetailerKyc(
 export async function getApplicationStatus(
   applicationId: string
 ): Promise<{ application: Record<string, unknown>; documents: Array<Record<string, unknown>> }> {
-  const response = await fetch(`${REGISTRATION_BASE}/status/${applicationId}`);
+  // AUDIT-RET-051: Include credentials for cookie-based auth
+  const response = await fetch(`${REGISTRATION_BASE}/status/${applicationId}`, {
+    credentials: 'include',
+  });
   const json = await response.json();
   if (!response.ok) {
     throw { status: response.status, ...json.error };
@@ -321,7 +332,7 @@ export interface LookupResponse {
 export async function lookupRetailerRegistration(phone: string): Promise<LookupResponse> {
   const response = await fetch(
     `${REGISTRATION_BASE}/lookup?phone=${encodeURIComponent(phone)}`,
-    { method: 'GET', headers: { 'Content-Type': 'application/json' } }
+    { method: 'GET', headers: { 'Content-Type': 'application/json' }, credentials: 'include' }
   );
   const json = await response.json();
   if (!response.ok) {

--- a/retailer-admin/src/pages/SettingsPage.tsx
+++ b/retailer-admin/src/pages/SettingsPage.tsx
@@ -81,12 +81,15 @@ export default function SettingsPage() {
     loadSettings();
   }, [accessToken, store?.name]);
 
-  // Validate UPI VPA format
+  // AUDIT-RET-046: Unified UPI VPA validation (matches UpiInput component)
   const validateUpiVpa = (vpa: string): string | undefined => {
     if (!vpa) return undefined; // Optional
-    const upiRegex = /^[\w.-]+@[\w]+$/;
-    if (!upiRegex.test(vpa)) {
-      return 'Invalid UPI VPA format (e.g., store@upi)';
+    const trimmed = vpa.trim();
+    if (trimmed.length < 6) return 'UPI VPA must be at least 6 characters';
+    if (trimmed.length > 100) return 'UPI VPA cannot exceed 100 characters';
+    const upiRegex = /^[a-zA-Z0-9._-]{3,}@[a-zA-Z0-9]{2,}$/;
+    if (!upiRegex.test(trimmed)) {
+      return 'Invalid UPI VPA format. Use: name@bank (e.g., store@ybl)';
     }
     return undefined;
   };


### PR DESCRIPTION
## Phase 3 — Data Integrity (Retailer)

### Tickets Fixed
| Ticket | Issue | Fix |
|--------|-------|-----|
| RET-051 | Registration API calls missing credentials: include | Added to all 6 registration fetch calls |
| RET-046 | UPI VPA regex differs between SettingsPage and UpiInput | Unified to stricter regex with length checks |

### False Positives Identified
| Ticket | Reason |
|--------|--------|
| RET-054 | Token refresh already has isRefreshingRef.current mutex |
| RET-062 | Logout already calls clearStoreAuth + clearLegacyAuth + removes ACTIVE_STORE_KEY |

### Files Changed
- `retailer-admin/src/lib/api.ts` — credentials: include on 6 registration endpoints
- `retailer-admin/src/pages/SettingsPage.tsx` — Unified UPI VPA regex