### PR TITLE
fix(FIX-004): Validate VITE_API_BASE_URL at build time

### DIFF
--- a/retailer-admin/vite.config.ts
+++ b/retailer-admin/vite.config.ts
@@ -42,28 +42,39 @@ function versionPlugin(): Plugin {
   };
 }
 
-export default defineConfig({
-  plugins: [react(), versionPlugin()],
-  base: '/retailer/',
-  // GO-LIVE-SOP: Inject build info at compile time
-  define: {
-    'import.meta.env.VITE_BUILD_SHA': JSON.stringify(buildInfo.sha),
-    'import.meta.env.VITE_BUILD_TIME': JSON.stringify(buildInfo.time),
-  },
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: true,
+export default defineConfig(({ command }) => {
+  // FIX-004: Fail build when VITE_API_BASE_URL is not explicitly set
+  // Empty string is valid (load-balancer relative paths). Undefined = misconfigured build.
+  if (command === 'build' && process.env.VITE_API_BASE_URL === undefined) {
+    throw new Error(
+      '[FIX-004] VITE_API_BASE_URL must be explicitly set for production builds. ' +
+      'Set VITE_API_BASE_URL="" for load-balancer relative paths, or provide a full URL.'
+    );
+  }
+
+  return {
+    plugins: [react(), versionPlugin()],
+    base: '/retailer/',
+    // GO-LIVE-SOP: Inject build info at compile time
+    define: {
+      'import.meta.env.VITE_BUILD_SHA': JSON.stringify(buildInfo.sha),
+      'import.meta.env.VITE_BUILD_TIME': JSON.stringify(buildInfo.time),
+    },
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:3000',
+          changeOrigin: true,
+        },
       },
     },
-  },
-  esbuild: {
-    drop: ['console', 'debugger'],
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: false,
-  },
+    esbuild: {
+      drop: ['console', 'debugger'],
+    },
+    build: {
+      outDir: 'dist',
+      sourcemap: false,
+    },
+  };
 });

--- a/supermandi-superadmin/vite.config.ts
+++ b/supermandi-superadmin/vite.config.ts
@@ -19,15 +19,26 @@ function getBuildInfo() {
 const buildInfo = getBuildInfo();
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  base: '/admin/',
-  // GO-LIVE-SOP: Inject build info at compile time
-  define: {
-    'import.meta.env.VITE_BUILD_SHA': JSON.stringify(buildInfo.sha),
-    'import.meta.env.VITE_BUILD_TIME': JSON.stringify(buildInfo.time),
-  },
-  esbuild: {
-    drop: ['console', 'debugger'],
-  },
+export default defineConfig(({ command }) => {
+  // FIX-004: Fail build when VITE_API_BASE_URL is not explicitly set
+  // Empty string is valid (load-balancer relative paths). Undefined = misconfigured build.
+  if (command === 'build' && process.env.VITE_API_BASE_URL === undefined) {
+    throw new Error(
+      '[FIX-004] VITE_API_BASE_URL must be explicitly set for production builds. ' +
+      'Set VITE_API_BASE_URL="" for load-balancer relative paths, or provide a full URL.'
+    );
+  }
+
+  return {
+    plugins: [react()],
+    base: '/admin/',
+    // GO-LIVE-SOP: Inject build info at compile time
+    define: {
+      'import.meta.env.VITE_BUILD_SHA': JSON.stringify(buildInfo.sha),
+      'import.meta.env.VITE_BUILD_TIME': JSON.stringify(buildInfo.time),
+    },
+    esbuild: {
+      drop: ['console', 'debugger'],
+    },
+  };
 })

--- a/supplier-portal/next.config.js
+++ b/supplier-portal/next.config.js
@@ -20,6 +20,16 @@ function getBuildInfo() {
 
 const buildInfo = getBuildInfo();
 
+// FIX-004: Fail build when NEXT_PUBLIC_API_BASE_URL is not explicitly set
+// Empty string is valid (load-balancer relative paths). Undefined = misconfigured build.
+const isNextBuild = process.argv.some(arg => arg === 'build');
+if (isNextBuild && process.env.NEXT_PUBLIC_API_BASE_URL === undefined) {
+  throw new Error(
+    '[FIX-004] NEXT_PUBLIC_API_BASE_URL must be explicitly set for production builds. ' +
+    'Set NEXT_PUBLIC_API_BASE_URL="" for load-balancer relative paths, or provide a full URL.'
+  );
+}
+
 const nextConfig = {
   // CONSOLE-STRIP-001: Strip console.log/debug from production builds (keep error+warn)
   compiler: {


### PR DESCRIPTION
## Summary
- Retailer-admin + SuperAdmin: Convert `defineConfig` to function form, throw error if `VITE_API_BASE_URL` is undefined during `vite build`
- Supplier-portal: Check `NEXT_PUBLIC_API_BASE_URL` before `next build`
- Empty string `""` is valid (load-balancer relative paths). Truly undefined = misconfigured build → build fails with clear error message

## Files Changed
- `retailer-admin/vite.config.ts`
- `supermandi-superadmin/vite.config.ts`
- `supplier-portal/next.config.js`

## Test Plan
- [ ] `pnpm -r build` without env var set → fails with `[FIX-004]` error
- [ ] `VITE_API_BASE_URL="" pnpm -r build` → succeeds
- [ ] Docker builds unaffected (Dockerfiles set `ARG/ENV` defaults)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>