### PR TITLE
fix(FIX-054): remove profile nav link to prevent 404

### DIFF
--- a/supplier-portal/src/app/(dashboard)/layout.tsx
+++ b/supplier-portal/src/app/(dashboard)/layout.tsx
@@ -11,7 +11,7 @@ import Modal from '@/components/Modal';
 // REG-AUTH-302: LIMITED MODE Banner
 import LimitedModeBanner from '@/components/LimitedModeBanner';
 // T-082: Lucide SVG nav icons  |  T-087: Mobile hamburger icons
-import { LayoutDashboard, Package, FileSpreadsheet, ShoppingCart, ClipboardList, DollarSign, Receipt, User, Menu, X, Bell } from 'lucide-react';
+import { LayoutDashboard, Package, FileSpreadsheet, ShoppingCart, ClipboardList, DollarSign, Receipt, Menu, X, Bell } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 // T-082: Lucide SVG icons replace emoji strings
@@ -24,7 +24,7 @@ const navItems: { href: string; label: string; icon: LucideIcon }[] = [
   { href: '/earnings', label: 'Earnings', icon: DollarSign },
   { href: '/invoices', label: 'Invoices', icon: Receipt },  // T-073
   { href: '/notifications', label: 'Notifications', icon: Bell },  // Phase 8
-  { href: '/profile', label: 'Profile', icon: User },
+  // FIX-054: Profile page not yet implemented — removed to avoid 404
 ];
 
 export default function DashboardLayout({


### PR DESCRIPTION
## FIX-054: Fix profile page 404 in Supplier Portal nav

### Problem
Nav links to `/profile` but no page exists at that route. Users get 404.

### Fix
Removed profile nav link until the page is implemented. Removed unused `User` icon import.

### Risk
Low — removes a broken link. Profile functionality can be added later.