### PR TITLE
fix(STAGE-024): fix GIT_SHA extraction in parity gate

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -667,9 +667,12 @@ jobs:
             fi
 
             # Check GIT_SHA env var in the serving revision
+            # NOTE: gcloud --format doesn't support .filter() on env arrays.
+            # Use --format=json + jq to extract the value reliably.
             GIT_SHA_VAL=$(gcloud run revisions describe "$TRAFFIC_REV" \
               --region="${{ env.GCP_REGION }}" \
-              --format="value(spec.containers[0].env.filter(name=GIT_SHA).value)" 2>/dev/null || echo "")
+              --format=json 2>/dev/null \
+              | jq -r '.spec.containers[0].env[]? | select(.name=="GIT_SHA") | .value // empty' 2>/dev/null || echo "")
 
             if [ "$GIT_SHA_VAL" = "${{ env.SHA }}" ]; then
               echo "  PASS: $svc ($TRAFFIC_REV) GIT_SHA=$GIT_SHA_VAL"


### PR DESCRIPTION
## Summary
- gcloud `--format` doesn't support `.filter()` on env var arrays
- `env.filter(name=GIT_SHA).value` returns empty for ALL revisions (confirmed via MCP: GIT_SHA=0e6ae23 exists)
- Fix: Use `--format=json` + `jq` to extract GIT_SHA env var reliably

## Evidence
CD run 21997973183: All 6 services show `GIT_SHA=` (empty) despite env var being correctly set.
MCP verification: `gcloud run revisions describe api-gateway-00022-drw --format=json` shows `GIT_SHA: 0e6ae23`.

## Test plan
- [ ] CI passes
- [ ] CD deploys all 6 services
- [ ] GCP-Git parity gate PASSES (reads GIT_SHA via jq)
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)