### PR TITLE
fix(superadmin): add missing login page CSS classes (#159)

### DIFF
--- a/supermandi-superadmin/src/App.css
+++ b/supermandi-superadmin/src/App.css
@@ -782,3 +782,136 @@
   flex-direction: column;
   gap: 0;
 }
+
+/* #159: SuperAdmin Login page styles */
+.loginContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 24px;
+}
+
+.loginCard {
+  width: 100%;
+  max-width: 420px;
+  border: 1px solid var(--color-border);
+  border-radius: 18px;
+  background: var(--color-surface);
+  box-shadow: var(--shadow-card);
+  padding: 32px;
+  animation: fadeUp 0.25s ease;
+}
+
+.loginHeader {
+  margin-bottom: 24px;
+}
+
+.loginField {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 16px;
+}
+
+.loginField label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.loginField input {
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
+  font-size: 15px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.loginField input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-soft);
+}
+
+.loginField input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.loginError {
+  color: var(--color-error);
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: var(--color-error-soft);
+  border: 1px solid var(--color-error);
+}
+
+.loginButton {
+  width: 100%;
+  padding: 12px;
+  border-radius: 12px;
+  font-size: 15px;
+  font-weight: 700;
+  background: var(--color-primary);
+  color: white;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.1s;
+}
+
+.loginButton:hover:not(:disabled) {
+  background: var(--color-primary-dark);
+}
+
+.loginButton:active:not(:disabled) {
+  transform: scale(0.98);
+}
+
+.loginButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.loginInfo {
+  margin-top: 16px;
+  font-size: 12px;
+  color: var(--color-text-muted);
+  text-align: center;
+  line-height: 1.5;
+}
+
+.loginLink {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.loginLink:hover {
+  color: var(--color-primary-dark);
+  text-decoration: underline;
+}
+
+.loginLink:disabled {
+  color: var(--color-text-muted);
+  cursor: not-allowed;
+  text-decoration: none;
+}
+
+@media (max-width: 480px) {
+  .loginContainer {
+    padding: 16px;
+  }
+  .loginCard {
+    padding: 24px;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 8 missing CSS class definitions (`loginContainer`, `loginCard`, `loginField`, `loginButton`, `loginError`, `loginInfo`, `loginLink`, `loginHeader`) to `App.css`
- Login page now has centered card layout, styled inputs with focus rings, error state styling, and responsive mobile support
- Uses existing CSS variables and design tokens (no new dependencies)

## Test plan
- [ ] Verify `/admin/` login page renders with centered card, styled inputs, and branded header
- [ ] Verify OTP step renders properly (sent-to banner, OTP input, resend/back links)
- [ ] Verify error messages show in red with soft background
- [ ] Verify responsive layout on mobile (< 480px)

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)