### PR TITLE
fix(RCAT-FIX-004): Add feature flag gating to retailer-admin

### DIFF
--- a/backend/src/routes/v1/retailer-admin/inventory.ts
+++ b/backend/src/routes/v1/retailer-admin/inventory.ts
@@ -758,3 +758,69 @@ retailerAdminInventoryRouter.delete("/categories/:categoryId", async (req: Reque
     });
   }
 });
+
+// =============================================================================
+// FEATURE FLAGS - RCAT-FIX-004
+// =============================================================================
+
+/**
+ * GET /api/v1/retailer-admin/feature-flags
+ * RCAT-FIX-004: Feature flags for retailer-admin portal
+ * Resolves global flags + store-level overrides (same logic as POS ui-status)
+ *
+ * Returns: { features: { buyEnabled, reorderEnabled, bnplEnabled, ... } }
+ */
+retailerAdminInventoryRouter.get("/feature-flags", async (req: Request, res: Response) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: "database unavailable" });
+
+  const storeId = getStoreId(req);
+  if (!storeId) {
+    return res.status(401).json({ error: "Store not identified" });
+  }
+
+  // Defaults (all enabled)
+  const features: Record<string, boolean> = {
+    buyEnabled: true,
+    reorderEnabled: true,
+    bnplEnabled: true,
+    creditEnabled: false,
+    voiceEnabled: false,
+    categoryBrowsingEnabled: true,
+  };
+
+  try {
+    // SA-P0-005: Resolve global flags + store overrides
+    const ffRes = await pool.query(
+      `SELECT g.flag_key,
+              COALESCE(s.enabled, g.enabled) AS effective
+       FROM platform.feature_flags g
+       LEFT JOIN platform.feature_flags s
+         ON s.flag_key = g.flag_key AND s.scope_type = 'store' AND s.scope_id = $1::uuid
+       WHERE g.scope_type = 'global'`,
+      [storeId]
+    );
+
+    for (const row of ffRes.rows) {
+      if (row.flag_key in features) {
+        features[row.flag_key] = Boolean(row.effective);
+      }
+    }
+
+    // Also check reorder_settings for reorderEnabled override
+    const reorderRes = await pool.query(
+      `SELECT reorder_enabled FROM reorder_settings WHERE store_id = $1`,
+      [storeId]
+    );
+    if (reorderRes.rows[0] !== undefined) {
+      features.reorderEnabled = Boolean(reorderRes.rows[0].reorder_enabled);
+    }
+  } catch {
+    // feature_flags or reorder_settings may not exist — defaults apply
+  }
+
+  return res.json({
+    success: true,
+    data: { features },
+  });
+});

--- a/retailer-admin/src/App.tsx
+++ b/retailer-admin/src/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import React, { useEffect, Suspense, lazy } from 'react';
 import { AuthProvider, useAuth } from './lib/AuthContext';
+import { FeatureFlagProvider } from './lib/FeatureFlagContext';
 import ProtectedLayout from './components/ProtectedLayout';
 // ISSUE-MICRO-105: Global error boundary
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -217,7 +218,9 @@ export default function App() {
   return (
     <ErrorBoundary>
       <AuthProvider>
-        <AppRoutes />
+        <FeatureFlagProvider>
+          <AppRoutes />
+        </FeatureFlagProvider>
       </AuthProvider>
     </ErrorBoundary>
   );

--- a/retailer-admin/src/lib/FeatureFlagContext.tsx
+++ b/retailer-admin/src/lib/FeatureFlagContext.tsx
@@ -1,0 +1,87 @@
+// RCAT-FIX-004: Feature flag context for retailer-admin portal
+// Fetches flags from backend and provides via React context
+// Matches POS feature flag resolution: global defaults + store overrides
+
+import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import { authFetch } from './api';
+import { useAuth } from './AuthContext';
+
+interface FeatureFlags {
+  buyEnabled: boolean;
+  reorderEnabled: boolean;
+  bnplEnabled: boolean;
+  creditEnabled: boolean;
+  voiceEnabled: boolean;
+  categoryBrowsingEnabled: boolean;
+}
+
+const DEFAULT_FLAGS: FeatureFlags = {
+  buyEnabled: true,
+  reorderEnabled: true,
+  bnplEnabled: true,
+  creditEnabled: false,
+  voiceEnabled: false,
+  categoryBrowsingEnabled: true,
+};
+
+interface FeatureFlagContextType {
+  flags: FeatureFlags;
+  loading: boolean;
+  refresh: () => void;
+}
+
+const FeatureFlagContext = createContext<FeatureFlagContextType>({
+  flags: DEFAULT_FLAGS,
+  loading: true,
+  refresh: () => {},
+});
+
+export function FeatureFlagProvider({ children }: { children: React.ReactNode }) {
+  const { accessToken, isAuthenticated } = useAuth();
+  const [flags, setFlags] = useState<FeatureFlags>(DEFAULT_FLAGS);
+  const [loading, setLoading] = useState(true);
+
+  const fetchFlags = useCallback(async () => {
+    if (!isAuthenticated) {
+      setFlags(DEFAULT_FLAGS);
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const res = await authFetch(
+        '/api/v1/retailer-admin/feature-flags',
+        accessToken
+      );
+      if (res.ok) {
+        const json = await res.json();
+        if (json.success && json.data?.features) {
+          setFlags({ ...DEFAULT_FLAGS, ...json.data.features });
+        }
+      }
+    } catch {
+      // Network error — keep defaults
+    } finally {
+      setLoading(false);
+    }
+  }, [accessToken, isAuthenticated]);
+
+  useEffect(() => {
+    fetchFlags();
+  }, [fetchFlags]);
+
+  return (
+    <FeatureFlagContext.Provider value={{ flags, loading, refresh: fetchFlags }}>
+      {children}
+    </FeatureFlagContext.Provider>
+  );
+}
+
+export function useFeatureFlags(): FeatureFlagContextType {
+  return useContext(FeatureFlagContext);
+}
+
+export function useFeatureFlag(key: keyof FeatureFlags): boolean {
+  const { flags } = useContext(FeatureFlagContext);
+  return flags[key] ?? true;
+}


### PR DESCRIPTION
## Summary
- **Ticket:** RCAT-FIX-004 (#59) | **Phase:** UX | **Risk Class:** B
- Feature flags worked for POS via `/api/v1/pos/ui-status` but retailer-admin had zero awareness
- Added backend endpoint + frontend React context with `useFeatureFlag()` hook

## Changes
| File | Change |
|------|--------|
| `backend/src/routes/v1/retailer-admin/inventory.ts` | New `GET /feature-flags` endpoint |
| `retailer-admin/src/lib/FeatureFlagContext.tsx` | New: React context, provider, `useFeatureFlag()` hook |
| `retailer-admin/src/App.tsx` | Wrap with `FeatureFlagProvider` |

## How It Works
1. Backend resolves `platform.feature_flags` (global + store overrides) — same SQL as POS
2. Frontend fetches flags on auth, provides via React context
3. Components use `useFeatureFlag('reorderEnabled')` to gate UI sections
4. Defaults to all-enabled when not authenticated or on fetch error

## Evidence
- Backend typecheck: PASS
- Frontend typecheck: PASS

## Risk Assessment
- **Low risk** — additive only, no existing behavior changed
- Feature flags default to enabled — no functionality hidden by default

Fixes #59 | Parent: #55