### PR TITLE
fix(BUG-002): add requirePosStaff to scan/resolve endpoint

### DIFF
--- a/backend/src/routes/v1/pos/scan.ts
+++ b/backend/src/routes/v1/pos/scan.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../services/posScanStore";
 import { resolveScanForDigitisation } from "../../../services/storeProductDigitisationService";
 import { requireDeviceToken } from "../../../middleware/deviceToken";
+import { requirePosStaff } from "../../../middleware/posStaff";
 
 export const posScanRouter = Router();
 
@@ -95,7 +96,8 @@ function validateBarcodeFormat(barcode: string): { valid: boolean; error?: strin
  * GO-LIVE-040: Rate limited to 120 requests per minute per device
  * GO-LIVE-041: Barcode format validation applied
  */
-posScanRouter.post("/scan/resolve", requireDeviceToken, scanRateLimiter, async (req, res) => {
+// BUG-002: Added requirePosStaff to validate x-staff-id header against platform.store_staff
+posScanRouter.post("/scan/resolve", requireDeviceToken, requirePosStaff, scanRateLimiter, async (req, res) => {
   const { storeId, deviceId } = (req as any).posDevice as { storeId: string; deviceId: string };
 
   // Detect request format


### PR DESCRIPTION
## Summary
- Added `requirePosStaff` middleware to `POST /api/v1/pos/scan/resolve`
- Previously accepted any `x-staff-id` header value without DB validation

## Risk Assessment
- **Risk Class**: C (Auth/RBAC)
- **Blast radius**: POS scan now requires valid staff — POS app already sends x-staff-id

## Test plan
- [x] Backend typecheck passes
- [ ] Scan with valid staff ID still works
- [ ] Scan with fake staff ID returns 401 STAFF_INVALID

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)