### PR TITLE
fix(CD): deploy-verify bash arithmetic exit trap

### DIFF
--- a/scripts/verification/deploy-verify.sh
+++ b/scripts/verification/deploy-verify.sh
@@ -69,17 +69,17 @@ log_info() {
 
 log_pass() {
     echo -e "${GREEN}[PASS]${NC} $1"
-    ((PASS_COUNT++))
+    PASS_COUNT=$((PASS_COUNT + 1))
 }
 
 log_fail() {
     echo -e "${RED}[FAIL]${NC} $1"
-    ((FAIL_COUNT++))
+    FAIL_COUNT=$((FAIL_COUNT + 1))
 }
 
 log_warn() {
     echo -e "${YELLOW}[WARN]${NC} $1"
-    ((WARN_COUNT++))
+    WARN_COUNT=$((WARN_COUNT + 1))
 }
 
 # Create evidence directory


### PR DESCRIPTION
## Summary
- `((PASS_COUNT++))` with `set -e` causes immediate script exit when `PASS_COUNT` is 0
- Post-increment evaluates to old value (0 = falsy in bash arithmetic), triggering `set -e` exit
- Fix: use `PASS_COUNT=$((PASS_COUNT + 1))` for all counters (PASS, FAIL, WARN)

## Root cause
Deploy Verification API & Asset Verification job shows `[PASS] health_api` then immediately exits with code 1. The very first `log_pass` call triggers the arithmetic trap.

## Test plan
- [ ] CI passes
- [ ] Deploy Verification API & Asset Verification completes all checks (not just first one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)