### PR TITLE
fix(FIX-041): clear printer error on successful print

### DIFF
--- a/src/services/printerService.ts
+++ b/src/services/printerService.ts
@@ -91,6 +91,11 @@ class PrinterService {
   /**
    * Get current printer status.
    */
+  // FIX-041: Manual error clearing
+  clearError(): void {
+    this.status.error = undefined;
+  }
+
   getStatus(): PrinterStatus {
     return { ...this.status };
   }
@@ -169,6 +174,9 @@ class PrinterService {
         contentLength: content.length,
         method: "expo-print",
       });
+
+      // FIX-041: Clear error state on successful print
+      this.status.error = undefined;
 
       return true;
     } catch (e: any) {


### PR DESCRIPTION
## FIX-041: Fix printer error state not clearing

### Problem
`printerService.status.error` was set on print failure but never cleared on success. Once an error occurred, the error message persisted even after subsequent successful prints, potentially blocking future print attempts at the `!this.status.connected` check.

### Fix
- Clear `this.status.error = undefined` after successful print
- Added `clearError()` method for manual error clearing

### Risk
Low — `checkConnectivity()` already cleared error on success, this extends the same pattern to `printReceipt()`.