### PR TITLE
fix(FIX-050): clear publish state on product list refresh

### DIFF
--- a/supermandi-superadmin/src/tabs/SuppliersTab.tsx
+++ b/supermandi-superadmin/src/tabs/SuppliersTab.tsx
@@ -1,6 +1,6 @@
 // SA-001: Suppliers tab extracted from App.tsx
 // T-188: Batch approval/rejection for pending products
-import React, { Component, useState } from "react";
+import React, { Component, useEffect, useState } from "react";
 import type { PendingSupplierRequest, VerifiedSupplier, PendingProduct, BankChangeEntry } from "../api/suppliers";
 import { toggleAutoApproval, publishProduct, batchProductAction } from "../api/suppliers";
 
@@ -140,6 +140,12 @@ export function SuppliersTab({
   // T-068: Publish button state
   const [publishLoading, setPublishLoading] = useState<Record<string, boolean>>({});
   const [publishResult, setPublishResult] = useState<Record<string, string>>({});
+
+  // FIX-050: Clear stale publish state when product list refreshes
+  useEffect(() => {
+    setPublishLoading({});
+    setPublishResult({});
+  }, [pendingProducts]);
   // T-188: Batch selection state
   const [selectedProductIds, setSelectedProductIds] = useState<Set<string>>(new Set());
   const [batchActionLoading, setBatchActionLoading] = useState(false);


### PR DESCRIPTION
## FIX-050: Fix memory leak in SuppliersTab publish state

### Problem
`publishLoading` and `publishResult` Record objects grow unbounded. After 50+ publish operations, old product IDs accumulate in state and are never cleared.

### Fix
Added `useEffect` that resets both maps to `{}` when `pendingProducts` reference changes (indicating a list refresh).

### Risk
Low — clears stale state on refresh. Any in-flight publish operation's result will be lost on refresh, which is acceptable since the product list is re-fetched anyway.