### PR TITLE
fix(STAGE-019): correct gcloud deploy flag syntax

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -341,7 +341,7 @@ jobs:
       # STAGE-018: GCP-level deploy safety — startup probes, CPU boost, readiness wait
       # Startup probes: GCP won't route traffic to a revision until /health returns 200.
       # This eliminates "old revision responds during cold start" at the platform level.
-      # --startup-cpu-boost: Allocate extra CPU during startup for faster cold starts.
+      # --cpu-boost: Allocate extra CPU during startup for faster cold starts.
       - name: Deploy main-backend to staging
         id: deploy-main-backend
         run: |
@@ -357,11 +357,8 @@ jobs:
             --cpu=1 \
             --min-instances=0 \
             --max-instances=3 \
-            --startup-cpu-boost \
-            --startup-probe-path=/health \
-            --startup-probe-period=5 \
-            --startup-probe-timeout=3 \
-            --startup-probe-failure-threshold=10 \
+            --cpu-boost \
+            --startup-probe=httpGet.path=/health,periodSeconds=5,timeoutSeconds=3,failureThreshold=10 \
             --vpc-connector="$VPC_CONNECTOR" \
             --vpc-egress=private-ranges-only \
             --add-cloudsql-instances="${{ env.GCP_PROJECT }}:${{ env.GCP_REGION }}:supermandi-staging" \
@@ -418,11 +415,8 @@ jobs:
             --cpu=1 \
             --min-instances=0 \
             --max-instances=3 \
-            --startup-cpu-boost \
-            --startup-probe-path=/health \
-            --startup-probe-period=5 \
-            --startup-probe-timeout=3 \
-            --startup-probe-failure-threshold=10 \
+            --cpu-boost \
+            --startup-probe=httpGet.path=/health,periodSeconds=5,timeoutSeconds=3,failureThreshold=10 \
             --vpc-connector="$VPC_CONNECTOR" \
             --vpc-egress=private-ranges-only \
             --set-env-vars="\


### PR DESCRIPTION
## Summary

- Fix invalid `gcloud run deploy` flags introduced in STAGE-018 that broke CD pipeline (run 21995287223)
- `--startup-cpu-boost` → `--cpu-boost` (correct gcloud flag name)
- 4 separate `--startup-probe-*` flags → single `--startup-probe=httpGet.path=/health,periodSeconds=5,timeoutSeconds=3,failureThreshold=10` (gcloud uses KEY=VALUE comma format)
- Applies to both `main-backend` and `api-gateway` deploy steps

## Root Cause

STAGE-018 used Kubernetes-style probe flag names (`--startup-probe-path`, `--startup-probe-period`, etc.) which don't exist in the `gcloud run deploy` CLI. The correct syntax is a single `--startup-probe` flag with comma-separated key=value pairs.

## Evidence

CD pipeline error:
```
ERROR: (gcloud.run.deploy) unrecognized arguments:
  --startup-cpu-boost (did you mean '--cpu-boost'?)
  --startup-probe-path=/health (did you mean '--startup-probe'?)
```

Verified correct syntax via `gcloud run deploy --help`.

## Test plan

- [ ] CI build passes
- [ ] CD pipeline triggers and deploys successfully with corrected flags

🤖 Generated with [Claude Code](https://claude.com/claude-code)