### PR TITLE
fix(FIX-015): Replace bare .json() with safeJson() in retailer-admin

### DIFF
--- a/retailer-admin/src/lib/FeatureFlagContext.tsx
+++ b/retailer-admin/src/lib/FeatureFlagContext.tsx
@@ -3,7 +3,7 @@
 // Matches POS feature flag resolution: global defaults + store overrides
 
 import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
-import { authFetch } from './api';
+import { authFetch, safeJson } from './api';
 import { useAuth } from './AuthContext';
 
 interface FeatureFlags {
@@ -54,7 +54,7 @@ export function FeatureFlagProvider({ children }: { children: React.ReactNode })
         accessToken
       );
       if (res.ok) {
-        const json = await res.json();
+        const json = await safeJson(res, {} as any);
         if (json.success && json.data?.features) {
           setFlags({ ...DEFAULT_FLAGS, ...json.data.features });
         }

--- a/retailer-admin/src/pages/NotificationsPage.tsx
+++ b/retailer-admin/src/pages/NotificationsPage.tsx
@@ -5,7 +5,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../lib/AuthContext';
-import { authFetch } from '../lib/api';
+import { authFetch, safeJson } from '../lib/api';
 import { Bell, CheckCheck, RefreshCw, AlertTriangle, Package, CreditCard, Truck } from 'lucide-react';
 
 interface Notification {
@@ -33,9 +33,9 @@ export default function NotificationsPage() {
     try {
       const res = await authFetch(`/api/v1/retailer-admin/notifications?limit=${limit}&offset=${offset}`, accessToken);
       if (res.ok) {
-        const data = await res.json();
-        setNotifications(data.data || []);
-        setTotal(data.pagination?.total || 0);
+        const data = await safeJson<{ data?: any[]; pagination?: { total?: number } }>(res, { data: [], pagination: { total: 0 } });
+        setNotifications(data?.data || []);
+        setTotal(data?.pagination?.total || 0);
       }
     } catch (err) {
       console.error('Failed to fetch notifications:', err);

--- a/retailer-admin/src/pages/admin/ProductQueuePage.tsx
+++ b/retailer-admin/src/pages/admin/ProductQueuePage.tsx
@@ -174,8 +174,8 @@ export default function ProductQueuePage() {
         );
 
         if (!editResponse.ok) {
-          const data = await editResponse.json();
-          throw new Error(data.error || 'Failed to save product edits');
+          const data = await safeJson<{ error?: string }>(editResponse, { error: 'Failed to save product edits' });
+          throw new Error(data?.error || 'Failed to save product edits');
         }
       }
 
@@ -187,8 +187,8 @@ export default function ProductQueuePage() {
       );
 
       if (!approveResponse.ok) {
-        const data = await approveResponse.json();
-        throw new Error(data.error || 'Failed to approve product');
+        const data = await safeJson<{ error?: string }>(approveResponse, { error: 'Failed to approve product' });
+        throw new Error(data?.error || 'Failed to approve product');
       }
 
       setSuccess(`Product "${editForm.editedName || selectedProduct.productName}" approved successfully!`);


### PR DESCRIPTION
## Summary
- Replace bare `response.json()` with `safeJson()` in 3 files (4 call sites)
- Prevents JSON parse crashes on HTML error responses (500, 502)

## Files Changed
- `retailer-admin/src/lib/FeatureFlagContext.tsx`
- `retailer-admin/src/pages/admin/ProductQueuePage.tsx`
- `retailer-admin/src/pages/NotificationsPage.tsx`

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>