### PR TITLE
fix(FIX-052): rename version.json to _version.json

### DIFF
--- a/retailer-admin/vite.config.ts
+++ b/retailer-admin/vite.config.ts
@@ -33,7 +33,7 @@ function versionPlugin(): Plugin {
       const distPath = join(__dirname, 'dist');
       try {
         mkdirSync(distPath, { recursive: true });
-        writeFileSync(join(distPath, 'version.json'), JSON.stringify(versionData, null, 2));
+        writeFileSync(join(distPath, '_version.json'), JSON.stringify(versionData, null, 2));
         console.log('[version-plugin] Wrote _version.json:', versionData);
       } catch (err) {
         console.error('[version-plugin] Failed to write _version.json:', err);


### PR DESCRIPTION
## FIX-052: Fix version.json filename convention

### Problem
Vite plugin wrote `version.json` but convention (and console log) says `_version.json`. Inconsistent with backend convention and may be indexed by search engines.

### Fix
Changed `writeFileSync` path from `version.json` to `_version.json`.

### Risk
Low — only affects build artifact filename.