### PR TITLE
fix(STAGE-021): GCP-Git parity enforcement + auto-cleanup on smoke failure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -566,13 +566,61 @@ jobs:
           done
           if [ "$ALL_READY" = "false" ]; then
             echo ""
-            echo "WARNING: Not all revisions are READY and serving traffic."
-            echo "Smoke tests will still run — but failures may be due to revision startup lag."
-            echo "If smoke tests fail, check Cloud Run revision logs for startup errors."
+            echo "FATAL: Not all revisions are READY and serving traffic."
+            echo "Deploy did not fully propagate. Failing pipeline."
+            exit 1
           else
             echo ""
             echo "All 6 services: latest revision READY and serving 100% traffic."
           fi
+
+      # STAGE-021: GCP-Git Image Parity Gate (BLOCKING)
+      # Verify each service's serving revision uses the Docker image tagged with
+      # the expected Git SHA. If ANY service has a mismatched image, the deploy
+      # is broken (wrong code running). Fail BEFORE smoke tests.
+      - name: "GCP-Git image parity gate (BLOCKING)"
+        run: |
+          echo "=== STAGE-021: GCP-Git Image Parity Gate ==="
+          echo "Verifying serving revisions use images tagged with SHA: ${{ env.SHA }}"
+          echo ""
+
+          SERVICES=(api-gateway main-backend retailer-admin supplier-portal superadmin landing)
+          MISMATCH=0
+          for svc in "${SERVICES[@]}"; do
+            # Get the revision currently receiving traffic
+            TRAFFIC_REV=$(gcloud run services describe "$svc" \
+              --region="${{ env.GCP_REGION }}" \
+              --format="value(status.traffic[0].revisionName)" 2>/dev/null || echo "")
+            if [ -z "$TRAFFIC_REV" ]; then
+              echo "  FAIL: $svc — cannot determine traffic revision"
+              MISMATCH=$((MISMATCH + 1))
+              continue
+            fi
+
+            # Get the image used by that revision
+            IMAGE=$(gcloud run revisions describe "$TRAFFIC_REV" \
+              --region="${{ env.GCP_REGION }}" \
+              --format="value(spec.containers[0].image)" 2>/dev/null || echo "")
+
+            # Check the image tag contains our SHA
+            if echo "$IMAGE" | grep -q "${{ env.SHA }}"; then
+              echo "  PASS: $svc ($TRAFFIC_REV) → $IMAGE"
+            else
+              echo "  FAIL: $svc ($TRAFFIC_REV) → $IMAGE"
+              echo "    Expected tag: ${{ env.SHA }} — got different image!"
+              MISMATCH=$((MISMATCH + 1))
+            fi
+          done
+
+          echo ""
+          if [ $MISMATCH -gt 0 ]; then
+            echo "BLOCKED: $MISMATCH service(s) have image-SHA mismatch."
+            echo "GCP is NOT running the code from git SHA ${{ env.SHA }}."
+            echo "Deploy may have silently failed or reverted to old revision."
+            exit 1
+          fi
+          echo "PASS: All 6 services running images tagged ${{ env.SHA }}. GCP-Git parity confirmed."
+          echo ""
 
   # ==========================================================================
   # STAGE-017: Hardened smoke tests — every check has retries, timeouts,
@@ -810,24 +858,33 @@ jobs:
           echo "  Check: ADMIN_SERVICE_URL env var, VPC connector, main-backend health"
           exit 1
 
-      # STAGE-007: Auto-rollback all services if ANY smoke test fails
-      - name: Auto-rollback on failure
+      # STAGE-007 + STAGE-021: Auto-rollback + delete failed revisions on smoke failure.
+      # On failure: (1) rollback traffic to pre-deploy revisions, (2) delete ALL
+      # revisions created by this deploy so GCP has zero stale artifacts.
+      # Learned: failed deploys leave orphan revisions that clutter GCP state
+      # and make parity analysis between GCP and Git impossible.
+      - name: Auto-rollback and cleanup on failure
         if: failure()
         run: |
-          echo "SMOKE TEST FAILED — Rolling back all services to previous revisions..."
+          echo "=== SMOKE TEST FAILED — Rollback + Cleanup ==="
+          echo ""
+
+          # --- Phase 1: Rollback traffic to pre-deploy revisions ---
+          echo "Phase 1: Rolling back traffic..."
           PRE_REVISIONS="${{ needs.deploy-staging.outputs.pre_revisions }}"
           if [ -z "$PRE_REVISIONS" ]; then
             echo "WARN: No pre-deploy revisions recorded. Manual rollback required."
             echo "  Use: gcloud run services update-traffic <SERVICE> --to-revisions=<REVISION>=100 --region=${{ env.GCP_REGION }}"
             exit 1
           fi
