### PR TITLE
fix(FIX-035): dismiss keyboard on split payment modal close

### DIFF
--- a/src/components/sell/SplitPaymentModal.tsx
+++ b/src/components/sell/SplitPaymentModal.tsx
@@ -11,6 +11,7 @@ import {
   TextInput,
   Alert,
   ActivityIndicator,
+  Keyboard,
 } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import QRCode from "react-native-qrcode-svg";
@@ -118,8 +119,9 @@ export function SplitPaymentModal({
       setManualUtrVisible(false);
       setManualUtr("");
     }
-    // Cleanup polling on unmount
+    // FIX-035: Dismiss keyboard + cleanup polling on close/unmount
     return () => {
+      Keyboard.dismiss();
       if (pollIntervalRef.current) {
         clearInterval(pollIntervalRef.current);
         pollIntervalRef.current = null;


### PR DESCRIPTION
## FIX-035: Add keyboard dismiss on modal close

### Problem
SplitPaymentModal cleanup doesn't dismiss keyboard. If a TextInput (amount field) was focused when the modal closes, the keyboard stays visible.

### Fix
Added `Keyboard.dismiss()` call in the useEffect cleanup that fires when the modal's `visible` prop changes to false or on unmount.

### Risk
Low — `Keyboard.dismiss()` is a no-op if keyboard is already hidden.