### PR TITLE
fix(CD): STAGE-020 grep flag parsing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -455,7 +455,7 @@ jobs:
           CHECKED=0
           for flag in $DEPLOY_FLAGS; do
             CHECKED=$((CHECKED + 1))
-            if echo "$VALID_FLAG_NAMES" | grep -qx "$flag"; then
+            if echo "$VALID_FLAG_NAMES" | grep -qxF -- "$flag"; then
               echo "  OK: $flag"
             else
               echo "  FAIL: $flag — NOT a valid gcloud run deploy flag"


### PR DESCRIPTION
## Summary
- `grep -qx "$flag"` fails when `$flag` starts with `--` (e.g., `--add-cloudsql-instances`) because grep interprets it as an option, not a pattern
- Fix: `grep -qxF -- "$flag"` — `--` marks end of grep options, `-F` uses fixed-string match
- Root cause of Deploy Staging failure in CD run 22002842910 (STAGE-020 falsely reporting all valid flags as invalid)

## Evidence
CD run log shows:
```
grep: unrecognized option '--add-cloudsql-instances'
FAIL: --add-cloudsql-instances — NOT a valid gcloud run deploy flag
grep: unrecognized option '--allow-unauthenticated'
FAIL: --allow-unauthenticated — NOT a valid gcloud run deploy flag
```

All these flags ARE valid `gcloud run deploy` flags — grep just misinterpreted them as options.

## Test plan
- [ ] CI passes (13 jobs)
- [ ] CD pipeline reaches Deploy Staging → STAGE-020 passes
- [ ] All 6 services deploy to staging
- [ ] Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)