### PR TITLE
fix(FIX-049): add Load More pagination for applications

### DIFF
--- a/supermandi-superadmin/src/App.tsx
+++ b/supermandi-superadmin/src/App.tsx
@@ -1607,6 +1607,27 @@ export default function App() {
     }
   }
 
+  // FIX-049: Load more applications (append to existing list)
+  async function loadMoreApplications() {
+    if (applicationsInFlightRef.current) return;
+    applicationsInFlightRef.current = true;
+    setApplicationsLoading(true);
+    try {
+      const data = await fetchApplications({
+        entityType: appEntityFilter || undefined,
+        limit: 100,
+        offset: applications.length,
+      });
+      setApplications(prev => [...prev, ...data.items]);
+      setApplicationsTotal(data.total);
+    } catch (e: any) {
+      setApplicationsError(e?.message ? String(e.message) : "Failed to load more applications");
+    } finally {
+      applicationsInFlightRef.current = false;
+      setApplicationsLoading(false);
+    }
+  }
+
   async function handleApproveApplication(appId: string) {
     setAppActionLoading((prev) => ({ ...prev, [appId]: true }));
     setApplicationsError("");
@@ -2985,6 +3006,7 @@ export default function App() {
           refreshApplications={refreshApplications}
           handleApproveApplication={confirmedApproveApplication}
           handleRejectApplication={confirmedRejectApplication}
+          onLoadMore={loadMoreApplications}
         />
       )}
 

--- a/supermandi-superadmin/src/tabs/ApplicationsTab.tsx
+++ b/supermandi-superadmin/src/tabs/ApplicationsTab.tsx
@@ -15,6 +15,7 @@ interface ApplicationsTabProps {
   refreshApplications: () => void;
   handleApproveApplication: (id: string) => void;
   handleRejectApplication: (id: string) => void;
+  onLoadMore?: () => void;
 }
 
 export function ApplicationsTab({
@@ -30,6 +31,7 @@ export function ApplicationsTab({
   refreshApplications,
   handleApproveApplication,
   handleRejectApplication,
+  onLoadMore,
 }: ApplicationsTabProps) {
   return (
     <section className="card">
@@ -174,8 +176,18 @@ export function ApplicationsTab({
         </div>
       )}
 
-      <div style={{ padding: "12px 16px", fontSize: 12, color: "#666" }}>
-        Showing {applications.length} of {applicationsTotal} pending applications
+      <div style={{ padding: "12px 16px", fontSize: 12, color: "#666", display: "flex", alignItems: "center", gap: 12 }}>
+        <span>Showing {applications.length} of {applicationsTotal} pending applications</span>
+        {/* FIX-049: Load More button when more applications exist */}
+        {applications.length < applicationsTotal && onLoadMore && (
+          <button
+            onClick={onLoadMore}
+            disabled={applicationsLoading}
+            style={{ fontSize: 12, padding: "4px 12px", cursor: "pointer" }}
+          >
+            {applicationsLoading ? "Loading..." : "Load More"}
+          </button>
+        )}
       </div>
     </section>
   );


### PR DESCRIPTION
## FIX-049: Fix missing pagination in ApplicationsTab

### Problem
Shows "X of Y applications" but no way to load more when there are more than 100 applications. API supports `limit`/`offset` but UI didn't expose pagination.

### Fix
- Added `loadMoreApplications()` in App.tsx that fetches with `offset: applications.length` and appends to existing list
- Added `onLoadMore` prop to ApplicationsTab
- "Load More" button appears when `applications.length < applicationsTotal`

### Risk
Low — additive UI change. Existing refresh still replaces the full list.