### PR TITLE
fix(FIX-036): show ActivityIndicator during QR regeneration

### DIFF
--- a/src/screens/PaymentScreen.tsx
+++ b/src/screens/PaymentScreen.tsx
@@ -10,7 +10,8 @@ import {
   StyleSheet,
   TouchableOpacity,
   Alert,
-  BackHandler
+  BackHandler,
+  ActivityIndicator,
 } from "react-native";
 import { useNavigation, useRoute, type RouteProp } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
@@ -952,19 +953,19 @@ const PaymentScreen = () => {
                 <Text style={styles.qrHint}>Offline: UPI disabled.</Text>
               ) : upiIntent ? (
                 <QRCode value={upiIntent} size={220} />
+              ) : loadingUpi ? (
+                <View style={{ alignItems: "center", padding: 16 }}>
+                  <ActivityIndicator size="large" color="#2563EB" />
+                  <Text style={[styles.qrHint, { marginTop: 8 }]}>Generating QR...</Text>
+                </View>
               ) : (
                 <TouchableOpacity onPress={() => {
                   // T-261: Clear state to trigger re-generation via useEffect
-                  if (!loadingUpi) {
-                    setUpiIntent(null);
-                    setQrExpiresAt(null);
-                    setQrSecondsLeft(null);
-                    setLoadingUpi(false);
-                  }
+                  setUpiIntent(null);
+                  setQrExpiresAt(null);
+                  setQrSecondsLeft(null);
                 }}>
-                  <Text style={styles.qrHint}>
-                    {loadingUpi ? "Generating QR..." : "QR expired — Tap to regenerate"}
-                  </Text>
+                  <Text style={styles.qrHint}>QR expired — Tap to regenerate</Text>
                 </TouchableOpacity>
               )}
             </View>


### PR DESCRIPTION
## FIX-036: Add loading state for QR regeneration

### Problem
When QR expires and user taps "regenerate", there's a brief blank state with only text "Generating QR..." — no visual loading indicator.

### Fix
- Split the else branch into two: `loadingUpi` shows `ActivityIndicator` + text, `!loadingUpi` shows tap-to-regenerate
- Removed redundant `setLoadingUpi(false)` (was already false when the guard passed)
- Added `ActivityIndicator` import

### Risk
Low — purely visual improvement, no business logic change.