### PR TITLE
fix(CSP): add Google reCAPTCHA domains for Firebase Phone Auth

### DIFF
--- a/retailer-admin/nginx-local-prod.conf
+++ b/retailer-admin/nginx-local-prod.conf
@@ -9,11 +9,13 @@ server {
     index index.html;
 
     # URL-001: Security headers for all responses
+    # CSP-RECAPTCHA-001: script-src and frame-src include https://www.google.com
+    # for Firebase Phone Auth invisible reCAPTCHA verification
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com; frame-src 'self' https://*.firebaseapp.com" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.google.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com" always;
 
     # Docker healthcheck endpoint (must stay at root path)
     location = /health.txt {
@@ -43,13 +45,16 @@ server {
 
     # All /retailer/ paths - strip prefix, serve SPA with fallback
     # URL-003: Add no-cache for HTML to ensure fresh content after deploys
+    # NOTE: add_header in location block overrides ALL server-level headers.
+    # Every header needed for this location MUST be repeated here.
     location /retailer/ {
         rewrite ^/retailer/(.*) /$1 break;
         try_files $uri $uri/ /index.html;
         add_header Cache-Control "no-cache" always;
-        # URL-001: Re-add security headers
         add_header X-Frame-Options "DENY" always;
         add_header X-Content-Type-Options "nosniff" always;
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.google.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com" always;
     }
 }

--- a/supplier-portal/next.config.js
+++ b/supplier-portal/next.config.js
@@ -49,7 +49,9 @@ const nextConfig = {
           { key: 'X-Content-Type-Options', value: 'nosniff' },
           { key: 'Strict-Transport-Security', value: 'max-age=31536000; includeSubDomains' },
           { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
-          { key: 'Content-Security-Policy', value: "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com; frame-src 'self' https://*.firebaseapp.com" },
+          // CSP-RECAPTCHA-001: script-src and frame-src include https://www.google.com
+          // for Firebase Phone Auth invisible reCAPTCHA verification
+          { key: 'Content-Security-Policy', value: "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.google.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com" },
         ],
       },
       {


### PR DESCRIPTION
## Summary

Firebase Phone Auth OTP was failing with `auth/internal-error` because the Content-Security-Policy blocked Google's invisible reCAPTCHA iframe and scripts.

**Root cause**: CSP had `https://www.gstatic.com` but was missing `https://www.google.com` in `script-src` and `frame-src`. The reCAPTCHA verification iframe loads from `www.google.com/recaptcha/...`.

Note: `staging.supermandi.tech` was already in Firebase authorized domains — issue #156 was misdiagnosed and is now closed.

## Files Changed (2)

| File | Change |
|------|--------|
| `retailer-admin/nginx-local-prod.conf` | Add `https://www.google.com` to CSP `script-src` + `frame-src`. Fix header inheritance — `/retailer/` location now includes HSTS, CSP, Referrer-Policy |
| `supplier-portal/next.config.js` | Same CSP fix for reCAPTCHA domains |

## Test plan

- [ ] CI gates pass
- [ ] After deploy: Open retailer register page, send OTP → no CSP errors in console
- [ ] After deploy: Open supplier login page, send OTP → no CSP errors in console
- [ ] Verify CSP header includes `https://www.google.com` in script-src and frame-src

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)