### PR TITLE
fix(FIX-005,FIX-006): Store isolation for UPDATE/DELETE queries

### DIFF
--- a/backend/services/catalog-service/src/routes/mapping.ts
+++ b/backend/services/catalog-service/src/routes/mapping.ts
@@ -216,12 +216,13 @@ router.post(
   requireStoreAccess,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      const { mapId } = req.params;
+      const { storeId, mapId } = req.params;
 
       // Get user ID from request (if authenticated)
       const userId = (req as Request & { userId?: string }).userId;
 
-      const mapping = await verifyMapping(mapId, userId);
+      // FIX-005: Pass storeId for store ownership verification
+      const mapping = await verifyMapping(mapId, userId, storeId);
 
       res.json({
         success: true,

--- a/backend/services/catalog-service/src/services/mappingService.ts
+++ b/backend/services/catalog-service/src/services/mappingService.ts
@@ -486,10 +486,17 @@ export async function deleteMapping(input: DeleteMappingInput): Promise<void> {
       [storeId, mapping.supplier_id, mapping.supplier_product_id, mapping.product_id, userId]
     );
 
-    // Delete the mapping
+    // FIX-006: Delete with store ownership verification (defense-in-depth)
+    // The SELECT above already validated ownership, but the DELETE also checks via JOIN
     await client.query(
-      `DELETE FROM catalog.supplier_product_map WHERE id = $1`,
-      [mapId]
+      `DELETE FROM catalog.supplier_product_map spm
+       USING catalog.supplier_products sp
+       JOIN supplier.supplier_store_links ssl ON ssl.supplier_id = sp.supplier_id
+       WHERE spm.id = $1
+         AND spm.supplier_product_id = sp.id
+         AND ssl.store_id = $2
+         AND ssl.status = 'active'`,
+      [mapId, storeId]
     );
 
     await client.query('COMMIT');
@@ -641,22 +648,28 @@ export async function getMappingById(
  */
 export async function verifyMapping(
   mapId: string,
-  userId?: string
+  userId?: string,
+  storeId?: string
 ): Promise<SupplierProductMap> {
   if (!mapId) {
     throw new ApiError(400, ERROR_CODES.VALIDATION_ERROR, 'mapId is required');
   }
 
+  // FIX-005: store_id isolation — verify ownership through supplier_store_links chain
   const result = await query<MappingRow>(
-    `UPDATE catalog.supplier_product_map
-     SET is_verified = true, mapped_by_user_id = COALESCE($2, mapped_by_user_id), updated_at = NOW()
-     WHERE id = $1
-     RETURNING *`,
-    [mapId, userId]
+    `UPDATE catalog.supplier_product_map spm
+     SET is_verified = true, mapped_by_user_id = COALESCE($2, spm.mapped_by_user_id), updated_at = NOW()
+     FROM catalog.supplier_products sp
+     JOIN supplier.supplier_store_links ssl ON ssl.supplier_id = sp.supplier_id
+     WHERE spm.id = $1
+       AND spm.supplier_product_id = sp.id
+       AND ($3::uuid IS NULL OR (ssl.store_id = $3 AND ssl.status = 'active'))
+     RETURNING spm.*`,
+    [mapId, userId, storeId || null]
   );
 
   if (result.length === 0) {
-    throw new ApiError(404, ERROR_CODES.NOT_FOUND, 'Mapping not found');
+    throw new ApiError(404, ERROR_CODES.NOT_FOUND, 'Mapping not found or not accessible by this store');
   }
 
   const row = result[0]!;

--- a/backend/services/platform-service/src/routes/retailerPortal.ts
+++ b/backend/services/platform-service/src/routes/retailerPortal.ts
@@ -858,7 +858,7 @@ router.post(
       supplierVerified = true;
 
       // Update store_product with verified supplier_id using shared service
-      await linkSupplierToStoreProduct(storeProductId, supplierId);
+      await linkSupplierToStoreProduct(storeProductId, supplierId, storeId);
 
       // Create supplier-product link using shared service
       await createSupplierProductLink(supplierId, name, brand || null, purchasePrice);
@@ -874,13 +874,13 @@ router.post(
         // Found verified supplier - link it using shared service
         supplierLinked = true;
         supplierVerified = true;
-        await linkSupplierToStoreProduct(storeProductId, matchingSupplier.id);
+        await linkSupplierToStoreProduct(storeProductId, matchingSupplier.id, storeId);
       } else {
         // No verified supplier found - create pending enrollment request using shared service
         pendingSupplierRequestId = await createPendingSupplierRequest(storeId, supplierNameRaw);
 
         // Store raw name and pending request ID using shared service
-        await storeUnverifiedSupplierInfo(storeProductId, supplierNameRaw, pendingSupplierRequestId);
+        await storeUnverifiedSupplierInfo(storeProductId, supplierNameRaw, pendingSupplierRequestId, storeId);
 
         supplierLinked = false;
         supplierVerified = false;

--- a/backend/services/platform-service/src/services/retailerCatalogService.ts
+++ b/backend/services/platform-service/src/services/retailerCatalogService.ts
@@ -306,12 +306,17 @@ export async function updateStoreProductStock(
  */
 export async function linkSupplierToStoreProduct(
   storeProductId: string,
-  supplierId: string
+  supplierId: string,
+  storeId: string
 ): Promise<void> {
-  await query(
-    `UPDATE catalog.store_products SET supplier_id = $1 WHERE id = $2`,
-    [supplierId, storeProductId]
+  // FIX-005: store_id isolation — prevent cross-store supplier linking
+  const result = await query(
+    `UPDATE catalog.store_products SET supplier_id = $1 WHERE id = $2 AND store_id = $3`,
+    [supplierId, storeProductId, storeId]
   );
+  if ((result as unknown as { rowCount: number }).rowCount === 0) {
+    throw new Error('Store product not found or does not belong to this store');
+  }
 }
 
 /**
@@ -320,14 +325,19 @@ export async function linkSupplierToStoreProduct(
 export async function storeUnverifiedSupplierInfo(
   storeProductId: string,
   supplierNameRaw: string,
-  pendingSupplierRequestId: string | null
+  pendingSupplierRequestId: string | null,
+  storeId: string
 ): Promise<void> {
-  await query(
+  // FIX-005: store_id isolation — prevent cross-store unverified supplier info corruption
+  const result = await query(
     `UPDATE catalog.store_products
      SET supplier_name_raw = $1, pending_supplier_request_id = $2
-     WHERE id = $3`,
-    [supplierNameRaw, pendingSupplierRequestId, storeProductId]
+     WHERE id = $3 AND store_id = $4`,
+    [supplierNameRaw, pendingSupplierRequestId, storeProductId, storeId]
   );
+  if ((result as unknown as { rowCount: number }).rowCount === 0) {
+    throw new Error('Store product not found or does not belong to this store');
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
- **FIX-005**: `linkSupplierToStoreProduct` and `storeUnverifiedSupplierInfo` now require `storeId` with `AND store_id` in WHERE clause. `verifyMapping` validates ownership via supplier_store_links JOIN chain.
- **FIX-006**: `deleteMappingAndLogUnmap` DELETE now includes store ownership JOIN (defense-in-depth alongside existing SELECT check).

## Risk
P0 security fix — prevents cross-store data corruption via forged product IDs.

## Files Changed
- `backend/services/platform-service/src/services/retailerCatalogService.ts`
- `backend/services/platform-service/src/routes/retailerPortal.ts`
- `backend/services/catalog-service/src/services/mappingService.ts`
- `backend/services/catalog-service/src/routes/mapping.ts`

## Test Plan
- [ ] Cross-store UPDATE returns error (not silently succeeds)
- [ ] Cross-store DELETE returns 404 (mapping not found)
- [ ] Same-store operations work normally

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>