### PR TITLE
fix(BUG-004): reject stock-in with invalid quantity

### DIFF
--- a/backend/src/routes/v1/pos/stockIn.ts
+++ b/backend/src/routes/v1/pos/stockIn.ts
@@ -156,6 +156,18 @@ posStockInRouter.post("/stock-in", requireDeviceToken, requireActiveStore, requi
     return res.status(400).json({ success: false, error: "items array is required" });
   }
 
+  // BUG-004: Validate all item quantities upfront before processing
+  for (let i = 0; i < items.length; i++) {
+    const qty = items[i]?.quantity;
+    if (qty === undefined || qty === null || typeof qty !== "number" || !Number.isFinite(qty) || qty <= 0) {
+      return res.status(400).json({
+        success: false,
+        error: "INVALID_QUANTITY",
+        message: `Item ${i}: quantity must be a positive number, got: ${qty}`,
+      });
+    }
+  }
+
   // AUDIT-API-011: Use client-provided idempotency key as ledger reference for dedup
   const ledgerEntryId = (idempotencyKey && typeof idempotencyKey === "string") ? idempotencyKey : randomUUID();
   const client = await pool.connect();
@@ -168,7 +180,7 @@ posStockInRouter.post("/stock-in", requireDeviceToken, requireActiveStore, requi
     for (const item of items) {
       const { barcode, quantity, buyPrice } = item;
 
-      if (!quantity || quantity <= 0) continue;
+      // BUG-004: quantity validated upfront — always positive here
 
       // Look up product by barcode in store_product_barcodes + store_products
       const productResult = await client.query(


### PR DESCRIPTION
## Summary
- Added upfront validation to POST /api/v1/pos/stock-in that rejects items with quantity <= 0, non-number, or non-finite values
- Previously returned 200 OK with itemsProcessed: 0 (misleading success)
- Now returns 400 INVALID_QUANTITY with item index and received value

## Risk Assessment
- **Risk Class**: B (API/logic)
- **Blast radius**: Low — POS app always sends positive quantities; only catches invalid input

## Test plan
- [x] Backend typecheck passes
- [ ] Stock-in with quantity=5 still works
- [ ] Stock-in with quantity=0 returns 400
- [ ] Stock-in with quantity=-1 returns 400

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)