### PR TITLE
fix(BUG-003): enforce store suspension on state-changing POS routes

### DIFF
--- a/backend/src/routes/v1/pos/bnpl.ts
+++ b/backend/src/routes/v1/pos/bnpl.ts
@@ -4,6 +4,7 @@
 import { Router, Request, Response } from "express";
 import { getPool } from "../../../db/client";
 import { requireDeviceToken, PosDeviceContext } from "../../../middleware/deviceToken";
+import { requireActiveStore } from "../../../middleware/storeStatusGate";
 // AUDIT-API-041/063: Rate limit BNPL financial endpoints
 import { financialOperationsRateLimiter } from "../../../middleware/posRateLimiter";
 import { randomUUID } from "crypto";
@@ -159,7 +160,8 @@ posBnplRouter.get("/bnpl/summary", requireDeviceToken, async (req: Request, res:
  * SM-019: Pay off a BNPL drawdown
  * Generates UPI payment link for repayment
  */
-posBnplRouter.post("/bnpl/:drawdownId/pay", requireDeviceToken, financialOperationsRateLimiter, async (req: Request, res: Response) => {
+// BUG-003: Enforce store must be ACTIVE for BNPL payments
+posBnplRouter.post("/bnpl/:drawdownId/pay", requireDeviceToken, requireActiveStore, financialOperationsRateLimiter, async (req: Request, res: Response) => {
   const pool = getPool();
   if (!pool) return res.status(503).json({ error: "database unavailable" });
 
@@ -341,7 +343,7 @@ posBnplRouter.post("/bnpl/:drawdownId/pay", requireDeviceToken, financialOperati
  * POST /api/v1/pos/bnpl/:drawdownId/pay/confirm
  * SM-019: Confirm UPI repayment with UTR
  */
-posBnplRouter.post("/bnpl/:drawdownId/pay/confirm", requireDeviceToken, financialOperationsRateLimiter, async (req: Request, res: Response) => {
+posBnplRouter.post("/bnpl/:drawdownId/pay/confirm", requireDeviceToken, requireActiveStore, financialOperationsRateLimiter, async (req: Request, res: Response) => {
   const pool = getPool();
   if (!pool) return res.status(503).json({ error: "database unavailable" });
 
@@ -543,7 +545,7 @@ posBnplRouter.get("/bnpl/:drawdownId/pay/:repaymentId/status", requireDeviceToke
  * GO-LIVE-240: Submit a dispute for a BNPL drawdown
  * Creates a dispute record for review by support team
  */
-posBnplRouter.post("/bnpl/:drawdownId/dispute", requireDeviceToken, financialOperationsRateLimiter, async (req: Request, res: Response) => {
+posBnplRouter.post("/bnpl/:drawdownId/dispute", requireDeviceToken, requireActiveStore, financialOperationsRateLimiter, async (req: Request, res: Response) => {
   const pool = getPool();
   if (!pool) return res.status(503).json({ error: "database unavailable" });
 

--- a/backend/src/routes/v1/pos/dues.ts
+++ b/backend/src/routes/v1/pos/dues.ts
@@ -4,6 +4,7 @@
 import { Router, Request, Response } from "express";
 import { getPool } from "../../../db/client";
 import { requireDeviceToken, type PosDeviceContext } from "../../../middleware/deviceToken";
+import { requireActiveStore } from "../../../middleware/storeStatusGate";
 
 export const posDuesRouter = Router();
 
@@ -89,7 +90,8 @@ posDuesRouter.get("/dues", requireDeviceToken, async (req: Request, res: Respons
  * Record a partial or full payment on a due.
  * Body: { amountMinor: number }
  */
-posDuesRouter.post("/dues/:dueId/pay", requireDeviceToken, async (req: Request, res: Response) => {
+// BUG-003: Enforce store must be ACTIVE for due payments
+posDuesRouter.post("/dues/:dueId/pay", requireDeviceToken, requireActiveStore, async (req: Request, res: Response) => {
   const pool = getPool();
   if (!pool) return res.status(503).json({ error: "database unavailable" });
 

--- a/backend/src/routes/v1/pos/purchases.ts
+++ b/backend/src/routes/v1/pos/purchases.ts
@@ -1,11 +1,13 @@
 import { Router } from "express";
 import { getPool } from "../../../db/client";
 import { requireDeviceToken } from "../../../middleware/deviceToken";
+import { requireActiveStore } from "../../../middleware/storeStatusGate";
 import { createPurchase, type PurchaseItemInput } from "../../../services/purchaseService";
 
 export const posPurchasesRouter = Router();
 
-posPurchasesRouter.post("/purchases", requireDeviceToken, async (req, res) => {
+// BUG-003: Enforce store must be ACTIVE for purchases
+posPurchasesRouter.post("/purchases", requireDeviceToken, requireActiveStore, async (req, res) => {
   // SA-P0-004: Accept supplierGstin for GSTIN tracking
   const { items, supplierName, supplierGstin, currency, purchaseId } = req.body as {
     items?: Array<{

--- a/backend/src/routes/v1/pos/scan.ts
+++ b/backend/src/routes/v1/pos/scan.ts
@@ -8,6 +8,7 @@ import {
 } from "../../../services/posScanStore";
 import { resolveScanForDigitisation } from "../../../services/storeProductDigitisationService";
 import { requireDeviceToken } from "../../../middleware/deviceToken";
+import { requireActiveStore } from "../../../middleware/storeStatusGate";
 import { requirePosStaff } from "../../../middleware/posStaff";
 
 export const posScanRouter = Router();
@@ -97,7 +98,8 @@ function validateBarcodeFormat(barcode: string): { valid: boolean; error?: strin
  * GO-LIVE-041: Barcode format validation applied
  */
 // BUG-002: Added requirePosStaff to validate x-staff-id header against platform.store_staff
-posScanRouter.post("/scan/resolve", requireDeviceToken, requirePosStaff, scanRateLimiter, async (req, res) => {
+// BUG-003: Added requireActiveStore to enforce store suspension
+posScanRouter.post("/scan/resolve", requireDeviceToken, requireActiveStore, requirePosStaff, scanRateLimiter, async (req, res) => {
   const { storeId, deviceId } = (req as any).posDevice as { storeId: string; deviceId: string };
 
   // Detect request format
@@ -157,7 +159,8 @@ posScanRouter.post("/scan/resolve", requireDeviceToken, requirePosStaff, scanRat
 
 // POST /api/v1/pos/products/price
 // GO-LIVE-040: Rate limited
-posScanRouter.post("/products/price", requireDeviceToken, scanRateLimiter, async (req, res) => {
+// BUG-003: Added requireActiveStore to enforce store suspension
+posScanRouter.post("/products/price", requireDeviceToken, requireActiveStore, scanRateLimiter, async (req, res) => {
   const { productId, priceMinor } = req.body as {
     productId?: string;
     priceMinor?: number;

--- a/backend/src/routes/v1/pos/stockIn.ts
+++ b/backend/src/routes/v1/pos/stockIn.ts
@@ -5,6 +5,7 @@
 import { Router, Request, Response } from "express";
 import { getPool } from "../../../db/client";
 import { requireDeviceToken } from "../../../middleware/deviceToken";
+import { requireActiveStore } from "../../../middleware/storeStatusGate";
 import { requirePosStaff, requireRole } from "../../../middleware/posStaff";
 import type { PosStaffContext } from "../../../middleware/posStaff";
 import { randomUUID } from "crypto";
@@ -113,7 +114,8 @@ posStockInRouter.get("/stock-in", requireDeviceToken, async (req: Request, res: 
 // Submit a stock-in batch (products received from supplier).
 // =============================================================================
 
-posStockInRouter.post("/stock-in", requireDeviceToken, requirePosStaff, requireRole("STOCK_MANAGER", "MANAGER"), async (req: Request, res: Response) => {
+// BUG-003: Enforce store must be ACTIVE for stock-in
+posStockInRouter.post("/stock-in", requireDeviceToken, requireActiveStore, requirePosStaff, requireRole("STOCK_MANAGER", "MANAGER"), async (req: Request, res: Response) => {
   const pool = getPool();
   if (!pool) return res.status(503).json({ success: false, error: "database unavailable" });
 

--- a/backend/src/routes/v1/pos/storeProducts.ts
+++ b/backend/src/routes/v1/pos/storeProducts.ts
@@ -1,5 +1,6 @@
 import { Router } from "express";
 import { requireDeviceToken } from "../../../middleware/deviceToken";
+import { requireActiveStore } from "../../../middleware/storeStatusGate";
 import { getPool } from "../../../db/client";
 import {
   createStoreProductFromDigitisation,
@@ -97,7 +98,8 @@ function isConflictResult(result: CreateStoreProductResult): result is ConflictR
  *   "message": "Sell price must be positive"
  * }
  */
-posStoreProductsRouter.post("/store-products", requireDeviceToken, async (req, res) => {
+// BUG-003: Enforce store must be ACTIVE for product creation
+posStoreProductsRouter.post("/store-products", requireDeviceToken, requireActiveStore, async (req, res) => {
   const { storeId } = (req as any).posDevice as { storeId: string };
 
   // AUD-073-A FIX: Extract variant and packSize from request body
@@ -679,7 +681,7 @@ posStoreProductsRouter.get("/store-products/freshness", requireDeviceToken, asyn
  * Update sell price for a store product (by barcode or productId)
  * Used when POS user edits price inline
  */
-posStoreProductsRouter.patch("/store-products/price", requireDeviceToken, async (req, res) => {
+posStoreProductsRouter.patch("/store-products/price", requireDeviceToken, requireActiveStore, async (req, res) => {
   const { storeId } = (req as any).posDevice as { storeId: string };
   // ITER3-001: Accept storeProductId in addition to barcode/productId
   const { barcode, productId, storeProductId, sellPrice } = req.body as {
@@ -792,7 +794,7 @@ posStoreProductsRouter.patch("/store-products/price", requireDeviceToken, async 
  * Sets absolute stock level with ledger audit trail
  * Used when POS user updates stock from product detail view
  */
-posStoreProductsRouter.patch("/store-products/stock", requireDeviceToken, async (req, res) => {
+posStoreProductsRouter.patch("/store-products/stock", requireDeviceToken, requireActiveStore, async (req, res) => {
   const { storeId } = (req as any).posDevice as { storeId: string };
   // ITER3-001: Accept storeProductId in addition to productId/barcode
   // RET-POS-SYNC-012: Accept stockUpdatedAt for LWW conflict detection
@@ -923,7 +925,7 @@ posStoreProductsRouter.patch("/store-products/stock", requireDeviceToken, async 
  * Uses barcode/productId fallback when storeProductId is unavailable (offline-first, last-write-wins).
  * IMPORTANT: This literal route MUST be defined BEFORE the parametric /:storeProductId/metadata route.
  */
-posStoreProductsRouter.patch("/store-products/metadata", requireDeviceToken, async (req, res) => {
+posStoreProductsRouter.patch("/store-products/metadata", requireDeviceToken, requireActiveStore, async (req, res) => {
   const { storeId } = (req as any).posDevice as { storeId: string };
   const { barcode, productId, storeProductId, displayName, purchasePrice, sellPrice, brand, mode, metadataUpdatedAt } = req.body as {
     barcode?: string;
@@ -1151,7 +1153,7 @@ posStoreProductsRouter.patch("/store-products/metadata", requireDeviceToken, asy
  * SYNC-PRD-001: Update product metadata (display name) from POS (legacy path-param endpoint)
  * Last-write-wins: server sets metadata_updated_at = NOW() on every write
  */
-posStoreProductsRouter.patch("/store-products/:storeProductId/metadata", requireDeviceToken, async (req, res) => {
+posStoreProductsRouter.patch("/store-products/:storeProductId/metadata", requireDeviceToken, requireActiveStore, async (req, res) => {
   const { storeId } = (req as any).posDevice as { storeId: string };
   const { storeProductId } = req.params;
   const { displayName, purchasePrice, brand, metadataUpdatedAt } = req.body as {

--- a/backend/src/routes/v1/pos/sync.ts
+++ b/backend/src/routes/v1/pos/sync.ts
@@ -3,6 +3,7 @@ import { Router } from "express";
 import type { PoolClient } from "pg";
 import { getPool } from "../../../db/client";
 import { requireDeviceToken } from "../../../middleware/deviceToken";
+import { requireActiveStore } from "../../../middleware/storeStatusGate";
 // AUDIT-API-039: Rate limit sync endpoint
 import { salesRateLimiter } from "../../../middleware/posRateLimiter";
 import {
@@ -574,7 +575,8 @@ async function clearFailedEvent(
 }
 
 // POST /api/v1/pos/sync
-posSyncRouter.post("/sync", requireDeviceToken, salesRateLimiter, async (req, res) => {
+// BUG-003: Enforce store must be ACTIVE for offline sync replay
+posSyncRouter.post("/sync", requireDeviceToken, requireActiveStore, salesRateLimiter, async (req, res) => {
   const batchStartTime = Date.now();
 
   const pendingRaw = asNumber(req.body?.pendingOutboxCount);


### PR DESCRIPTION
## Summary
- Added `requireActiveStore` middleware to 13 state-changing POS endpoints across 7 route files
- Suspended stores now receive 403 `STATUS_NOT_ALLOWED` instead of being able to sync, scan, stock-in, purchase, or modify products
- Read-only GET endpoints, auth endpoints, and enrollment routes intentionally excluded

## Files Changed
- `sync.ts` — POST /sync
- `scan.ts` — POST /scan/resolve, POST /products/price
- `stockIn.ts` — POST /stock-in
- `purchases.ts` — POST /purchases
- `storeProducts.ts` — POST + 4 PATCH routes
- `bnpl.ts` — 3 POST routes (pay, confirm, dispute)
- `dues.ts` — POST /dues/:id/pay

## Risk Assessment
- **Risk Class**: B (API/logic)
- **Blast radius**: Medium — POS app must handle 403 for suspended stores (already does via storeActive flag)

## Test plan
- [x] Backend typecheck passes
- [ ] Active store can still call all endpoints normally
- [ ] Suspended store gets 403 STATUS_NOT_ALLOWED on state-changing routes
- [ ] Suspended store can still call GET endpoints

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)