### PR TITLE
fix(FIX-002): graceful degradation for missing Razorpay env vars

### DIFF
--- a/backend/services/payment-service/src/config.ts
+++ b/backend/services/payment-service/src/config.ts
@@ -1,6 +1,8 @@
 // Payment Service Configuration
 // SM-004: Environment config for Razorpay integration
-// ENV-FAILFAST-001: Crash in production if required env vars are missing
+// FIX-002: Razorpay vars use graceful degradation (warn + disable), not process.exit().
+//   Core POS must run even when Razorpay is not configured.
+//   DATABASE_URL still crashes in production (no fallback possible).
 
 const IS_PROD = process.env['NODE_ENV'] === 'production';
 
@@ -12,6 +14,8 @@ export interface PaymentConfig {
     keySecret: string;
     accountNumber: string;
     webhookSecret: string;
+    /** true when all 3 required Razorpay keys are present */
+    configured: boolean;
   };
   database: {
     connectionString: string;
@@ -27,7 +31,7 @@ function getEnvIntOrDefault(key: string, defaultValue: number): number {
   return value ? parseInt(value, 10) : defaultValue;
 }
 
-/** ENV-FAILFAST-001: Require env var in production; use dev default otherwise */
+/** Require env var in production; use dev default otherwise. Crashes on missing. */
 function requireEnv(key: string, devDefault: string): string {
   const value = process.env[key];
   if (value) return value;
@@ -38,18 +42,37 @@ function requireEnv(key: string, devDefault: string): string {
   return devDefault;
 }
 
+const razorpayKeyId = getEnvOrDefault('RAZORPAY_KEY_ID', '');
+const razorpayKeySecret = getEnvOrDefault('RAZORPAY_KEY_SECRET', '');
+const razorpayAccountNumber = getEnvOrDefault('RAZORPAY_ACCOUNT_NUMBER', '');
+const razorpayConfigured = !!(razorpayKeyId && razorpayKeySecret && razorpayAccountNumber);
+
+// FIX-002: Log clear startup warning instead of crashing
+if (!razorpayConfigured) {
+  const missing = [
+    !razorpayKeyId && 'RAZORPAY_KEY_ID',
+    !razorpayKeySecret && 'RAZORPAY_KEY_SECRET',
+    !razorpayAccountNumber && 'RAZORPAY_ACCOUNT_NUMBER',
+  ].filter(Boolean);
+  console.warn(
+    `[payment-service] WARNING: Razorpay not configured (missing: ${missing.join(', ')}). ` +
+    `UPI payments, payouts, and webhook verification are DISABLED. ` +
+    `Core POS (scan, checkout, cash) will work normally.`
+  );
+}
+
 export const config: PaymentConfig = {
   // CR-HEALTH-001: Cloud Run sets PORT; fall back to service-specific var
   port: parseInt(process.env['PORT'] || '') || getEnvIntOrDefault('PAYMENT_SERVICE_PORT', 3011),
   env: getEnvOrDefault('NODE_ENV', 'development'),
-  // ENV-FAILFAST-001: Razorpay keys are CRITICAL in production
   razorpay: {
-    keyId: requireEnv('RAZORPAY_KEY_ID', ''),
-    keySecret: requireEnv('RAZORPAY_KEY_SECRET', ''),
-    accountNumber: requireEnv('RAZORPAY_ACCOUNT_NUMBER', ''),
+    keyId: razorpayKeyId,
+    keySecret: razorpayKeySecret,
+    accountNumber: razorpayAccountNumber,
     webhookSecret: getEnvOrDefault('RAZORPAY_WEBHOOK_SECRET', ''),
+    configured: razorpayConfigured,
   },
-  // ENV-FAILFAST-001: DATABASE_URL required in production
+  // DATABASE_URL is truly critical — no service can run without it
   database: {
     connectionString: requireEnv(
       'DATABASE_URL',

--- a/backend/services/payment-service/src/index.ts
+++ b/backend/services/payment-service/src/index.ts
@@ -44,7 +44,7 @@ const startServer = async () => {
     app.listen(config.port, () => {
       console.log(`Payment service running on port ${config.port}`);
       console.log(`Environment: ${config.env}`);
-      console.log(`Razorpay configured: ${config.razorpay.keyId ? 'yes' : 'no'}`);
+      console.log(`Razorpay configured: ${config.razorpay.configured ? 'yes' : 'no'}`);
     });
   } catch (error) {
     console.error('Failed to start payment service:', error);

--- a/backend/services/payment-service/src/services/razorpayClient.ts
+++ b/backend/services/payment-service/src/services/razorpayClient.ts
@@ -14,6 +14,9 @@ const RAZORPAY_API_BASE = 'https://api.razorpay.com/v1';
  * Pattern matches supplierPayoutService.ts for consistency.
  */
 async function razorpayXFetch<T>(endpoint: string, body: Record<string, unknown>): Promise<T> {
+  if (!config.razorpay.configured) {
+    throw new Error('Razorpay credentials not configured — UPI payment features are disabled');
+  }
   const auth = Buffer.from(`${config.razorpay.keyId}:${config.razorpay.keySecret}`).toString('base64');
 
   const response = await fetch(`${RAZORPAY_API_BASE}${endpoint}`, {
@@ -41,11 +44,12 @@ let razorpayInstance: Razorpay | null = null;
 
 /**
  * Get Razorpay instance (lazy initialization)
+ * FIX-002: Throws descriptive error when Razorpay is not configured
  */
 function getRazorpay(): Razorpay {
   if (!razorpayInstance) {
-    if (!config.razorpay.keyId || !config.razorpay.keySecret) {
-      throw new Error('Razorpay credentials not configured');
+    if (!config.razorpay.configured) {
+      throw new Error('Razorpay credentials not configured — UPI payment features are disabled');
     }
     razorpayInstance = new Razorpay({
       key_id: config.razorpay.keyId,
@@ -60,13 +64,10 @@ function getRazorpay(): Razorpay {
  */
 export async function checkRazorpayConnection(): Promise<boolean> {
   try {
-    if (!config.razorpay.keyId || !config.razorpay.keySecret) {
+    if (!config.razorpay.configured) {
       return false;
     }
-    // Try to fetch account details to verify connection
     const rp = getRazorpay();
-    // Note: In production, we'd call an actual API to verify
-    // For now, we just check credentials are present
     return !!rp;
   } catch (error) {
     console.error('[RazorpayClient] Connection check failed:', error);


### PR DESCRIPTION
## Summary
- Replace `process.exit(1)` in payment-service config with startup warning + feature-gate
- Core POS (scan, checkout, cash) runs normally without Razorpay keys
- Add `razorpay.configured` flag for clean runtime checks

## Changes
- `backend/services/payment-service/src/config.ts` — `requireEnv` → `getEnvOrDefault` for RAZORPAY_* vars, add `configured` flag
- `backend/services/payment-service/src/services/razorpayClient.ts` — use `config.razorpay.configured`
- `backend/services/payment-service/src/index.ts` — use `configured` flag in startup log

## Test plan
- [ ] Service starts without RAZORPAY_* env vars (no crash)
- [ ] Startup log shows clear warning about disabled UPI features
- [ ] Core POS endpoints (scan, checkout, cash) unaffected
- [ ] UPI endpoints return descriptive error when called without config

🤖 Generated with [Claude Code](https://claude.com/claude-code)