-          # Parse "svc=rev," format and rollback each
           IFS=',' read -ra PAIRS <<< "$PRE_REVISIONS"
           ROLLBACK_FAILED=0
+          declare -A KEPT_REVS
           for pair in "${PAIRS[@]}"; do
             [ -z "$pair" ] && continue
             SVC="${pair%%=*}"
             REV="${pair##*=}"
+            KEPT_REVS["$SVC"]="$REV"
             if [ "$REV" = "none" ] || [ -z "$REV" ]; then
               echo "  SKIP: $SVC (no previous revision)"
               continue
@@ -848,6 +905,45 @@ jobs:
           else
             echo "All services rolled back to pre-deploy revisions."
           fi
+
+          # --- Phase 2: Delete stale revisions (keep only traffic revision) ---
+          echo ""
+          echo "Phase 2: Cleaning up stale revisions..."
+          SERVICES=(api-gateway main-backend retailer-admin supplier-portal superadmin landing)
+          DELETED=0
+          for svc in "${SERVICES[@]}"; do
+            KEEP="${KEPT_REVS[$svc]}"
+            if [ -z "$KEEP" ] || [ "$KEEP" = "none" ]; then
+              echo "  SKIP: $svc (no known good revision)"
+              continue
+            fi
+            # List all revisions for this service
+            ALL_REVS=$(gcloud run revisions list \
+              --service="$svc" \
+              --region="${{ env.GCP_REGION }}" \
+              --format="value(metadata.name)" 2>/dev/null || echo "")
+            for rev in $ALL_REVS; do
+              if [ "$rev" = "$KEEP" ]; then
+                echo "  KEEP: $rev (traffic revision)"
+              else
+                echo "  DELETE: $rev (stale)"
+                gcloud run revisions delete "$rev" \
+                  --region="${{ env.GCP_REGION }}" \
+                  --quiet 2>/dev/null && DELETED=$((DELETED + 1)) || echo "    WARN: Could not delete $rev"
+              fi
+            done
+          done
+          echo ""
+          echo "Cleanup complete: $DELETED stale revision(s) deleted."
+
+          # --- Phase 3: GCP-Git Parity Report ---
+          echo ""
+          echo "Phase 3: GCP-Git Parity Check"
+          echo "  Git HEAD: ${{ env.SHA }}"
+          echo "  Deploy target: FAILED — no service running ${{ env.SHA }}"
+          echo "  All services on pre-deploy revisions (rollback)"
+          echo ""
+
           # Still fail the pipeline
           exit 1
 


### PR DESCRIPTION
## Summary

Three hardening changes to prevent the STAGE-018/019 class of failures:

- **Revision readiness → BLOCKING**: Pipeline fails immediately if any revision isn't READY (was soft WARNING)
- **GCP-Git image parity gate**: After deploy, verifies each service's traffic revision uses the Docker image tagged with the expected Git SHA. Catches "deploy succeeded but wrong code running" before smoke tests even start
- **Auto-cleanup on smoke failure**: On rollback, delete ALL stale revisions so GCP has zero orphan artifacts

## Root Cause (CD run 21995942558)

Deploy succeeded (`gcloud run deploy` returned 0), but api-gateway still served old SHA (`01ffbc0` vs expected `7a8f788`). This left 26 stale revisions across 6 services. The image parity gate would have caught this immediately.

## GCP State Before Cleanup (MCP verified)

| Service | Traffic Rev | Latest Created | Stale |
|---------|------------|----------------|-------|
| api-gateway | 00013-f22 | 00018-qcx | 5 |
| main-backend | 00022-k4l | 00027-4m5 | 5 |
| retailer-admin | 00015-ld6 | 00020-dqv | 5 |
| supplier-portal | 00013-mbz | 00018-dvw | 5 |
| superadmin | 00010-flj | 00013-5db | 3 |
| landing | 00002-dzj | 00005-vdn | 3 |

## Test plan

- [ ] CI passes
- [ ] Next CD run: parity gate validates image tags match SHA
- [ ] If smoke fails: rollback + revision cleanup runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)