### PR TITLE
fix(CD): pass staging env vars to E2E tests

### DIFF
--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -123,6 +123,8 @@ jobs:
         working-directory: e2e-tests
         env:
           BASE_URL: ${{ env.TARGET_URL }}
+          API_BASE_URL: ${{ env.TARGET_URL }}
+          STAGING: 'true'
         run: |
           npx playwright test --project=chromium --reporter=html,json
 


### PR DESCRIPTION
## Summary
- E2E Playwright tests use `API_BASE_URL` for direct API calls (helpers.ts defaults to `localhost:3010`)
- Deploy Verification workflow only set `BASE_URL` (Playwright navigation) but not `API_BASE_URL` (API request helpers)
- Added `API_BASE_URL` and `STAGING=true` to the E2E test step environment

## Root cause
E2E tests in Deploy Verification failed with `ECONNREFUSED ::1:3010` — tests were hitting localhost instead of `staging.supermandi.tech`.

## Test plan
- [ ] CI passes
- [ ] Next Deploy Verification E2E tests use staging URL instead of localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)