### PR TITLE
fix(CD): remove deprecated --platform=managed flag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -547,7 +547,6 @@ jobs:
           gcloud run deploy "$SERVICE_NAME" \
             --image="$IMAGE" \
             --region="${{ env.GCP_REGION }}" \
-            --platform=managed \
             --memory=512Mi \
             --cpu=1 \
             --min-instances=0 \
@@ -613,7 +612,6 @@ jobs:
           gcloud run deploy "$SERVICE_NAME" \
             --image="$IMAGE" \
             --region="${{ env.GCP_REGION }}" \
-            --platform=managed \
             --memory=512Mi \
             --cpu=1 \
             --min-instances=0 \
@@ -651,7 +649,6 @@ jobs:
             if ! gcloud run deploy "$SERVICE_NAME" \
               --image="$IMAGE" \
               --region="${{ env.GCP_REGION }}" \
-              --platform=managed \
               --memory=256Mi \
               --cpu=1 \
               --min-instances=0 \


### PR DESCRIPTION
## Summary
- `--platform=managed` is no longer a valid `gcloud run deploy` flag (managed is the only mode and the default)
- STAGE-020 parity gate correctly caught this as an invalid flag
- Removed from all 3 deploy commands: main-backend, api-gateway, portal loop

## Root cause
CD run 22003282580 — STAGE-020 gate passed grep validation (PR #98 fix) but found 1 legitimate invalid flag: `--platform` is deprecated in current gcloud CLI.

## Test plan
- [ ] CI passes (13 jobs)
- [ ] CD: STAGE-020 passes with 0 invalid flags
- [ ] CD: All 6 services deploy to staging
- [ ] CD: Smoke tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)