### PR TITLE
fix(FIX-011): Add index on refresh_tokens.token_hash

### DIFF
--- a/backend/migrations/157_fix011_refresh_token_hash_index.sql
+++ b/backend/migrations/157_fix011_refresh_token_hash_index.sql
@@ -1,0 +1,12 @@
+-- FIX-011: Add index on refresh_tokens.token_hash for fast token lookups
+-- findRefreshTokenByHash queries on every token refresh (high frequency)
+-- Without index: full table scan. With index: O(log n) lookup.
+-- Partial index excludes revoked tokens (matching query's WHERE clause).
+
+BEGIN;
+
+CREATE INDEX IF NOT EXISTS idx_refresh_tokens_hash
+  ON auth.refresh_tokens(token_hash)
+  WHERE revoked_at IS NULL;
+
+COMMIT;


### PR DESCRIPTION
## Summary
- Add partial index on `auth.refresh_tokens(token_hash) WHERE revoked_at IS NULL`
- Speeds up `findRefreshTokenByHash` from full table scan to O(log n) lookup

## Files Changed
- `backend/migrations/157_fix011_refresh_token_hash_index.sql` (new)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>