### PR TITLE
fix(FIX-045): omit trailing ? when analytics params are empty

### DIFF
--- a/supermandi-superadmin/src/api/analytics.ts
+++ b/supermandi-superadmin/src/api/analytics.ts
@@ -59,7 +59,8 @@ export async function fetchAnalyticsOverview(params: { storeId?: string; from?: 
   if (params.storeId) qs.set("storeId", params.storeId);
   if (params.from) qs.set("from", params.from);
   if (params.to) qs.set("to", params.to);
-  return getJson<OverviewResponse>(`/api/v1/admin/analytics/overview?${qs.toString()}`);
+  const query = qs.toString();
+  return getJson<OverviewResponse>(`/api/v1/admin/analytics/overview${query ? `?${query}` : ""}`);
 }
 
 export type DevicesResponse = {
@@ -88,7 +89,8 @@ export async function fetchAnalyticsDevices(params: { storeId?: string; from?: s
   if (params.storeId) qs.set("storeId", params.storeId);
   if (params.from) qs.set("from", params.from);
   if (params.to) qs.set("to", params.to);
-  return getJson<DevicesResponse>(`/api/v1/admin/analytics/devices?${qs.toString()}`);
+  const query = qs.toString();
+  return getJson<DevicesResponse>(`/api/v1/admin/analytics/devices${query ? `?${query}` : ""}`);
 }
 
 export type ProductsResponse = {
@@ -118,7 +120,8 @@ export async function fetchAnalyticsProducts(params: { storeId?: string; from?: 
   if (params.from) qs.set("from", params.from);
   if (params.to) qs.set("to", params.to);
   if (params.groupBy) qs.set("groupBy", params.groupBy);
-  return getJson<ProductsResponse>(`/api/v1/admin/analytics/products?${qs.toString()}`);
+  const query = qs.toString();
+  return getJson<ProductsResponse>(`/api/v1/admin/analytics/products${query ? `?${query}` : ""}`);
 }
 
 // SA-P0-004: Stock-in breakdown types
@@ -164,7 +167,8 @@ export async function fetchAnalyticsPurchases(params: { storeId?: string; from?:
   if (params.storeId) qs.set("storeId", params.storeId);
   if (params.from) qs.set("from", params.from);
   if (params.to) qs.set("to", params.to);
-  return getJson<PurchasesResponse>(`/api/v1/admin/analytics/purchases?${qs.toString()}`);
+  const query = qs.toString();
+  return getJson<PurchasesResponse>(`/api/v1/admin/analytics/purchases${query ? `?${query}` : ""}`);
 }
 
 export type ConsumerSalesResponse = {
@@ -182,7 +186,8 @@ export async function fetchAnalyticsConsumerSales(params: { storeId?: string; fr
   if (params.storeId) qs.set("storeId", params.storeId);
   if (params.from) qs.set("from", params.from);
   if (params.to) qs.set("to", params.to);
-  return getJson<ConsumerSalesResponse>(`/api/v1/admin/analytics/consumer-sales?${qs.toString()}`);
+  const query = qs.toString();
+  return getJson<ConsumerSalesResponse>(`/api/v1/admin/analytics/consumer-sales${query ? `?${query}` : ""}`);
 }
 
 // P2-SADM-001: Activity Logs
@@ -206,7 +211,8 @@ export async function fetchAnalyticsActivity(params: { storeId?: string; from?: 
   if (params.storeId) qs.set("storeId", params.storeId);
   if (params.from) qs.set("from", params.from);
   if (params.to) qs.set("to", params.to);
-  return getJson<ActivityResponse>(`/api/v1/admin/analytics/activity?${qs.toString()}`);
+  const query = qs.toString();
+  return getJson<ActivityResponse>(`/api/v1/admin/analytics/activity${query ? `?${query}` : ""}`);
 }
 
 // P2-SADM-002: Dues Tracking
@@ -236,5 +242,6 @@ export async function fetchAnalyticsDues(params: { storeId?: string; from?: stri
   if (params.storeId) qs.set("storeId", params.storeId);
   if (params.from) qs.set("from", params.from);
   if (params.to) qs.set("to", params.to);
-  return getJson<DuesResponse>(`/api/v1/admin/analytics/dues?${qs.toString()}`);
+  const query = qs.toString();
+  return getJson<DuesResponse>(`/api/v1/admin/analytics/dues${query ? `?${query}` : ""}`);
 }


### PR DESCRIPTION
## FIX-045: Fix empty string params in analytics API

### Problem
All `fetchAnalytics*` functions unconditionally append `?` to the URL even when no query params exist, resulting in URLs like `/api/v1/admin/analytics/overview?`.

### Fix
Extract `qs.toString()` into a `query` variable and only append `?${query}` when non-empty. Applied to all 7 analytics fetch functions.

### Risk
Low — URL behavior is identical when params exist. When no params, removes trailing `?`.