### PR TITLE
fix(FIX-008): Require idempotency key on GRN receive

### DIFF
--- a/backend/services/order-service/src/routes/receive.ts
+++ b/backend/services/order-service/src/routes/receive.ts
@@ -3,7 +3,7 @@
 
 import { Router, Request, Response, NextFunction } from 'express';
 import type { Router as RouterType } from 'express';
-import { ApiError, ERROR_CODES } from '@supermandi/common';
+import { ApiError, ERROR_CODES, createIdempotencyMiddleware } from '@supermandi/common';
 import {
   receiveGoods,
   getReceiveRecords,
@@ -41,6 +41,8 @@ interface ReceiveGoodsBody {
  */
 router.post(
   '/stores/:storeId/orders/:orderId/receive',
+  // FIX-008: Require idempotency key to prevent duplicate stock entries on retry
+  createIdempotencyMiddleware({ required: true }),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { storeId, orderId } = req.params;


### PR DESCRIPTION
## Summary
- GRN receive endpoint (`POST /stores/:storeId/orders/:orderId/receive`) now requires `X-Idempotency-Key` header
- Missing header returns 400; duplicate key returns 409 with cached response
- Prevents duplicate stock entries when client retries failed/timed-out requests

## Files Changed
- `backend/services/order-service/src/routes/receive.ts`

## Test Plan
- [ ] Request without X-Idempotency-Key → 400 MISSING_IDEMPOTENCY_KEY
- [ ] Duplicate request with same key + body → 409 with cached response
- [ ] Duplicate request with same key + different body → 409 IDEMPOTENCY_CONFLICT

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>