### PR TITLE
fix(landing): add Google Fonts domains to CSP (#161)

### DIFF
--- a/supermandi-landing/nginx.conf
+++ b/supermandi-landing/nginx.conf
@@ -9,7 +9,9 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:" always;
+    # CSP-FONTS-001: style-src includes fonts.googleapis.com, font-src includes fonts.gstatic.com
+    # for Google Fonts (Inter) used on landing page
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'" always;
 
     location = /privacy {
         try_files /privacy.html =404;
@@ -18,7 +20,9 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:" always;
+        # CSP-FONTS-001: style-src includes fonts.googleapis.com, font-src includes fonts.gstatic.com
+    # for Google Fonts (Inter) used on landing page
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'" always;
     }
 
     location = /terms {
@@ -28,7 +32,9 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:" always;
+        # CSP-FONTS-001: style-src includes fonts.googleapis.com, font-src includes fonts.gstatic.com
+    # for Google Fonts (Inter) used on landing page
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'" always;
     }
 
     location = /pos {
@@ -38,7 +44,9 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:" always;
+        # CSP-FONTS-001: style-src includes fonts.googleapis.com, font-src includes fonts.gstatic.com
+    # for Google Fonts (Inter) used on landing page
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'" always;
     }
 
     location = / {
@@ -48,7 +56,9 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:" always;
+        # CSP-FONTS-001: style-src includes fonts.googleapis.com, font-src includes fonts.gstatic.com
+    # for Google Fonts (Inter) used on landing page
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self'" always;
     }
 
     location / {


### PR DESCRIPTION
## Summary
- Adds `https://fonts.googleapis.com` to `style-src` and `https://fonts.gstatic.com` to `font-src` in landing page nginx CSP
- Updates all 5 CSP declarations (server-level + 4 location blocks)
- Fixes E2E deploy verification failure (console error check on landing page)

## Test plan
- [ ] Deploy verification workflow E2E tests pass (no console errors on landing page)
- [ ] Google Fonts (Inter) loads correctly on landing page

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)