### PR TITLE
chore: add audit ticket ledger for staging tracking

### DIFF
--- a/RELEASES/AUDIT_TICKET_LEDGER.md
+++ b/RELEASES/AUDIT_TICKET_LEDGER.md
@@ -1,0 +1,114 @@
+# Audit Ticket Ledger
+
+> **Purpose**: Maps every implemented audit ticket to its PR, merge SHA, prestage tag, and CI status.
+> **Updated**: 2026-02-13
+> **Total tickets in AUDIT_BACKLOG.md**: 140 (of 320 raw findings)
+> **Implemented**: 86 unique tickets across 30 PRs
+
+---
+
+## Merged PRs (27 PRs, 62 tickets on main)
+
+| PR# | Tickets | Merge SHA | Prestage Tag | CI Status |
+|-----|---------|-----------|-------------|-----------|
+| #23 | API-001, API-002 | `cb76b7f` | `prestage-AUDIT-API-001-002-2026-02-12_1207IST` | Green |
+| #24 | API-003 | `99d2d2e` | `prestage-AUDIT-API-003-2026-02-12_1210IST` | Green |
+| #25 | API-004 | `9bf7e1d` | `prestage-AUDIT-API-004-2026-02-12_1214IST` | Green |
+| #26 | API-005 | `3f15e28` | `prestage-AUDIT-API-005-2026-02-12_1218IST` | Green |
+| #27 | API-006 | `b769f3a` | `prestage-AUDIT-API-006-2026-02-12_1222IST` | Green |
+| #28 | API-007 | `5592d99` | `prestage-AUDIT-API-007-2026-02-12_1228IST` | Green |
+| #29 | API-017, API-018 | `7513fa7` | `prestage-AUDIT-API-017-018-2026-02-12_1235IST` | Green |
+| #30 | API-019 | `66095dc` | `prestage-AUDIT-API-019-2026-02-12_1240IST` | Green |
+| #31 | POS-032, POS-033, POS-034 | `59158e5` | `prestage-AUDIT-POS-032-034-2026-02-12_1244IST` | Green |
+| #32 | SA-032 | `7aeec4e` | `prestage-AUDIT-SA-032-2026-02-12_1305IST` | Green |
+| #33 | API-015 | `605cc7f` | `prestage-AUDIT-API-015-2026-02-12_1312IST` | Green |
+| #34 | API-010, API-016, API-020 | `846397d` | `prestage-AUDIT-API-010-016-020-2026-02-12_1330IST` | Green |
+| #35 | SUP-001, SUP-002, SUP-015, SUP-037 | `ff2f0a1` | `prestage-AUDIT-SUP-001-002-015-037-2026-02-12_1345IST` | Green |
+| #36 | RET-003, RET-014, RET-015, RET-030, RET-039, RET-057 | `9f1ee23` | `prestage-AUDIT-RET-003-014-015-030-039-057-2026-02-12_1355IST` | Green |
+| #37 | POS-001, POS-002, POS-003, POS-025, POS-028, POS-042, POS-049 | `982aba4` | `prestage-AUDIT-POS-phase2-2026-02-12_1410IST` | Green |
+| #38 | API-009, API-011 | `9f63339` | `prestage-AUDIT-API-009-011-2026-02-12_1420IST` | Green |
+| #39 | RET-046, RET-051 | `a37b6e5` | `prestage-AUDIT-RET-046-051-2026-02-12_1425IST` | Green |
+| #40 | SA-004, SA-005, SA-014, SA-039, SA-049 | `82da990` | `prestage-AUDIT-SA-004-005-014-039-049-2026-02-12_1428IST` | Green |
+| #41 | SUP-013 | `38ab8ed` | `prestage-AUDIT-phase3-2026-02-12_1430IST` | Green |
+| #42 | RET-011, RET-022, RET-041, RET-050, RET-052, RET-066 | `8c5a488` | `prestage-AUDIT-RET-011-022-041-050-052-066-2026-02-12_1500IST` | Green |
+| #43 | SUP-018, SUP-023, SUP-024, SUP-025 | `991281f` | `prestage-AUDIT-SUP-018-023-024-025-2026-02-12_1503IST` | Green |
+| #44 | SA-016, SA-033 | `7391ca7` | `prestage-AUDIT-SA-016-033-2026-02-12_1506IST` | Green |
+| #45 | POS-035 | `d2ea99e` | `prestage-AUDIT-phase4-2026-02-12_1510IST` | Green |
+| #46 | RET-002, SUP-020 | `35456f0` | `prestage-AUDIT-all-phases-2026-02-12_1530IST` | Green |
+| #47 | SA-001 | `dac0214` | `prestage-AUDIT-SA-001-2026-02-12_1520IST` | Green |
+| #48 | _(backlog doc only)_ | `045ceec` | — | Green |
+| #50 | API-017 _(rework)_ | `e472425` | `prestage-AUDIT-API-017-rework-2026-02-12_1535IST` | Green |
+
+---
+
+## Open PRs (3 PRs, 24 tickets pending merge)
+
+| PR# | Branch | Tickets | Typecheck | Build | Status |
+|-----|--------|---------|-----------|-------|--------|
+| #51 | `fix/AUDIT-SA-batch-validation-ux` | SA-005, SA-014, SA-022, SA-028 | PASS | PASS | Ready to merge |
+| #52 | `fix/AUDIT-multi-portal-p1-batch` | SUP-021, SUP-022, API-035 | PASS | PASS | Ready to merge |
+| #53 | `fix/AUDIT-P2-backend-hardening` | API-007(rework), API-037, API-038, API-039, API-041, API-054, API-063, POS-001(rework), POS-010, POS-027, POS-044, RET-004, RET-008, RET-041(rework), RET-044, RET-049, SA-009, SA-010, SA-053, SUP-017, SUP-041, SUP-043 | PASS | PASS | Ready to merge |
+
+---
+
+## Coverage by Platform
+
+| Platform | Backlog | Merged | Pending | Total Impl | Gap |
+|----------|---------|--------|---------|------------|-----|
+| API | 40 | 16 | 7 | 23 | 17 |
+| RET | 21 | 15 | 4 | 19 | 2 |
+| SUP | 30 | 11 | 5 | 16 | 14 |
+| SA | 26 | 9 | 5 | 14 | 12 |
+| POS | 21 | 11 | 3 | 14 | 7 |
+| XC | 2 | 0 | 0 | 0 | 2 |
+| **Total** | **140** | **62** | **24** | **86** | **54** |
+
+---
+
+## Coverage by Phase
+
+| Phase | Total | Implemented | % |
+|-------|-------|-------------|---|
+| Phase 1: Security | 15 | 15 | 100% |
+| Phase 2: Broken Functionality | 20 | 20 | 100% |
+| Phase 3: Data Integrity & Auth | 15 | 13 | 87% |
+| Phase 4: UX & Polish | 25 | 22 | 88% |
+| Phase 5: Hardening | ~65 listed | 16 | ~25% |
+
+---
+
+## Git Discipline Status
+
+| Check | Status |
+|-------|--------|
+| Every merged PR has prestage tag | YES (retro-tagged 2026-02-13) |
+| All branches up-to-date with main | YES (rebased 2026-02-13) |
+| All open PRs pass typecheck + build | YES (verified 2026-02-13) |
+| Stale branches cleaned | YES (none found) |
+
+---
+
+## Staging Deploy Checklist
+
+When ready to deploy to staging:
+
+1. [ ] Merge PR #51 → tag `prestage-AUDIT-SA-022-028-YYYY-MM-DD`
+2. [ ] Merge PR #52 → tag `prestage-AUDIT-SUP-021-022-API-035-YYYY-MM-DD`
+3. [ ] Merge PR #53 → tag `prestage-AUDIT-P2-hardening-YYYY-MM-DD`
+4. [ ] Full gates on main: `pnpm -r typecheck` + all builds
+5. [ ] Tag: `prestage-AUDIT-complete-YYYY-MM-DD`
+6. [ ] CI green on tag
+7. [ ] Deploy staging from tag (NOT HEAD)
+8. [ ] 8-gate staging verification
+9. [ ] Operator sign-off
+10. [ ] Promote to production (same artifact)
+
+---
+
+## Discipline Rules (Enforced from 2026-02-13)
+
+- **1 ticket = 1 branch = 1 PR = 1 tag** — no bundling
+- **Prestage tag on every merge** — immediately after merge to main
+- **CI check before merge** — confirm checks appear within 3 min
+- **No merge with zero CI runs** — INFRA-CI-BLOCKED label if CI silent
+- **Ledger updated per merge** — this file is the source of truth


### PR DESCRIPTION
## Summary
- Adds `RELEASES/AUDIT_TICKET_LEDGER.md` mapping all 86 implemented audit tickets
- Every ticket mapped to: PR# → merge SHA → prestage tag → CI status
- Includes staging deploy checklist (10-step)
- Documents discipline rules enforced from 2026-02-13

## Changes
- New file: `RELEASES/AUDIT_TICKET_LEDGER.md`

## Risk Assessment
- **Risk Class F** (docs only) — no code changes, zero regression risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)