### PR TITLE
fix(retailer): add Google Fonts domains to CSP (#163)

### DIFF
--- a/retailer-admin/nginx-local-prod.conf
+++ b/retailer-admin/nginx-local-prod.conf
@@ -11,11 +11,13 @@ server {
     # URL-001: Security headers for all responses
     # CSP-RECAPTCHA-001: script-src and frame-src include https://www.google.com
     # for Firebase Phone Auth invisible reCAPTCHA verification
+    # CSP-FONTS-001: style-src includes fonts.googleapis.com, font-src includes fonts.gstatic.com
+    # for Google Fonts (Inter) used in retailer-admin index.css @import
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.google.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.google.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com" always;
 
     # Docker healthcheck endpoint (must stay at root path)
     location = /health.txt {
@@ -55,6 +57,8 @@ server {
         add_header X-Content-Type-Options "nosniff" always;
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.google.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com" always;
+        # CSP-FONTS-001: style-src includes fonts.googleapis.com, font-src includes fonts.gstatic.com
+        # for Google Fonts (Inter) used in retailer-admin index.css @import
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.google.com https://*.firebaseapp.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; font-src 'self' data: https://fonts.gstatic.com; connect-src 'self' https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com https://identitytoolkit.googleapis.com; frame-src 'self' https://*.firebaseapp.com https://www.google.com" always;
     }
 }


### PR DESCRIPTION
## Summary
- Add `https://fonts.googleapis.com` to `style-src` and `https://fonts.gstatic.com` to `font-src` in retailer-admin nginx CSP
- Fixes all 7 E2E failures in Deploy Verification caused by Google Fonts `@import` in `index.css` being blocked by CSP

## Root Cause
`retailer-admin/src/index.css` line 2: `@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');`

CSP `style-src` only had `'self' 'unsafe-inline'` — missing the `fonts.googleapis.com` domain.

## Test plan
- [ ] CI gates pass
- [ ] CD deploys to staging
- [ ] Deploy Verification E2E passes (all 30 tests green, 0 unexpected)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)