### PR TITLE
fix(FIX-023): use cookie check for auth redirects

### DIFF
--- a/supplier-portal/src/app/(auth)/onboard/page.tsx
+++ b/supplier-portal/src/app/(auth)/onboard/page.tsx
@@ -13,7 +13,7 @@ import {
   verifySupplierOtp,
   submitSupplierKyc,
   uploadSupplierDocument,
-  getAuthToken,
+  hasAuthCookie,
   ApiError,
 } from '@/lib/api';
 import { setupRecaptcha, sendOtp, verifyOtp, isFirebaseReady, cleanup } from '@/lib/firebase';
@@ -41,8 +41,9 @@ export default function SupplierOnboardingPage() {
   const router = useRouter();
 
   // AUDIT-SUP-001: Redirect authenticated users to dashboard
+  // FIX-023: Use cookie check instead of in-memory token (survives page reload)
   useEffect(() => {
-    if (getAuthToken()) {
+    if (hasAuthCookie()) {
       router.replace('/dashboard');
     }
   }, [router]);

--- a/supplier-portal/src/app/page.tsx
+++ b/supplier-portal/src/app/page.tsx
@@ -2,14 +2,14 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { getAuthToken } from '@/lib/api';
+// FIX-023: Use cookie check instead of in-memory token (survives page reload)
+import { hasAuthCookie } from '@/lib/api';
 
 export default function HomePage() {
   const router = useRouter();
 
   useEffect(() => {
-    const token = getAuthToken();
-    if (token) {
+    if (hasAuthCookie()) {
       router.replace('/dashboard');
     } else {
       router.replace('/login');


### PR DESCRIPTION
## Summary
- Replace `getAuthToken()` (in-memory, null after reload) with `hasAuthCookie()` for auth redirect checks
- Fixes root page (`/`) and onboard page auth guards
- Authenticated users no longer incorrectly redirected to login after page reload

## Test plan
- [x] TypeScript typecheck passes
- [x] Root page uses hasAuthCookie() for redirect decision
- [x] Onboard page uses hasAuthCookie() for auth guard