### PR TITLE
fix(FIX-042): reset audio session on recording start failure

### DIFF
--- a/src/services/voice/voiceClient.ts
+++ b/src/services/voice/voiceClient.ts
@@ -148,8 +148,13 @@ export async function startRecording(): Promise<boolean> {
     return true;
   } catch (error) {
     console.error("[voiceClient] Failed to start recording:", error);
-    // Reset state on error
+    // FIX-042: Reset audio session + state on error to unblock other audio
     currentRecording = null;
+    if (maxDurationTimer) {
+      clearTimeout(maxDurationTimer);
+      maxDurationTimer = null;
+    }
+    await resetAudioSession();
     return false;
   }
 }


### PR DESCRIPTION
## FIX-042: Fix voice audio session not reset on error

### Problem
If `Audio.Recording.createAsync()` fails after `prepareForRecording()` configured the audio session for recording, the session stays in recording mode. This blocks all other audio playback until the app is restarted.

### Fix
- Added `await resetAudioSession()` in the catch block of `startRecording()`
- Also clears the FIX-040 max duration timer if it was set before the failure

### Risk
Low — `resetAudioSession()` is safe to call even if session wasn't fully configured. Same pattern already used in `stopRecording()` and `cancelRecording()`.