### PR TITLE
fix(STAGE-015): follow redirects in portal smoke test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -519,6 +519,8 @@ jobs:
             exit 1
           fi
 
+      # STAGE-015: Follow redirects (-L) because SPA portals redirect / → base path
+      # retailer-admin → /retailer/, superadmin → /admin/, supplier-portal → Next.js redirect
       - name: Portal health checks (BLOCKING)
         run: |
           PORTALS=(retailer-admin supplier-portal superadmin landing)
@@ -532,11 +534,12 @@ jobs:
               FAILED=$((FAILED + 1))
               continue
             fi
-            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "$URL/" 2>/dev/null || echo "000")
+            # -L follows redirects (SPAs redirect / to base path like /retailer/)
+            STATUS=$(curl -sL -o /dev/null -w "%{http_code}" "$URL/" 2>/dev/null || echo "000")
             if [ "$STATUS" = "200" ]; then
               echo "PASS: $portal — HTTP $STATUS"
             else
-              echo "FAIL: $portal — HTTP $STATUS (expected 200)"
+              echo "FAIL: $portal — HTTP $STATUS (expected 200 after following redirects)"
               FAILED=$((FAILED + 1))
             fi
           done


### PR DESCRIPTION
## Summary
- Portal smoke test was failing because SPA portals redirect `/` to their base path
- `retailer-admin` → 302 → `/retailer/`
- `superadmin` → 302 → `/admin/`
- `supplier-portal` → 307 (Next.js redirect)
- `landing` → 200 (static, no redirect)
- Fix: `curl -sf` → `curl -sL` (follow redirects)

## Root Cause
The smoke test used `curl -sf -o /dev/null -w "%{http_code}"` which does NOT follow redirects. SPAs with base paths always redirect from `/` to their configured base path. The final page after redirect returns 200.

## What Changed
- `deploy.yml` portal health check: Added `-L` flag to curl to follow redirects
- Added comment explaining why redirects are expected for SPA portals

## Test Plan
- [ ] CD pipeline portal smoke test passes (302/307 redirects followed to 200)
- [ ] Backend health check still works (no redirect, still 200)
- [ ] Auto-rollback no longer triggers on healthy portals

🤖 Generated with [Claude Code](https://claude.com/claude-code)