### PR TITLE
fix(FIX-056): add ARIA labels to payment mode tabs

### DIFF
--- a/src/screens/PaymentScreen.tsx
+++ b/src/screens/PaymentScreen.tsx
@@ -857,6 +857,9 @@ const PaymentScreen = () => {
         ]}
         onPress={() => handlePaymentSelect(mode)}
         disabled={disabled}
+        accessibilityRole="tab"
+        accessibilityLabel={`${title} payment${selected ? ", selected" : ""}`}
+        accessibilityState={{ selected, disabled }}
       >
         <MaterialCommunityIcons
           name={icon as any}
@@ -1027,6 +1030,9 @@ const PaymentScreen = () => {
           style={[styles.primaryCta, !canSubmit && styles.primaryCtaDisabled]}
           onPress={handleCompletePayment}
           disabled={!canSubmit}
+          accessibilityRole="button"
+          accessibilityLabel={ctaLabel}
+          accessibilityState={{ disabled: !canSubmit }}
         >
           <Text style={styles.primaryCtaText}>{ctaLabel}</Text>
         </TouchableOpacity>


### PR DESCRIPTION
## FIX-056: Add ARIA labels to payment mode tabs

### Problem
Payment mode tabs and primary CTA lack accessibilityLabel/accessibilityHint. Screen readers announce "Button" with no context.

### Fix
- Added `accessibilityRole="tab"`, `accessibilityLabel`, and `accessibilityState` to payment mode tab buttons
- Added `accessibilityRole="button"`, `accessibilityLabel`, and `accessibilityState` to the primary CTA

### Risk
Low — accessibility-only change, no visual or behavioral change.