### PR TITLE
fix(AUDIT-SA-016/033): clear errors on tab switch, load storeDirectory for staff tab

### DIFF
--- a/supermandi-superadmin/src/App.tsx
+++ b/supermandi-superadmin/src/App.tsx
@@ -575,8 +575,20 @@ function EnrollmentCountdown({ expiresAt }: { expiresAt: string }) {
 export default function App() {
   const [tab, setTabRaw] = useState<TabKey>("events");
   // ISSUE-MICRO-063: Abort in-flight requests when switching tabs
+  // AUDIT-SA-016: Clear error states on tab switch to prevent stale errors
   const setTab = (newTab: TabKey) => {
-    if (newTab !== tab) abortActiveRequests();
+    if (newTab !== tab) {
+      abortActiveRequests();
+      setEventsError(""); setHealthError(""); setAiError(""); setStoreError("");
+      setStoreDirectoryError(""); setStoreNameError(""); setCreateStoreError("");
+      setBarcodeSheetError(""); setDevicesError(""); setDeviceActionError("");
+      setEnrollError(""); setAnalyticsError(""); setSuppliersError("");
+      setSupplierActionError(""); setStoreSuspendError(""); setProductActionError("");
+      setEditProductError(""); setUsersError(""); setUserActionError("");
+      setCreateUserError(""); setSettingsError(""); setAuditLogsError("");
+      setRegEventsError(""); setDocumentsError(""); setStaffError("");
+      setGrnAlertsError(""); setFeatureFlagsError(""); setApplicationsError("");
+    }
     setTabRaw(newTab);
   };
 
@@ -1855,7 +1867,8 @@ export default function App() {
 
     const shouldRefreshEvents = tab === "events" || tab === "devices" || tab === "payments"; // P0-DEPLOY-002: Include payments
     const shouldRefreshDevices = tab === "devices";
-    const shouldRefreshStores = tab === "stores";
+    // AUDIT-SA-033: Also load storeDirectory on staff tab (depends on store data)
+    const shouldRefreshStores = tab === "stores" || tab === "staff";
     const shouldRefreshSuppliers = tab === "suppliers";
     const shouldRefreshUsers = tab === "users";
     const shouldRefreshSettings = tab === "settings";


### PR DESCRIPTION
## Phase 4 — UX & Polish (SuperAdmin)

### Tickets Fixed
| Ticket | Issue | Fix |
|--------|-------|-----|
| SA-016 | Error states persist across tab switches | Clear all 28 error states in setTab() |
| SA-033 | Staff tab depends on storeDirectory loaded by Stores tab | Also load storeDirectory on staff tab |

### Deferred to Phase 5 (Major Refactors)
| Ticket | Reason |
|--------|--------|
| SA-009/010 | Skeleton loaders across 14 tabs — P2 effort, 2-4h per tab |
| SA-019 | Extract 100+ useState into per-tab components — 3-5 day refactor |
| SA-024 | Server-side store search — requires backend API changes |
| SA-040 | Server-side events pagination — requires backend cursor API |

### Files Changed (1)
- `supermandi-superadmin/src/App.tsx`