### PR TITLE
fix(FIX-039): show stale price warning banner on payment screen

### DIFF
--- a/src/screens/PaymentScreen.tsx
+++ b/src/screens/PaymentScreen.tsx
@@ -882,6 +882,13 @@ const PaymentScreen = () => {
     !submitting &&
     (selectedMode !== "UPI" || Boolean(paymentId));
 
+  // FIX-039: Compute stale price count for warning badge
+  const stalePriceCount = useMemo(() => {
+    return saleItems.filter(
+      (item) => item.priceFetchedAt && Date.now() - item.priceFetchedAt > PRICE_FRESHNESS_THRESHOLD_MS
+    ).length;
+  }, [saleItems]);
+
   const ctaLabel =
     selectedMode === "UPI" ? "Payment Received" : selectedMode === "DUE" ? "Mark as Due" : "Complete Payment";
 
@@ -1004,6 +1011,16 @@ const PaymentScreen = () => {
           </View>
         )}
       </View>
+
+      {/* FIX-039: Stale price warning banner */}
+      {stalePriceCount > 0 && (
+        <View style={{ backgroundColor: "#FEF3C7", paddingHorizontal: 16, paddingVertical: 8, flexDirection: "row", alignItems: "center" }}>
+          <MaterialCommunityIcons name="alert-outline" size={18} color="#D97706" />
+          <Text style={{ color: "#92400E", fontSize: 13, marginLeft: 8, flex: 1 }}>
+            {stalePriceCount} item(s) have prices loaded over 4 hours ago. Prices may have changed.
+          </Text>
+        </View>
+      )}
 
       <View style={styles.footer}>
         <TouchableOpacity


### PR DESCRIPTION
## FIX-039: Add stale price warning before payment

### Problem
Cart price staleness was only checked when the user taps "Complete Payment" (too late). No visual indication before that point.

### Fix
- Added `stalePriceCount` useMemo that filters items older than `PRICE_FRESHNESS_THRESHOLD_MS` (4 hours)
- Shows amber warning banner with alert icon above the payment button when stale items exist
- The existing Alert on payment tap still fires as a secondary gate

### Risk
Low — additive UI change, no business logic modification. The 4-hour threshold constant was already defined.