### PR TITLE
fix(FIX-013): Fix toFixed paisa-to-rupees display in error msg

### DIFF
--- a/backend/services/order-service/src/services/purchaseOrderService.ts
+++ b/backend/services/order-service/src/services/purchaseOrderService.ts
@@ -146,7 +146,7 @@ export async function createPurchaseOrderFromCart(
       throw new ApiError(
         400,
         ERROR_CODES.VALIDATION_ERROR,
-        `Order total ${orderTotal.toFixed(2)} is below minimum order value ${minOrderValue.toFixed(2)} for this supplier`
+        `Order total ₹${(orderTotal / 100).toFixed(2)} is below minimum order value ₹${(minOrderValue / 100).toFixed(2)} for this supplier`
       );
     }
   }


### PR DESCRIPTION
## Summary
- Convert paisa (integer) to rupees before `toFixed(2)` in min order value error message
- Calculations remain integer arithmetic — only display string affected

## Files Changed
- `backend/services/order-service/src/services/purchaseOrderService.ts`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>