### PR TITLE
fix(AUDIT-SUP-021/022,API-035): consolidate formatters + UPI rate limit

### DIFF
--- a/backend/src/routes/v1/pos/payments.ts
+++ b/backend/src/routes/v1/pos/payments.ts
@@ -10,6 +10,8 @@ import { getPool } from "../../../db/client";
 import { requireDeviceToken, type PosDeviceContext } from "../../../middleware/deviceToken";
 // SEC-001: Import store status gate for ACTIVE store enforcement
 import { requireActiveStore } from "../../../middleware/storeStatusGate";
+// AUDIT-API-035: Rate limit UPI generate to prevent QR abuse
+import { financialOperationsRateLimiter } from "../../../middleware/posRateLimiter";
 
 export const posPaymentsRouter = Router();
 
@@ -84,6 +86,7 @@ posPaymentsRouter.post(
   "/payments/upi/generate",
   requireDeviceToken,
   requireActiveStore,
+  financialOperationsRateLimiter,
   async (req: Request, res: Response, _next: NextFunction) => {
     const { storeId, deviceId } = (req as unknown as PosRequest).posDevice;
     const { saleId, amountMinor } = req.body as UpiInitRequest;

--- a/supplier-portal/src/app/(dashboard)/orders/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/orders/page.tsx
@@ -4,23 +4,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
 import { getOrders, updateOrderStatus, updateOrderShipment, updateOrderItemStatus, getOrderNotes, addOrderNote, markOrdersRead, getOrderDetail, getOrderEvents, getOrderStreamUrl, Order, OrderItem, OrderNote, OrderDetail, OrderDetailItem, OrderEvent, PaginatedResponse } from '@/lib/api';
-
-function formatPrice(paise: number): string {
-  return `₹${(paise / 100).toLocaleString('en-IN', {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })}`;
-}
-
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString('en-IN', {
-    day: 'numeric',
-    month: 'short',
-    year: 'numeric',
-    hour: '2-digit',
-    minute: '2-digit',
-  });
-}
+import { formatCurrency, formatDateTime } from '@/lib/formatters';
 
 const statusColors: Record<string, string> = {
   pending: 'bg-yellow-100 text-yellow-700',
@@ -326,7 +310,7 @@ export default function OrdersPage() {
                     {order.items.length} items
                   </td>
                   <td className="py-3 px-4 font-medium">
-                    {formatPrice(order.totalAmount)}
+                    {formatCurrency(order.totalAmount)}
                   </td>
                   <td className="py-3 px-4">
                     <span
@@ -338,7 +322,7 @@ export default function OrdersPage() {
                     </span>
                   </td>
                   <td className="py-3 px-4 text-sm text-slate-500">
-                    {formatDate(order.createdAt)}
+                    {formatDateTime(order.createdAt)}
                   </td>
                   <td className="py-3 px-4">
                     <button
@@ -441,7 +425,7 @@ export default function OrdersPage() {
               </div>
               <div>
                 <p className="text-slate-500">Date</p>
-                <p className="font-medium">{formatDate(selectedOrder.createdAt)}</p>
+                <p className="font-medium">{formatDateTime(selectedOrder.createdAt)}</p>
               </div>
               <div>
                 <p className="text-slate-500">Status</p>
@@ -456,7 +440,7 @@ export default function OrdersPage() {
               {orderDetail?.expectedDeliveryDate && (
                 <div>
                   <p className="text-slate-500">Expected Delivery</p>
-                  <p className="font-medium">{formatDate(orderDetail.expectedDeliveryDate)}</p>
+                  <p className="font-medium">{formatDateTime(orderDetail.expectedDeliveryDate)}</p>
                 </div>
               )}
               {orderDetail?.storeNotes && (
@@ -539,10 +523,10 @@ export default function OrdersPage() {
                         )}
                       </td>
                       <td className="py-2 px-4 text-right">
-                        {formatPrice(item.unitPrice)}
+                        {formatCurrency(item.unitPrice)}
                       </td>
                       <td className="py-2 px-4 text-right font-medium">
-                        {formatPrice(item.total)}
+                        {formatCurrency(item.total)}
                       </td>
                       <td className="py-2 px-4 text-center">
                         {/* GL-WF-038: Item status with dropdown for shipped/delivered orders */}
@@ -582,7 +566,7 @@ export default function OrdersPage() {
                       Total Amount
                     </td>
                     <td className="py-3 px-4 text-right font-bold text-lg">
-                      {formatPrice(selectedOrder.totalAmount)}
+                      {formatCurrency(selectedOrder.totalAmount)}
                     </td>
                     <td></td>
                   </tr>
@@ -602,7 +586,7 @@ export default function OrdersPage() {
                         <p className="text-slate-700 font-medium">
                           {event.eventType.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
                         </p>
-                        <p className="text-slate-400 text-xs">{formatDate(event.createdAt)} &middot; {event.actorType}</p>
+                        <p className="text-slate-400 text-xs">{formatDateTime(event.createdAt)} &middot; {event.actorType}</p>
                       </div>
                     </div>
                   ))}

--- a/supplier-portal/src/app/(dashboard)/products/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/products/page.tsx
@@ -13,12 +13,7 @@ import {
   ProductInput,
   PaginatedResponse,
 } from '@/lib/api';
-
-// AUDIT-SUP-020: Fix 0 treated as falsy — use null check instead
-function formatPrice(paise: number | undefined): string {
-  if (paise == null) return '-';
-  return `₹${(paise / 100).toFixed(2)}`;
-}
+import { formatCurrency } from '@/lib/formatters';
 
 const statusColors: Record<string, string> = {
   pending: 'bg-yellow-100 text-yellow-700',
@@ -593,11 +588,11 @@ export default function ProductsPage() {
                   </td>
                   <td className="py-3 px-4">
                     <div className="font-medium">
-                      {formatPrice(product.purchasePrice)}
+                      {product.purchasePrice != null ? formatCurrency(product.purchasePrice) : '-'}
                     </div>
-                    {product.mrp && (
+                    {product.mrp != null && (
                       <div className="text-sm text-slate-500">
-                        MRP: {formatPrice(product.mrp)}
+                        MRP: {formatCurrency(product.mrp)}
                       </div>
                     )}
                   </td>


### PR DESCRIPTION
## Summary

- **SUP-021/022**: Replace local `formatPrice`/`formatDate` in supplier portal `orders/page.tsx` and `products/page.tsx` with centralized `formatCurrency`/`formatDateTime` from `@/lib/formatters`
- **API-035**: Add `financialOperationsRateLimiter` (30 req/min per store) to `POST /payments/upi/generate` to prevent QR abuse

## Changes

| File | Change |
|------|--------|
| `supplier-portal/src/app/(dashboard)/orders/page.tsx` | Remove local `formatPrice`/`formatDate`, import from `@/lib/formatters` |
| `supplier-portal/src/app/(dashboard)/products/page.tsx` | Remove local `formatPrice`, import `formatCurrency` from `@/lib/formatters` |
| `backend/src/routes/v1/pos/payments.ts` | Add `financialOperationsRateLimiter` middleware to UPI generate endpoint |

## Evidence

- All package typechecks pass (backend, retailer-admin, supplier-portal, supermandi-superadmin)
- All portal builds pass (supplier-portal, retailer-admin, supermandi-superadmin, backend)
- Risk Class: A (supplier UI) + B (backend API middleware)

## Risk Assessment

- **Low risk**: Formatter consolidation is a refactor — same output format, now with proper IST timezone from centralized formatters
- **Low risk**: Rate limiter is additive middleware using existing `financialOperationsRateLimiter` (30/min/store)

🤖 Generated with [Claude Code](https://claude.com/claude-code)