### PR TITLE
fix(FIX-012): Add LIMIT 500 to catalog categories query

### DIFF
--- a/backend/services/catalog-service/src/routes/catalog.ts
+++ b/backend/services/catalog-service/src/routes/catalog.ts
@@ -126,15 +126,19 @@ router.get(
           AND s.verification_status = 'verified'
           AND sp.approval_status = 'approved'
         ORDER BY p.category ASC
+        LIMIT 501
       `;
 
       const rows = await query<{ category: string }>(categoriesSql, [storeId]);
-      const categories = rows.map((r) => r.category);
+      // FIX-012: Cap at 500 and flag truncation to prevent memory issues
+      const truncated = rows.length > 500;
+      const categories = rows.slice(0, 500).map((r) => r.category);
 
       res.json({
         success: true,
         data: categories,
         count: categories.length,
+        truncated,
       });
     } catch (error) {
       next(error);


### PR DESCRIPTION
## Summary
- Add `LIMIT 501` to unbounded DISTINCT categories query
- Cap results at 500, return `truncated: true` if more exist
- Prevents memory issues from malicious/large category data

## Files Changed
- `backend/services/catalog-service/src/routes/catalog.ts`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>