### PR TITLE
fix(STAGE-016): add retries to version SHA check for cold-start lag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -505,19 +505,28 @@ jobs:
           echo "BLOCKED: Staging is unhealthy. Deploy has failed."
           exit 1
 
+      # STAGE-016: Retry version check — new revision needs cold-start time after deploy
       - name: Version SHA check (BLOCKING)
         if: steps.url.outputs.gateway_url != ''
         run: |
           URL="${{ steps.url.outputs.gateway_url }}"
-          VERSION=$(curl -sf "$URL/version" 2>/dev/null || echo "{}")
-          echo "Version response: $VERSION"
-          if echo "$VERSION" | grep -q "${{ env.SHA }}"; then
-            echo "PASS: SHA matches deployed version"
-          else
-            echo "FATAL: SHA mismatch — expected ${{ env.SHA }} in /version response"
-            echo "BLOCKED: Deployed code does not match expected SHA. Possible stale revision."
-            exit 1
-          fi
+          EXPECTED="${{ env.SHA }}"
+          echo "Checking version SHA at $URL/version (expecting $EXPECTED)..."
+          for attempt in 1 2 3 4 5; do
+            VERSION=$(curl -sf "$URL/version" 2>/dev/null || echo "{}")
+            echo "  Attempt $attempt: $VERSION"
+            if echo "$VERSION" | grep -q "$EXPECTED"; then
+              echo "PASS: SHA matches deployed version"
+              exit 0
+            fi
+            if [ "$attempt" -lt 5 ]; then
+              echo "  SHA not yet matching (cold-start lag). Retrying in 10s..."
+              sleep 10
+            fi
+          done
+          echo "FATAL: SHA mismatch after 5 attempts — expected $EXPECTED in /version response"
+          echo "BLOCKED: Deployed code does not match expected SHA. Possible stale revision."
+          exit 1
 
       # STAGE-015: Follow redirects (-L) because SPA portals redirect / → base path
       # retailer-admin → /retailer/, superadmin → /admin/, supplier-portal → Next.js redirect


### PR DESCRIPTION
## Summary
- Version SHA check had **zero retries**, while health check had 5 retries with 10s delay
- After deploy, new revision needs cold-start time (min-instances=0)
- Health check passed (had retries), but version check hit the old revision and failed
- This triggered an unnecessary rollback + created orphaned revisions

## Root Cause
`gcloud run deploy` routes traffic to the new revision, but with `min-instances=0`, the first request triggers a cold start. During cold start (~3-5s), requests may still be served by the old revision (Cloud Run traffic routing propagation).

The health check had retries and passed. The version check immediately followed with zero retries and got the old SHA.

## What Changed
- Version SHA check: 1 attempt → 5 attempts with 10s delay (matches health check pattern)

## Test Plan
- [ ] CD pipeline version SHA check passes with retries
- [ ] No unnecessary rollback on healthy deploy
- [ ] Pipeline completes successfully through smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)