### PR TITLE
fix(FIX-010): Add per-supplier rate limiting to product endpoints

### DIFF
--- a/backend/services/supplier-service/src/routes/products.ts
+++ b/backend/services/supplier-service/src/routes/products.ts
@@ -30,6 +30,37 @@ const upload = multer({
 const router: RouterType = Router();
 
 // =============================================================================
+// FIX-010: Per-supplier rate limiting
+// =============================================================================
+
+function supplierRateLimit(opts: { windowMs: number; max: number; label: string }) {
+  const hits = new Map<string, number[]>();
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    const supplierId = (req as AuthenticatedRequest).supplier?.supplierId;
+    if (!supplierId) { next(); return; }
+
+    const now = Date.now();
+    const arr = (hits.get(supplierId) ?? []).filter(t => now - t < opts.windowMs);
+    arr.push(now);
+    hits.set(supplierId, arr);
+
+    if (arr.length > opts.max) {
+      const retryAfter = Math.ceil(opts.windowMs / 1000);
+      res.set('Retry-After', String(retryAfter));
+      res.status(429).json({
+        error: { code: 'RATE_LIMIT_EXCEEDED', message: `${opts.label}: max ${opts.max} requests per ${retryAfter}s` },
+      });
+      return;
+    }
+    next();
+  };
+}
+
+const csvUploadLimit = supplierRateLimit({ windowMs: 60 * 60 * 1000, max: 5, label: 'CSV upload' });
+const productCrudLimit = supplierRateLimit({ windowMs: 60 * 1000, max: 60, label: 'Product CRUD' });
+
+// =============================================================================
 // TYPES
 // =============================================================================
 
@@ -85,6 +116,7 @@ interface SupplierProductRow {
 router.post(
   '/products',
   supplierAuth,
+  productCrudLimit,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { supplier } = req as AuthenticatedRequest;
@@ -321,6 +353,7 @@ router.get(
 router.put(
   '/products/:productId',
   supplierAuth,
+  productCrudLimit,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { supplier } = req as AuthenticatedRequest;
@@ -444,6 +477,7 @@ router.put(
 router.patch(
   '/products/:productId/stock',
   supplierAuth,
+  productCrudLimit,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const { supplier } = req as AuthenticatedRequest;
@@ -510,6 +544,7 @@ interface CsvError {
 router.post(
   '/products/csv-upload',
   supplierAuth,
+  csvUploadLimit,
   upload.single('file'),
   async (req: Request, res: Response, next: NextFunction) => {
     try {


### PR DESCRIPTION
## Summary
- CSV upload: max 5/hour per supplier
- Product CRUD (POST, PUT, PATCH): max 60/min per supplier
- In-memory rate limiter keyed on supplierId from JWT
- Returns 429 with `Retry-After` header when limit exceeded

## Files Changed
- `backend/services/supplier-service/src/routes/products.ts`

## Test Plan
- [ ] 6th CSV upload within 1 hour → 429
- [ ] 61st product CRUD within 1 minute → 429
- [ ] Different suppliers have independent limits

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>