### PR TITLE
fix(routing): redirect bare portal paths to trailing-slash

### DIFF
--- a/retailer-admin/nginx-local-prod.conf
+++ b/retailer-admin/nginx-local-prod.conf
@@ -29,6 +29,11 @@ server {
         return 302 /retailer/;
     }
 
+    # Redirect /retailer (no trailing slash) to /retailer/
+    location = /retailer {
+        return 302 /retailer/;
+    }
+
     # Assets with immutable cache headers
     location ~* ^/retailer/assets/ {
         rewrite ^/retailer/(.*) /$1 break;

--- a/scripts/staging-urlmap.yaml
+++ b/scripts/staging-urlmap.yaml
@@ -17,11 +17,14 @@ pathMatchers:
     - /version
     service: https://www.googleapis.com/compute/v1/projects/supermandi-backend/global/backendServices/api-gateway-backend
   - paths:
+    - /retailer
     - /retailer/*
     service: https://www.googleapis.com/compute/v1/projects/supermandi-backend/global/backendServices/retailer-backend
   - paths:
+    - /admin
     - /admin/*
     service: https://www.googleapis.com/compute/v1/projects/supermandi-backend/global/backendServices/superadmin-backend
   - paths:
+    - /supplier
     - /supplier/*
     service: https://www.googleapis.com/compute/v1/projects/supermandi-backend/global/backendServices/supplier-backend

--- a/supermandi-superadmin/nginx-local-prod.conf
+++ b/supermandi-superadmin/nginx-local-prod.conf
@@ -25,6 +25,11 @@ server {
         return 302 /admin/;
     }
 
+    # Redirect /admin (no trailing slash) to /admin/
+    location = /admin {
+        return 302 /admin/;
+    }
+
     # Assets with immutable cache headers
     location ~* ^/admin/assets/ {
         rewrite ^/admin/(.*) /$1 break;


### PR DESCRIPTION
## Summary
- Add bare path rules (`/retailer`, `/admin`, `/supplier`) to GCP URL map so they route to the correct Cloud Run services (primary fix)
- Add nginx `location = /portal { return 302 /portal/; }` redirects in retailer-admin + superadmin configs (defense-in-depth)
- Supplier portal already handles via Next.js `trailingSlash: true`

Fixes #167

## Post-merge action required
After CD deploys the new nginx configs, apply the URL map change to GCP:
```bash
gcloud compute url-maps import supermandi-staging \
  --source scripts/staging-urlmap.yaml \
  --global --project=supermandi-backend
```

## Test plan
- [ ] CI passes
- [ ] After merge + CD deploy + URL map apply: `curl -I https://staging.supermandi.tech/retailer` → 302
- [ ] `curl -I https://staging.supermandi.tech/admin` → 302
- [ ] `curl -I https://staging.supermandi.tech/supplier` → 302

🤖 Generated with [Claude Code](https://claude.com/claude-code)