### PR TITLE
fix(CD): deploy-verify grep crash + E2E @prod filter

### DIFF
--- a/.github/workflows/deploy-verify.yml
+++ b/.github/workflows/deploy-verify.yml
@@ -126,7 +126,7 @@ jobs:
           API_BASE_URL: ${{ env.TARGET_URL }}
           STAGING: 'true'
         run: |
-          npx playwright test --project=chromium --reporter=html,json
+          npx playwright test --project=chromium --grep @prod --reporter=html,json
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/scripts/verification/deploy-verify.sh
+++ b/scripts/verification/deploy-verify.sh
@@ -272,8 +272,8 @@ verify_asset_caching() {
     local js_hash=""
     local css_hash=""
     if [ -f "$EVIDENCE_DIR/assets/retailer_html.body" ]; then
-        js_hash=$(grep -oE 'index-[A-Za-z0-9]+\.js' "$EVIDENCE_DIR/assets/retailer_html.body" | head -1)
-        css_hash=$(grep -oE 'index-[A-Za-z0-9]+\.css' "$EVIDENCE_DIR/assets/retailer_html.body" | head -1)
+        js_hash=$(grep -oE 'index-[A-Za-z0-9]+\.js' "$EVIDENCE_DIR/assets/retailer_html.body" | head -1 || true)
+        css_hash=$(grep -oE 'index-[A-Za-z0-9]+\.css' "$EVIDENCE_DIR/assets/retailer_html.body" | head -1 || true)
     fi
 
     # Verify JS asset accessible and has immutable cache


### PR DESCRIPTION
## Summary

- **deploy-verify.sh**: `grep -oE` in `verify_asset_caching()` returns exit code 1 when no match found, which triggers `set -euo pipefail` and kills the script before completing all sections. Added `|| true` guards.
- **deploy-verify.yml**: E2E step ran ALL Playwright specs (including auth-dependent business logic tests like bank-reverification, onboarding, retailer-pos-sync). These fail with 403 in CI since there's no Firebase auth. Now filters to `--grep @prod` for staging-safe tests only.

## Evidence

CD run 22005349713 (commit 29a7bdf):
- API & Asset Verification: Crashed at section 3 "STATIC ASSET CACHING" — grep exit 1 under set -e
- E2E Browser Tests: 29 passed, 41 failed (all 403s from auth-dependent tests), 62 skipped

## Test plan

- [ ] CI passes (13 jobs)
- [ ] After merge, verify Deploy Verification run: API & Asset completes all 6 sections, E2E runs only @prod tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)