### PR TITLE
fix(CD): pass git SHA + build time to all portal Docker builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,8 @@ jobs:
             -t "${{ env.AR_REPO }}/retailer-admin:${{ env.SHA }}" \
             -f retailer-admin/Dockerfile \
             --build-arg VITE_API_BASE_URL="" \
+            --build-arg VITE_GIT_SHA="${{ env.SHA }}" \
+            --build-arg VITE_BUILD_TIME="${{ env.BUILD_TIME }}" \
             --build-arg VITE_FIREBASE_API_KEY="${{ secrets.FIREBASE_API_KEY }}" \
             --build-arg VITE_FIREBASE_AUTH_DOMAIN="${{ secrets.FIREBASE_AUTH_DOMAIN }}" \
             --build-arg VITE_FIREBASE_PROJECT_ID="${{ secrets.FIREBASE_PROJECT_ID }}" \
@@ -140,6 +142,7 @@ jobs:
             -t "${{ env.AR_REPO }}/supplier-portal:${{ env.SHA }}" \
             -f supplier-portal/Dockerfile \
             --build-arg NEXT_PUBLIC_API_BASE_URL="" \
+            --build-arg NEXT_PUBLIC_GIT_SHA="${{ env.SHA }}" \
             --build-arg NEXT_PUBLIC_FIREBASE_API_KEY="${{ secrets.FIREBASE_API_KEY }}" \
             --build-arg NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="${{ secrets.FIREBASE_AUTH_DOMAIN }}" \
             --build-arg NEXT_PUBLIC_FIREBASE_PROJECT_ID="${{ secrets.FIREBASE_PROJECT_ID }}" \
@@ -154,6 +157,8 @@ jobs:
             -t "${{ env.AR_REPO }}/superadmin:${{ env.SHA }}" \
             -f supermandi-superadmin/Dockerfile \
             --build-arg VITE_API_BASE_URL="" \
+            --build-arg VITE_GIT_SHA="${{ env.SHA }}" \
+            --build-arg VITE_BUILD_TIME="${{ env.BUILD_TIME }}" \
             supermandi-superadmin/
 
       - name: Build landing

--- a/retailer-admin/vite.config.ts
+++ b/retailer-admin/vite.config.ts
@@ -5,13 +5,16 @@ import { writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 
 // GO-LIVE-SOP: Get build info for cache-proof deployment verification
+// STAGING-FIX-006: Check VITE_GIT_SHA env var first (Docker builds lack .git directory)
 function getBuildInfo() {
   try {
-    const sha = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+    const sha = process.env.VITE_GIT_SHA
+      || process.env.VITE_BUILD_SHA
+      || execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
     const time = new Date().toLocaleString('en-IN', { timeZone: 'Asia/Kolkata' }).replace(',', '');
     return { sha, time };
   } catch {
-    return { sha: 'unknown', time: new Date().toISOString() };
+    return { sha: process.env.VITE_GIT_SHA || 'unknown', time: new Date().toISOString() };
   }
 }
 


### PR DESCRIPTION
## Summary
- Add `--build-arg VITE_GIT_SHA` and `VITE_BUILD_TIME` to retailer-admin + superadmin Docker builds in deploy.yml
- Add `--build-arg NEXT_PUBLIC_GIT_SHA` to supplier-portal Docker build
- Fix retailer-admin `vite.config.ts` to read `VITE_GIT_SHA` env var in Docker builds (STAGING-FIX-006 parity with superadmin)

Fixes #165 — "Build: unknown" displayed on all 3 portals in staging.

## Test plan
- [ ] CI passes (deploy.yml YAML valid, retailer-admin builds)
- [ ] After merge + CD deploy: verify all 3 portals show actual git SHA instead of "unknown"
- [ ] Check `https://staging.supermandi.tech/admin/` BuildStamp shows short SHA
- [ ] Check `https://staging.supermandi.tech/retailer/` BuildStamp shows short SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)