### PR TITLE
fix(RCAT-FIX-002): Enforce user status check on existing JWT tokens

### DIFF
--- a/backend/src/middleware/storeOwnership.ts
+++ b/backend/src/middleware/storeOwnership.ts
@@ -460,3 +460,67 @@ export function requireActiveStore(
 
   next();
 }
+
+/**
+ * RCAT-FIX-002: Require that the authenticated user has active status in DB.
+ * Blocks deactivated/suspended users even if their JWT is still valid.
+ * Reads x-user-id header (set by gateway from JWT claims).
+ * Must be applied AFTER gateway JWT verification.
+ */
+export async function requireActiveUser(
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> {
+  // SuperAdmin bypasses user status check
+  if (isSuperAdmin(req)) {
+    return next();
+  }
+
+  const userId = req.headers['x-user-id'];
+  if (!userId || typeof userId !== 'string') {
+    // No user ID — let other middleware handle auth
+    return next();
+  }
+
+  const pool = getPool();
+  if (!pool) {
+    res.status(503).json({
+      error: { code: 'SERVICE_UNAVAILABLE', message: 'Database unavailable' },
+    });
+    return;
+  }
+
+  try {
+    const result = await pool.query(
+      `SELECT status FROM auth.users WHERE id = $1`,
+      [userId]
+    );
+
+    if (result.rows.length === 0) {
+      res.status(401).json({
+        error: { code: 'USER_NOT_FOUND', message: 'User account not found' },
+      });
+      return;
+    }
+
+    const userStatus = result.rows[0].status;
+    if (userStatus !== 'active') {
+      console.warn(`[RCAT-FIX-002] Blocked ${userStatus} user ${userId} on ${req.method} ${req.path}`);
+      res.status(403).json({
+        error: {
+          code: 'USER_INACTIVE',
+          message: `Account is ${userStatus}. Please contact support.`,
+        },
+      });
+      return;
+    }
+
+    next();
+  } catch (error: any) {
+    console.error('[requireActiveUser] DB error:', error.message);
+    // Fail open on DB error to avoid blocking all traffic
+    // Production monitoring will catch persistent failures
+    next();
+  }
+}

--- a/backend/src/routes/v1/index.ts
+++ b/backend/src/routes/v1/index.ts
@@ -43,7 +43,7 @@ import { adminGstCreditsRouter } from "./admin/gstCredits";  // GO-LIVE-097: GST
 import { adminAuthRouter } from "./admin/adminAuth";  // GO-LIVE-LOGIN-004: Admin email OTP auth
 import { adminAuditMiddleware } from "../../middleware/adminAudit";  // GL-CRIT-0049: Audit logging
 import { validateGatewayHeaders } from "../../middleware/validateGatewayHeaders";  // GO-LIVE-046: Validate gateway headers
-import { requireStoreOwnership, verifyStoreExists, requireActiveStore } from "../../middleware/storeOwnership";  // GO-LIVE-047: Store ownership verification
+import { requireStoreOwnership, verifyStoreExists, requireActiveStore, requireActiveUser } from "../../middleware/storeOwnership";  // GO-LIVE-047: Store ownership verification
 import { retailerAdminInventoryRouter } from "./retailer-admin/inventory";
 import { retailerAdminSuppliersRouter } from "./retailer-admin/suppliers";
 import { retailerAdminProductsRouter } from "./retailer-admin/products";
@@ -157,10 +157,12 @@ v1Router.use("/registration", retailerRegistrationRouter);
 // GO-LIVE-046: Apply gateway header validation to retailer-admin routes
 // GO-LIVE-047: Apply store ownership verification to retailer-admin routes
 // RCAT-FIX-001: Add verifyStoreExists + requireActiveStore to block suspended stores
+// RCAT-FIX-002: Add requireActiveUser to block deactivated/suspended users
 v1Router.use("/retailer-admin", validateGatewayHeaders);
 v1Router.use("/retailer-admin", requireStoreOwnership);
 v1Router.use("/retailer-admin", verifyStoreExists);
 v1Router.use("/retailer-admin", requireActiveStore);
+v1Router.use("/retailer-admin", requireActiveUser);
 v1Router.use("/retailer-admin", retailerAdminInventoryRouter);
 v1Router.use("/retailer-admin", retailerAdminSuppliersRouter);
 v1Router.use("/retailer-admin", retailerAdminProductsRouter);


### PR DESCRIPTION
## Summary
- **Ticket:** RCAT-FIX-002 (#57) | **Phase:** Security | **Risk Class:** C (Auth)
- Deactivated/suspended users with valid JWTs could still access retailer-admin API
- Added `requireActiveUser` middleware that queries `auth.users.status` per request
- Implemented in backend middleware (not gateway) since gateway is a pure proxy with no DB

## Changes
| File | Change |
|------|--------|
| `backend/src/middleware/storeOwnership.ts` | New `requireActiveUser` middleware — queries DB for user status |
| `backend/src/routes/v1/index.ts` | Wire `requireActiveUser` into retailer-admin route chain |

## Middleware Chain (After Fix)
`validateGatewayHeaders → requireStoreOwnership → requireActiveUser → handlers`

## Design Decisions
- **Backend not gateway**: Gateway has no DB access by design (pure proxy). Adding pg dependency there would break architecture.
- **Fail-open on DB error**: Avoids blocking all traffic if DB is briefly unavailable. Monitoring catches persistent failures.
- **No cache (yet)**: Direct DB query per request. Can add Redis/in-memory TTL cache later for performance at scale.

## Evidence
- Backend typecheck: PASS

## Risk Assessment
- **Medium risk** — adds per-request DB query. Acceptable for current load, monitor latency.
- SuperAdmin operations unaffected (bypass check)

Fixes #57 | Parent: #55