### PR TITLE
fix(FIX-032): network listener mounted ref guard

### DIFF
--- a/src/components/PosStatusBar.tsx
+++ b/src/components/PosStatusBar.tsx
@@ -65,8 +65,12 @@ export default function PosStatusBar({
   const popoverTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
 
+  // FIX-032: Mounted ref prevents setState after unmount if callback fires during cleanup
+  const mountedRef = useRef(true);
   useEffect(() => {
+    mountedRef.current = true;
     const unsubscribe = NetInfo.addEventListener((state) => {
+      if (!mountedRef.current) return;
       setNetworkState({
         isConnected: state.isConnected ?? null,
         isInternetReachable: state.isInternetReachable ?? null
@@ -74,6 +78,7 @@ export default function PosStatusBar({
     });
 
     return () => {
+      mountedRef.current = false;
       unsubscribe();
     };
   }, []);


### PR DESCRIPTION
## Summary
- Add `mountedRef` guard to NetInfo listener callback
- Set `mountedRef.current = false` before calling `unsubscribe()` in cleanup
- Prevents setState on unmounted PosStatusBar component

## Test plan
- [x] TypeScript typecheck passes (e2e-tests errors are pre-existing, unrelated)