### PR TITLE
fix(FIX-047): await approval before publish instead of setTimeout

### DIFF
--- a/supermandi-superadmin/src/tabs/SuppliersTab.tsx
+++ b/supermandi-superadmin/src/tabs/SuppliersTab.tsx
@@ -38,7 +38,7 @@ interface SuppliersTabProps {
   setProductRejectReason: (fn: (prev: Record<string, string>) => Record<string, string>) => void;
   productActionLoading: Record<string, boolean>;
   handleOpenEditProduct: (product: PendingProduct) => void;
-  handleApproveProduct: (productId: string) => void;
+  handleApproveProduct: (productId: string) => void | Promise<void>;
   handleRejectProduct: (productId: string) => void;
   // Product edit modal
   editingProduct: PendingProduct | null;
@@ -666,9 +666,9 @@ export function SuppliersTab({
                   </button>
                   <button
                     onClick={async () => {
-                      handleApproveProduct(product.id);
-                      // Wait briefly for approval to complete, then publish
-                      setTimeout(() => handlePublishProduct(product.id), 1500);
+                      // FIX-047: Await approval before publishing (was setTimeout race)
+                      await handleApproveProduct(product.id);
+                      await handlePublishProduct(product.id);
                     }}
                     disabled={productActionLoading[product.id] || publishLoading[product.id]}
                     style={{ background: "#2563eb", color: "white" }}


### PR DESCRIPTION
## FIX-047: Fix SuppliersTab approve+publish setTimeout race

### Problem
"Approve & Publish" used `setTimeout(() => handlePublishProduct(id), 1500)` after calling `handleApproveProduct`. If the approval API takes longer than 1.5s, publish fires before approval completes.

### Fix
- Replace `setTimeout` with sequential `await`: first `await handleApproveProduct`, then `await handlePublishProduct`
- Updated prop type to `void | Promise<void>` to reflect that the function returns a promise

### Risk
Low — publish now correctly waits for approval. If approval fails (throws), publish is skipped (correct behavior).