### PR TITLE
fix(FIX-038): differentiate offline vs API scan errors

### DIFF
--- a/src/services/scan/handleScan.ts
+++ b/src/services/scan/handleScan.ts
@@ -394,7 +394,13 @@ export async function onBarcodeScanned(rawText: string, format?: string, source:
     await handleScan(trimmed, format, "SELL", source);
   } catch (err) {
     console.error("onBarcodeScanned error:", err);
-    notify({ tone: "error", message: "Scan failed. Please try again." });
+    // FIX-038: Differentiate offline vs generic scan errors
+    const online = await isOnline();
+    if (!online) {
+      notify({ tone: "error", message: "Offline — scan will process when back online." });
+    } else {
+      notify({ tone: "error", message: "Scan failed. Please try again." });
+    }
   }
 }
 
@@ -732,10 +738,15 @@ async function handleScan(
         return;
       }
     }
-    // Log non-API errors for debugging
-    if (!(error instanceof ApiError)) {
+    // FIX-038: Differentiate offline vs API vs unknown errors
+    const online = await isOnline();
+    if (!online) {
+      notify({ tone: "error", message: "Offline — scan will process when back online." });
+    } else if (error instanceof ApiError) {
+      notify({ tone: "error", message: `Scan error: ${error.message}` });
+    } else {
       console.error("handleScan non-API error:", String(error));
+      notify({ tone: "error", message: "Could not resolve scan. Check connection." });
     }
-    notify({ tone: "error", message: "Could not resolve scan. Check connection." });
   }
 }


### PR DESCRIPTION
## FIX-038: Surface offline scan errors to user

### Problem
Both `onBarcodeScanned` and `handleScan` catch blocks show generic messages ("Scan failed", "Could not resolve scan") regardless of whether the device is offline or the API returned an error.

### Fix
- Check `isOnline()` in both catch blocks
- Offline: "Offline — scan will process when back online."
- API error: Show the specific error message
- Unknown error: Keep generic "Could not resolve scan" with connection hint

### Risk
Low — only changes error message strings, no scan logic change.