### PR TITLE
fix(FIX-014): Replace empty catch blocks with logging

### DIFF
--- a/backend/services/catalog-service/src/cache/redis.ts
+++ b/backend/services/catalog-service/src/cache/redis.ts
@@ -170,7 +170,10 @@ export async function cacheGetOrSet<T>(
   const value = await fetchFn();
 
   // Store in cache (fire and forget)
-  cacheSet(namespace, key, value, ttlSeconds).catch(() => {});
+  // FIX-014: Log cache write failures instead of silently swallowing
+  cacheSet(namespace, key, value, ttlSeconds).catch((err) => {
+    console.warn(`[cache] Failed to set ${namespace}:${key}:`, err?.message || err);
+  });
 
   return value;
 }

--- a/backend/services/platform-service/src/services/retailerCatalogService.ts
+++ b/backend/services/platform-service/src/services/retailerCatalogService.ts
@@ -441,7 +441,8 @@ export async function createSupplierProductLink(
      VALUES ($1, $2, NULL, $3, $4, true)
      ON CONFLICT DO NOTHING`,
     [supplierId, name, brand, purchasePrice]
-  ).catch(() => {
-    // Table might not exist yet, silently ignore
+  ).catch((err) => {
+    // FIX-014: Log instead of silently swallowing — helps debug catalog issues
+    console.warn('[retailerCatalogService] createSupplierProductLink failed:', err?.message || err);
   });
 }


### PR DESCRIPTION
## Summary
- Replace `.catch(() => {})` with `.catch((err) => console.warn(...))` in catalog-service and platform-service
- Aids production debugging by logging cache failures and DB operation errors

## Files Changed
- `backend/services/catalog-service/src/cache/redis.ts`
- `backend/services/platform-service/src/services/retailerCatalogService.ts`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>