### PR TITLE
fix(staging): resolve portal auth errors — Firebase + email OTP

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -570,6 +570,7 @@ jobs:
           FIREBASE_PROJECT_ID=supermandi-pos,\
           SMS_DISABLED=true,\
           RATE_LIMIT_MULTIPLIER=100,\
+          EMAIL_PROVIDER=smtp,\
           SMTP_HOST=smtp.gmail.com,\
           SMTP_PORT=587,\
           SMTP_USER=supermanditech@gmail.com,\

--- a/supplier-portal/.env.production.example
+++ b/supplier-portal/.env.production.example
@@ -1,0 +1,14 @@
+# Supplier Portal - Production Environment
+# GO-LIVE-LOGIN: Firebase Phone OTP + API config
+
+# API Gateway URL - leave empty for relative paths (load balancer proxies /api/ to backend)
+NEXT_PUBLIC_API_BASE_URL=
+
+# Firebase Configuration (client-side keys - safe for public repos)
+# Same Firebase project as retailer-admin
+NEXT_PUBLIC_FIREBASE_API_KEY=AIzaSyAF67YOn6DJC0UdHGMOYYeKLUem1EB68LM
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=supermandi-pos.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=supermandi-pos
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=supermandi-pos.firebasestorage.app
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=547554299508
+NEXT_PUBLIC_FIREBASE_APP_ID=1:547554299508:web:4a81c65ee0725fc1cd0b21

--- a/supplier-portal/Dockerfile
+++ b/supplier-portal/Dockerfile
@@ -26,10 +26,16 @@ COPY . .
 # FRONTEND-CR-201: No hardcoded domain — set at build time via --build-arg
 ARG NEXT_PUBLIC_API_BASE_URL=""
 ARG NEXT_PUBLIC_GIT_SHA="unknown"
-# STAGING-FIX-007: Firebase config comes from .env.production (NOT Docker ARGs)
-# Removed empty ARG/ENV for NEXT_PUBLIC_FIREBASE_* — empty strings override .env.production
+# STAGING-FIX-007: Firebase config comes from .env.production file (NOT Docker ARGs)
+# Empty ARG strings would override file values, so Firebase is loaded from .env.production
 ENV NEXT_PUBLIC_API_BASE_URL=${NEXT_PUBLIC_API_BASE_URL}
 ENV NEXT_PUBLIC_GIT_SHA=${NEXT_PUBLIC_GIT_SHA}
+
+# STAGING-AUTH-001: Load Firebase config from .env.production for Next.js build
+# Next.js reads NEXT_PUBLIC_* from .env.production at build time (NODE_ENV=production)
+RUN if [ -f .env.production ]; then echo "Using .env.production"; \
+    elif [ -f .env.production.example ]; then cp .env.production.example .env.production && echo "Using .env.production.example as .env.production"; \
+    fi
 
 RUN npm run build
 
@@ -68,10 +74,9 @@ ENV PORT=3001
 
 EXPOSE 3001
 
-# SUP-ROOT-001: Health check uses /supplier path (basePath in next.config.js)
-# URL-003: trailingSlash=false — no trailing slash in healthcheck URL
+# SUP-ROOT-001: Health check uses /supplier/ path (basePath + trailingSlash in next.config.js)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:${PORT}/supplier || exit 1
+  CMD wget --no-verbose --tries=1 --spider http://localhost:${PORT}/supplier/ || exit 1
 
 # Start Next.js production server
 CMD ["npm", "start"]


### PR DESCRIPTION
## Summary

Fixes 3 portal authentication issues discovered during staging validation:

- **Supplier Portal** — "Phone Verification Unavailable": Firebase env vars missing from Docker build. Created `.env.production.example` with Firebase client keys and added `.env.production` copy step in Dockerfile so Next.js picks up `NEXT_PUBLIC_FIREBASE_*` at build time.
- **SuperAdmin** — Email OTP disabled: `EMAIL_PROVIDER` env var missing from main-backend Cloud Run service (defaults to 'disabled'). Added `EMAIL_PROVIDER=smtp` to deploy.yml env vars. **Also applied immediately to live staging** via `gcloud run services update`.
- **Retailer Admin** — "Authentication service error": Firebase IS configured but `staging.supermandi.tech` is not in Firebase authorized domains. This is an **operator action** tracked in #156.

## Files Changed (3 + 1 new)

| File | Change |
|------|--------|
| `supplier-portal/.env.production.example` | **NEW** — Firebase client keys for production build |
| `supplier-portal/Dockerfile` | Add `.env.production` copy step + fix HEALTHCHECK trailing slash |
| `.github/workflows/deploy.yml` | Add `EMAIL_PROVIDER=smtp` to main-backend env vars |

## Test plan

- [ ] CI gates pass (lint, typecheck, build)
- [ ] After deploy: Supplier portal shows phone OTP form (not "Phone Verification Unavailable")
- [ ] After deploy: SuperAdmin "Send OTP" sends email (not "Email service not configured")
- [ ] **Operator**: Add `staging.supermandi.tech` to Firebase authorized domains (#156)
- [ ] After #156: Retailer registration OTP works end-to-end

## Immediate staging fix

`EMAIL_PROVIDER=smtp` was applied to the live `main-backend` service via `gcloud run services update` — SuperAdmin email OTP should work now without waiting for the next deploy.

Related: #156 (Firebase authorized domain — operator action)

🤖 Generated with [Claude Code](https://claude.com/claude-code)