### PR TITLE
fix(auth): session persistence via HttpOnly cookies + nginx redirect fix

### DIFF
--- a/backend/src/routes/v1/retailer-admin/auth.ts
+++ b/backend/src/routes/v1/retailer-admin/auth.ts
@@ -9,6 +9,8 @@ import bcrypt from "bcryptjs";
 import { randomUUID } from "crypto";
 import { getPool } from "../../../db/client";
 import { logLoginSuccess } from "../../../services/authAuditService";
+// AUTH-SESSION-169: Cookie utility for auth session persistence
+import { setAuthCookies, clearAuthCookies, getRefreshTokenFromRequest } from "../../../utils/authCookies";
 // GO-LIVE-189: Import rate limiter to prevent store code enumeration
 import { authRateLimiter } from "../../../middleware/posRateLimiter";
 // GO-LIVE-195: Enhanced auth protection with per-store-code limiting and progressive lockout
@@ -577,6 +579,10 @@ router.post("/auth/firebase-otp-login", enhancedAuthProtection(), authRateLimite
 
     console.log(`[RetailerAuth] GO-LIVE-RET-AUTH-001: OTP login successful for ***${phoneNormalized.slice(-4)}, ${stores.length} stores`);
 
+    // AUTH-SESSION-169: Set HttpOnly cookies for session persistence across page refreshes
+    // Access token: 24h (matches JWT expiresIn), Refresh token: 7d
+    setAuthCookies(res, accessToken, refreshToken, 86400, 7 * 86400);
+
     res.json({
       success: true,
       token: accessToken,
@@ -1097,7 +1103,8 @@ router.post("/auth/forgot-password/reset", authRateLimiter, async (req: Request,
  */
 router.post("/auth/refresh", async (req: Request, res: Response, next: NextFunction) => {
   try {
-    const { refreshToken } = req.body;
+    // AUTH-SESSION-169: Read refresh token from cookie or body (backward compat with POS app)
+    const refreshToken = getRefreshTokenFromRequest(req);
 
     if (!refreshToken) {
       res.status(400).json({ error: "Refresh token is required" });
@@ -1194,6 +1201,9 @@ router.post("/auth/refresh", async (req: Request, res: Response, next: NextFunct
       issuer: JWT_ISSUER,
       expiresIn: JWT_EXPIRES_IN,
     });
+
+    // AUTH-SESSION-169: Refresh cookies on token refresh (new access token, same refresh token)
+    setAuthCookies(res, accessToken, refreshToken, 86400, 7 * 86400);
 
     res.json({
       success: true,
@@ -1357,6 +1367,9 @@ router.post("/auth/logout", async (req: Request, res: Response, next: NextFuncti
       // Log but don't fail
       console.warn('[RetailerAuth] GO-LIVE-137: Failed to record token revocation:', dbError);
     }
+
+    // AUTH-SESSION-169: Clear auth cookies on logout
+    clearAuthCookies(res);
 
     res.json({
       data: {

--- a/backend/src/routes/v1/supplier/auth.ts
+++ b/backend/src/routes/v1/supplier/auth.ts
@@ -11,6 +11,8 @@ import rateLimit from "express-rate-limit";
 import { getPool } from "../../../db/client";
 import { checkIpBlockMiddleware, recordAuthFailure, clearIpFailures } from "../../../services/ipBlockingService";
 import { logLoginSuccess, logLoginFailed, logAccountLocked } from "../../../services/authAuditService";
+// AUTH-SESSION-169: Cookie utility for auth session persistence
+import { setAuthCookies, clearAuthCookies, getRefreshTokenFromRequest } from "../../../utils/authCookies";
 
 // GO-LIVE-LOGIN: Import Firebase verification for phone-based auth
 let verifyFirebaseIdToken: ((idToken: string) => Promise<{ success: boolean; payload?: { phone_number?: string; uid?: string }; error?: string; code?: string }>) | null = null;
@@ -630,6 +632,18 @@ router.post("/auth/login", checkIpBlockMiddleware, loginRateLimiter, async (req:
       expiresIn: JWT_EXPIRES_IN,
     });
 
+    // AUTH-SESSION-169: Generate refresh token for email/password login
+    const refreshJti = randomUUID();
+    const refreshPayload = {
+      sub: supplier.id,
+      type: 'refresh',
+      jti: refreshJti,
+    };
+    const refreshToken = jwt.sign(refreshPayload, JWT_SECRET, {
+      issuer: JWT_ISSUER,
+      expiresIn: '7d',
+    });
+
     // GO-LIVE-144: Log successful login
     logLoginSuccess({
       actorType: 'supplier',
@@ -639,9 +653,13 @@ router.post("/auth/login", checkIpBlockMiddleware, loginRateLimiter, async (req:
       userAgent: req.get('user-agent'),
     }).catch(() => {}); // Non-blocking
 
+    // AUTH-SESSION-169: Set HttpOnly cookies for session persistence
+    setAuthCookies(res, token, refreshToken, 86400, 7 * 86400);
+
     res.json({
       data: {
         token,
+        refreshToken,
         supplier: {
           id: supplier.id,
           email: supplier.primary_email,
@@ -1204,6 +1222,9 @@ router.post("/auth/logout", requireSupplierAuth, async (req: SupplierAuthRequest
       console.warn('[SupplierAuth] Failed to record token revocation:', dbError);
     }
 
+    // AUTH-SESSION-169: Clear auth cookies on logout
+    clearAuthCookies(res);
+
     res.json({
       data: {
         success: true,
@@ -1623,6 +1644,9 @@ router.post("/auth/firebase-login", checkIpBlockMiddleware, loginRateLimiter, as
 
     console.log(`[SupplierAuth] GO-LIVE-SUP-AUTH-001: OTP login successful for ***${phoneNormalized.slice(-4)}`);
 
+    // AUTH-SESSION-169: Set HttpOnly cookies for session persistence across page refreshes
+    setAuthCookies(res, token, refreshToken, 86400, 7 * 86400);
+
     res.json({
       success: true,
       status: 'active',
@@ -1637,6 +1661,105 @@ router.post("/auth/firebase-login", checkIpBlockMiddleware, loginRateLimiter, as
         businessName: supplier.business_name,
         gstin: supplier.gstin,
         verificationStatus: supplier.verification_status,
+      },
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+/**
+ * POST /api/v1/supplier/auth/refresh
+ * AUTH-SESSION-169: Refresh an expired access token using a valid refresh token (cookie or body)
+ */
+router.post("/auth/refresh", async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const refreshToken = getRefreshTokenFromRequest(req);
+
+    if (!refreshToken) {
+      res.status(400).json({ error: { code: 'VALIDATION_ERROR', message: 'Refresh token is required' } });
+      return;
+    }
+
+    // Verify refresh token
+    let decoded: { sub: string; type: string; jti?: string; iat?: number };
+    try {
+      decoded = jwt.verify(refreshToken, JWT_SECRET, {
+        issuer: JWT_ISSUER,
+      }) as { sub: string; type: string; jti?: string; iat?: number };
+    } catch (error) {
+      if (error instanceof jwt.TokenExpiredError) {
+        res.status(401).json({ error: { code: 'TOKEN_EXPIRED', message: 'Refresh token expired. Please login again.' } });
+        return;
+      }
+      res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Invalid refresh token' } });
+      return;
+    }
+
+    if (decoded.type !== 'refresh') {
+      res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Invalid token type' } });
+      return;
+    }
+
+    const pool = getPool();
+    if (!pool) {
+      res.status(503).json({ error: { code: 'DB_UNAVAILABLE', message: 'Database unavailable' } });
+      return;
+    }
+
+    // Check if refresh token has been revoked
+    if (decoded.jti) {
+      const revocationCheck = await pool.query(
+        `SELECT 1 FROM auth.token_revocations WHERE jti = $1 LIMIT 1`,
+        [decoded.jti]
+      );
+      if (revocationCheck.rows.length > 0) {
+        res.status(401).json({ error: { code: 'TOKEN_REVOKED', message: 'Session has been logged out. Please login again.' } });
+        return;
+      }
+    }
+
+    // Get supplier info
+    const supplierResult = await pool.query(
+      `SELECT id, primary_email, primary_phone, business_name, status
+       FROM supplier.suppliers
+       WHERE id = $1 AND status = 'active'`,
+      [decoded.sub]
+    );
+
+    if (!supplierResult.rows[0]) {
+      res.status(401).json({ error: { code: 'USER_NOT_FOUND', message: 'Supplier not found or inactive' } });
+      return;
+    }
+
+    const supplier = supplierResult.rows[0];
+
+    // Generate new access token
+    const newJti = randomUUID();
+    const jwtPayload = {
+      sub: supplier.id,
+      actorType: 'SUPPLIER',
+      actorId: supplier.id,
+      email: supplier.primary_email,
+      phone: supplier.primary_phone,
+      permissions: ['supplier:read', 'supplier:write', 'products:read', 'products:write'],
+      jti: newJti,
+    };
+
+    const accessToken = jwt.sign(jwtPayload, JWT_SECRET, {
+      issuer: JWT_ISSUER,
+      expiresIn: JWT_EXPIRES_IN,
+    });
+
+    // AUTH-SESSION-169: Refresh cookies
+    setAuthCookies(res, accessToken, refreshToken, 86400, 7 * 86400);
+
+    res.json({
+      success: true,
+      data: {
+        accessToken,
+        expiresIn: 86400,
+        tokenType: 'Bearer',
       },
     });
   } catch (error) {

--- a/backend/src/utils/authCookies.ts
+++ b/backend/src/utils/authCookies.ts
@@ -1,0 +1,106 @@
+// AUTH-SESSION-169: Shared cookie utility for auth session persistence
+// Sets HttpOnly cookies on login/refresh responses so frontend can maintain
+// session across page refreshes (sm_auth indicator + sm_access_token + sm_refresh_token)
+//
+// Mirrors backend/services/auth-service/src/utils/cookies.ts but for the main backend routes.
+
+import { Response, Request } from 'express';
+
+// Cookie names (must match frontend hasAuthCookie() check)
+const ACCESS_TOKEN_COOKIE = 'sm_access_token';
+const REFRESH_TOKEN_COOKIE = 'sm_refresh_token';
+const AUTH_INDICATOR_COOKIE = 'sm_auth'; // Non-HttpOnly, readable by JS
+
+interface CookieConfig {
+  secure: boolean;
+  domain?: string;
+  sameSite: 'lax' | 'strict' | 'none';
+}
+
+function getCookieConfig(): CookieConfig {
+  const isProduction = process.env.NODE_ENV === 'production';
+  return {
+    secure: isProduction || process.env.COOKIE_SECURE === 'true',
+    domain: process.env.COOKIE_DOMAIN || undefined,
+    sameSite: 'lax',
+  };
+}
+
+/**
+ * Set HttpOnly auth cookies on the response.
+ * Called after successful login or token refresh.
+ */
+export function setAuthCookies(
+  res: Response,
+  accessToken: string,
+  refreshToken: string,
+  accessTokenMaxAgeSec: number,
+  refreshTokenMaxAgeSec: number,
+): void {
+  const cfg = getCookieConfig();
+
+  // Access token - HttpOnly (JS can't read), sent on all /api requests
+  res.cookie(ACCESS_TOKEN_COOKIE, accessToken, {
+    httpOnly: true,
+    secure: cfg.secure,
+    sameSite: cfg.sameSite,
+    domain: cfg.domain,
+    path: '/api',
+    maxAge: accessTokenMaxAgeSec * 1000,
+  });
+
+  // Refresh token - HttpOnly, sent on all /api requests
+  res.cookie(REFRESH_TOKEN_COOKIE, refreshToken, {
+    httpOnly: true,
+    secure: cfg.secure,
+    sameSite: cfg.sameSite,
+    domain: cfg.domain,
+    path: '/api',
+    maxAge: refreshTokenMaxAgeSec * 1000,
+  });
+
+  // Auth indicator - NOT HttpOnly, JS can check document.cookie for auth state
+  res.cookie(AUTH_INDICATOR_COOKIE, '1', {
+    httpOnly: false,
+    secure: cfg.secure,
+    sameSite: cfg.sameSite,
+    domain: cfg.domain,
+    path: '/',
+    maxAge: refreshTokenMaxAgeSec * 1000,
+  });
+}
+
+/**
+ * Clear all auth cookies on the response.
+ * Called on logout.
+ */
+export function clearAuthCookies(res: Response): void {
+  const cfg = getCookieConfig();
+  const base = {
+    secure: cfg.secure,
+    sameSite: cfg.sameSite as boolean | 'lax' | 'strict' | 'none',
+    domain: cfg.domain,
+  };
+
+  res.clearCookie(ACCESS_TOKEN_COOKIE, { ...base, path: '/api' });
+  res.clearCookie(REFRESH_TOKEN_COOKIE, { ...base, path: '/api' });
+  res.clearCookie(AUTH_INDICATOR_COOKIE, { ...base, path: '/' });
+}
+
+/**
+ * Extract refresh token from request.
+ * Prefers body (backward compatible with POS app), falls back to cookie.
+ */
+export function getRefreshTokenFromRequest(req: Request): string | undefined {
+  // Prefer body (explicit, backward compatible)
+  if (req.body?.refreshToken) {
+    return req.body.refreshToken;
+  }
+
+  // Fall back to cookie
+  const cookieHeader = req.headers.cookie;
+  if (!cookieHeader) return undefined;
+
+  const match = cookieHeader.match(/(?:^|;\s*)sm_refresh_token=([^;]*)/);
+  return match && match[1] ? decodeURIComponent(match[1]) : undefined;
+}

--- a/retailer-admin/nginx-local-prod.conf
+++ b/retailer-admin/nginx-local-prod.conf
@@ -8,6 +8,10 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # AUTH-SESSION-169: Behind HTTPS-terminating LB, nginx sees HTTP and generates
+    # Location: http://host/path/ on redirects. Use relative redirects instead.
+    absolute_redirect off;
+
     # URL-001: Security headers for all responses
     # CSP-RECAPTCHA-001: script-src and frame-src include https://www.google.com
     # for Firebase Phone Auth invisible reCAPTCHA verification

--- a/retailer-admin/src/lib/AuthContext.tsx
+++ b/retailer-admin/src/lib/AuthContext.tsx
@@ -334,12 +334,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const checkAndRefresh = async () => {
       const expiresAt = tokenExpiresAtRef.current;
 
-      // If no known expiry (e.g., page refresh), refresh immediately to get fresh token
+      // AUTH-SESSION-169: If no known expiry (e.g., page refresh), try refresh but don't
+      // immediately logout on failure — the user may have just logged in and the expiry
+      // ref hasn't been set yet. Only logout if we also don't have an auth cookie.
       if (!expiresAt || expiresAt === 0) {
         console.log('[Auth] No known token expiry, refreshing to get fresh token...');
         const success = await refreshAccessToken();
-        if (!success) {
-          console.warn('[Auth] Initial token refresh failed');
+        if (!success && !hasAuthCookie()) {
+          console.warn('[Auth] Token refresh failed and no auth cookie — logging out');
           logout();
         }
         return;

--- a/supermandi-superadmin/nginx-local-prod.conf
+++ b/supermandi-superadmin/nginx-local-prod.conf
@@ -8,6 +8,10 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # AUTH-SESSION-169: Behind HTTPS-terminating LB, nginx sees HTTP and generates
+    # Location: http://host/path/ on redirects. Use relative redirects instead.
+    absolute_redirect off;
+
     # URL-001: Security headers for all responses
     add_header X-Frame-Options "DENY" always;
     add_header X-Content-Type-Options "nosniff" always;

--- a/supplier-portal/next.config.js
+++ b/supplier-portal/next.config.js
@@ -1,14 +1,20 @@
 /** @type {import('next').NextConfig} */
 
 // GO-LIVE-SOP: Get build info for cache-proof deployment verification
+// AUTH-SESSION-169: Check NEXT_PUBLIC_GIT_SHA env var first (set by CI), fallback to git
 function getBuildInfo() {
   try {
+    const envSha = process.env.NEXT_PUBLIC_GIT_SHA;
+    if (envSha && envSha !== 'unknown') {
+      const time = new Date().toLocaleString('en-IN', { timeZone: 'Asia/Kolkata' }).replace(',', '');
+      return { sha: envSha, time };
+    }
     const { execSync } = require('child_process');
     const sha = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
     const time = new Date().toLocaleString('en-IN', { timeZone: 'Asia/Kolkata' }).replace(',', '');
     return { sha, time };
   } catch {
-    return { sha: 'unknown', time: new Date().toISOString() };
+    return { sha: process.env.NEXT_PUBLIC_GIT_SHA || 'unknown', time: new Date().toISOString() };
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the **retailer login loop** (user logs in → sees "Welcome back" → immediately asked to log in again) and 6 other auth/session issues discovered during comprehensive staging browser testing.

### Root Cause
Backend login routes returned JWT tokens in the response body but **never set HttpOnly cookies**. The frontend's `hasAuthCookie()` check always returned `false`, causing auth state to be cleared on every page refresh or navigation.

### Changes

**Backend (3 files)**
- New `authCookies.ts` utility: `setAuthCookies()`, `clearAuthCookies()`, `getRefreshTokenFromRequest()`
- Retailer `firebase-otp-login`: sets `sm_access_token` + `sm_refresh_token` + `sm_auth` cookies
- Retailer `auth/refresh`: reads refresh token from cookie (was body-only, breaking web portals)
- Retailer `auth/logout`: clears cookies
- Supplier `firebase-login` + `auth/login`: both now set cookies + generate refresh tokens
- Supplier `auth/refresh`: **new route** (previously returned 404)
- Supplier `auth/logout`: clears cookies

**Frontend (2 files)**
- Retailer `AuthContext.tsx`: fixed token refresh race condition — don't logout if `sm_auth` cookie still exists
- Supplier `next.config.js`: check `NEXT_PUBLIC_GIT_SHA` env var before `git` (fixes "unknown" SHA in CI builds)

**Nginx (2 files)**
- Retailer + SuperAdmin: added `absolute_redirect off;` — fixes `Location: http://` redirects when behind HTTPS-terminating load balancer

## Test plan

- [ ] CI passes (typecheck, lint, build for all services)
- [ ] Retailer login flow: phone → OTP → "Welcome back" → stays on dashboard (no loop)
- [ ] Retailer page refresh: stays authenticated (cookie persists)
- [ ] Retailer logout: clears cookies, returns to login
- [ ] Supplier login flow: email/password → dashboard (stays authenticated)
- [ ] Supplier Firebase login: phone → OTP → dashboard (stays authenticated)
- [ ] Supplier token refresh: `POST /api/v1/supplier/auth/refresh` returns 200 (was 404)
- [ ] Trailing slash redirect: `GET /retailer` → `Location: /retailer/` (relative, not `http://`)
- [ ] Trailing slash redirect: `GET /admin` → `Location: /admin/` (relative, not `http://`)
- [ ] Supplier build version page shows commit SHA (not "unknown")

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)