### PR TITLE
fix(AUDIT-API-017): BNPL UPI confirm store isolation

### DIFF
--- a/backend/src/routes/v1/pos/bnpl.ts
+++ b/backend/src/routes/v1/pos/bnpl.ts
@@ -392,11 +392,12 @@ posBnplRouter.post("/bnpl/:drawdownId/pay/confirm", requireDeviceToken, async (r
     }
 
     // Update repayment record (GO-LIVE-127: Use normalized UTR)
+    // AUDIT-API-017: Add store_id filter for store isolation
     await client.query(`
       UPDATE payments.buy_payments
       SET status = 'completed', upi_payer_ref = $1, completed_at = NOW()
-      WHERE id = $2
-    `, [normalizedUtr, repaymentId]);
+      WHERE id = $2 AND store_id = $3
+    `, [normalizedUtr, repaymentId, storeId]);
 
     // Mark drawdown as paid
     await client.query(`


### PR DESCRIPTION
## Summary
- **Ticket**: AUDIT-API-017 | Phase 1 Security | Risk Class E (DB/schema)
- **Issue**: `UPDATE payments.buy_payments` in UPI repayment confirm handler was missing `AND store_id` in WHERE clause, allowing potential cross-store payment confirmation
- **Fix**: Added `AND store_id = $3` to the UPDATE query, passing `storeId` (derived from device token) as 3rd parameter

## Changes
| File | Change |
|------|--------|
| `backend/src/routes/v1/pos/bnpl.ts:395-399` | Added `AND store_id = $3` to buy_payments UPDATE WHERE clause |

## Context
The handler already correctly uses `store_id` in:
- SELECT at L371-375 (`AND store_id = $2`) 
- Drawdown UPDATE at L402-406 (`AND store_id = $3`)
- Original BNPL UPDATE at L409-413 (`AND store_id = $2`)

Only the repayment UPDATE at L395-399 was missing it.

## Evidence
- Backend typecheck: PASS (0 errors)
- Backend build: PASS
- Change is 1 line in 1 file — adds WHERE clause filter only

## Risk Assessment
- **Low risk**: Strictly additive WHERE clause filter
- **If wrong**: UPI repayment confirmations would fail with "0 rows updated" — safe failure mode

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>