### PR TITLE
fix(STAGE-020): GCP CLI parity gate — validate deploy flags before deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -319,6 +319,59 @@ jobs:
           fi
           echo "All 6 images verified in Artifact Registry."
 
+      # STAGE-020: GCP CLI Parity Gate — validate gcloud run deploy flags
+      # BEFORE any deploy. Prevents pipeline failures from invalid flag syntax.
+      # Learned from STAGE-018/019: gcloud CLI uses --cpu-boost (not --startup-cpu-boost)
+      # and --startup-probe=KEY=VALUE (not individual --startup-probe-* flags).
+      # Extracts flags from gcloud run deploy command blocks in deploy.yml,
+      # then validates each against `gcloud run deploy --help`.
+      - name: "GCP CLI parity gate (BLOCKING)"
+        run: |
+          echo "=== STAGE-020: GCP CLI Parity Gate ==="
+          echo "Validating gcloud run deploy flags against installed gcloud CLI..."
+          echo ""
+
+          # Step 1: Build valid flag set from gcloud run deploy --help
+          HELP_OUTPUT=$(gcloud run deploy --help 2>&1)
+          VALID_FLAG_NAMES=$(echo "$HELP_OUTPUT" | grep -oE '\-\-[a-z][a-z0-9-]*' | sort -u)
+          VALID_COUNT=$(echo "$VALID_FLAG_NAMES" | wc -l)
+          echo "gcloud run deploy accepts $VALID_COUNT flags."
+
+          # Step 2: Extract flags ONLY from gcloud run deploy command blocks.
+          # These blocks start with 'gcloud run deploy' and end at a line without '\'.
+          # Use awk to isolate these blocks, then extract --flag patterns.
+          DEPLOY_FLAGS=$(awk '
+            /gcloud run deploy/ { in_block=1 }
+            in_block && /--[a-z]/ { print }
+            in_block && !/\\$/ { in_block=0 }
+          ' .github/workflows/deploy.yml \
+            | grep -oE '\-\-[a-z][a-z0-9-]*' \
+            | sort -u)
+
+          echo ""
+          echo "Flags used in gcloud run deploy blocks:"
+          INVALID=0
+          CHECKED=0
+          for flag in $DEPLOY_FLAGS; do
+            CHECKED=$((CHECKED + 1))
+            if echo "$VALID_FLAG_NAMES" | grep -qx "$flag"; then
+              echo "  OK: $flag"
+            else
+              echo "  FAIL: $flag — NOT a valid gcloud run deploy flag"
+              INVALID=$((INVALID + 1))
+            fi
+          done
+
+          echo ""
+          echo "Checked $CHECKED flags."
+          if [ $INVALID -gt 0 ]; then
+            echo "BLOCKED: $INVALID invalid gcloud run deploy flag(s) detected."
+            echo "Fix deploy.yml before deploying. Reference: gcloud run deploy --help"
+            exit 1
+          fi
+          echo "PASS: All $CHECKED gcloud run deploy flags are valid. GCP parity confirmed."
+          echo ""
+
       # STAGE-007: Record current serving revisions BEFORE deploy (for rollback)
       - name: Record pre-deploy revisions
         id: pre-revisions


### PR DESCRIPTION
## Summary

- Adds a **pre-deploy GCP CLI parity gate** that validates all `gcloud run deploy` flags BEFORE any deploy attempt
- Extracts flags from deploy command blocks using `awk`, validates each against `gcloud run deploy --help`
- If ANY invalid flag is found → pipeline **BLOCKED** with clear error message
- Prevents the exact failure that hit us in STAGE-018 (invalid `--startup-cpu-boost`, `--startup-probe-path` etc.)

## How It Works

1. Runs `gcloud run deploy --help` to get the canonical flag list
2. Uses `awk` to isolate multi-line `gcloud run deploy` command blocks in deploy.yml
3. Extracts `--flag-name` patterns from those blocks
4. Validates each flag exists in the help output
5. Fails with explicit `BLOCKED` message listing invalid flags

## GCP MCP Parity Verification (Pre-Commit)

Verified all 16 current deploy flags against live `gcloud run deploy --help` via GCP MCP:

| Flag | Valid |
|------|-------|
| `--image` | PASS |
| `--region` | PASS |
| `--platform` | PASS |
| `--memory` | PASS |
| `--cpu` | PASS |
| `--min-instances` | PASS |
| `--max-instances` | PASS |
| `--cpu-boost` | PASS |
| `--startup-probe` | PASS |
| `--vpc-connector` | PASS |
| `--vpc-egress` | PASS |
| `--add-cloudsql-instances` | PASS |
| `--set-env-vars` | PASS |
| `--set-secrets` | PASS |
| `--allow-unauthenticated` | PASS |
| `--quiet` | PASS |

## Test plan

- [ ] CI passes on this PR
- [ ] Next CD pipeline run includes parity gate step
- [ ] Gate outputs "PASS: All N flags are valid"

🤖 Generated with [Claude Code](https://claude.com/claude-code)