### PR TITLE
fix(FIX-033): surface sync errors to UI

### DIFF
--- a/src/components/ui/SyncStatusWidget.tsx
+++ b/src/components/ui/SyncStatusWidget.tsx
@@ -67,6 +67,7 @@ export function SyncStatusWidget() {
   const connectionStatus = useSyncStore((s) => s.connectionStatus);
   const outboxCount = useSyncStore((s) => s.outboxCount);
   const lastSyncAt = useSyncStore((s) => s.lastSyncAt);
+  const lastSyncError = useSyncStore((s) => s.lastSyncError); // FIX-033
   const deadletterCount = useSyncStore((s) => s.deadletterCount);
   const stockDrifts = useSyncStore((s) => s.stockDrifts);
   const syncing = useSyncStore((s) => s.syncing);
@@ -152,6 +153,7 @@ export function SyncStatusWidget() {
   const hasPendingItems = outboxCount > 0;
   const hasDeadletterItems = deadletterCount > 0;
   const hasDrifts = stockDrifts.length > 0;
+  const hasSyncError = !!lastSyncError; // FIX-033
 
   return (
     <View style={styles.container}>
@@ -183,6 +185,11 @@ export function SyncStatusWidget() {
           <View style={styles.driftBadge}>
             <MaterialCommunityIcons name="swap-vertical" size={10} color={theme.colors.warning} />
           </View>
+        ) : null}
+
+        {/* FIX-033: Sync error indicator in compact bar */}
+        {hasSyncError ? (
+          <MaterialCommunityIcons name="alert" size={12} color={theme.colors.error} />
         ) : null}
 
         <Text style={styles.lastSyncText}>{relativeTime}</Text>
@@ -218,6 +225,18 @@ export function SyncStatusWidget() {
             <Text style={styles.detailLabel}>Last synced</Text>
             <Text style={styles.detailValue}>{relativeTime}</Text>
           </View>
+
+          {/* FIX-033: Show sync error */}
+          {lastSyncError ? (
+            <View style={styles.detailRow}>
+              <Text style={[styles.detailLabel, { color: theme.colors.error }]}>
+                Sync error
+              </Text>
+              <Text style={[styles.detailValue, { color: theme.colors.error, flex: 1, textAlign: "right" }]} numberOfLines={2}>
+                {lastSyncError}
+              </Text>
+            </View>
+          ) : null}
 
           {/* Deadletter items */}
           {hasDeadletterItems ? (

--- a/src/stores/syncStore.ts
+++ b/src/stores/syncStore.ts
@@ -20,6 +20,7 @@ type SyncState = {
   connectionStatus: ConnectionStatus;
   outboxCount: number;
   lastSyncAt: Date | null;
+  lastSyncError: string | null; // FIX-033: Surface sync errors to UI
   deadletterCount: number;
   stockDrifts: StockDrift[];
   syncing: boolean;
@@ -38,6 +39,7 @@ export const useSyncStore = create<SyncState>((set, get) => ({
   connectionStatus: "disconnected",
   outboxCount: 0,
   lastSyncAt: null,
+  lastSyncError: null,
   deadletterCount: 0,
   stockDrifts: [],
   syncing: false,
@@ -68,19 +70,22 @@ export const useSyncStore = create<SyncState>((set, get) => ({
       return;
     }
 
-    set({ syncing: true });
+    set({ syncing: true, lastSyncError: null });
     try {
       await syncOutbox();
       const count = await pendingOutboxCount();
       set({
         outboxCount: count,
         lastSyncAt: new Date(),
+        lastSyncError: null,
         syncing: false,
       });
       console.log("[SyncStore] Manual sync complete");
     } catch (error) {
-      console.error("[SyncStore] Manual sync failed:", error);
-      set({ syncing: false });
+      // FIX-033: Surface sync error to UI instead of swallowing
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      console.error("[SyncStore] Manual sync failed:", errorMsg);
+      set({ syncing: false, lastSyncError: errorMsg });
     }
   },
 }));


### PR DESCRIPTION
## Summary
- Add `lastSyncError` field to syncStore
- Set error message on sync failure, clear on success
- Show error details in SyncStatusWidget expanded panel
- Show alert icon in compact bar when sync has failed

## Test plan
- [x] TypeScript typecheck passes (pre-existing expo-constants errors only)
- [x] Error clears on next successful sync