### PR TITLE
fix(AUDIT-POS-035): block inward on stock check failure

### DIFF
--- a/src/screens/InwardScreen.tsx
+++ b/src/screens/InwardScreen.tsx
@@ -388,9 +388,16 @@ export default function InwardScreen({
         await doSubmit();
       }
     } catch (error) {
-      // If stock check fails, still allow submission
-      console.warn("[InwardScreen] GO-LIVE-235: Stock check failed, proceeding:", error);
-      await doSubmit();
+      // AUDIT-POS-035: Block submission on stock check failure instead of silently proceeding
+      console.warn("[InwardScreen] Stock check failed:", error);
+      Alert.alert(
+        "Stock Check Failed",
+        "Could not verify current stock levels. Please check your connection and try again.",
+        [
+          { text: "Cancel", style: "cancel", onPress: () => setSubmitting(false) },
+          { text: "Submit Anyway", onPress: () => doSubmit() },
+        ]
+      );
     }
   };
 


### PR DESCRIPTION
## Phase 4 — UX & Polish (POS)

### Tickets Fixed
| Ticket | Issue | Fix |
|--------|-------|-----|
| POS-035 | Stock check failure silently continues inward | Alert with Cancel/Submit Anyway instead of silent proceed |

### False Positives
| Ticket | Reason |
|--------|--------|
| POS-005 | EnrollDevice already has invariant check + blocking on failure |
| POS-007 | UPI polling already has 40 attempts max + exponential backoff + manual UTR fallback |
| POS-008 | Barcode scan already has 2000ms duplicate window + storm detection (8 scans/2s) |

### Files Changed (1)
- `src/screens/InwardScreen.tsx`