### PR TITLE
fix(FIX-057): add accessibility label to UPI QR code

### DIFF
--- a/src/screens/PaymentScreen.tsx
+++ b/src/screens/PaymentScreen.tsx
@@ -962,7 +962,9 @@ const PaymentScreen = () => {
               ) : !isOnline ? (
                 <Text style={styles.qrHint}>Offline: UPI disabled.</Text>
               ) : upiIntent ? (
-                <QRCode value={upiIntent} size={220} />
+                <View accessible accessibilityLabel="UPI payment QR code. Ask customer to scan with any UPI app." accessibilityRole="image">
+                  <QRCode value={upiIntent} size={220} />
+                </View>
               ) : loadingUpi ? (
                 <View style={{ alignItems: "center", padding: 16 }}>
                   <ActivityIndicator size="large" color="#2563EB" />


### PR DESCRIPTION
## FIX-057: Fix QR code accessibility

### Problem
QRCode component has no accessibilityLabel. Screen readers announce nothing meaningful for the QR code.

### Fix
Wrapped QRCode in an accessible View with `accessibilityRole="image"` and descriptive label.

### Risk
Low — accessibility-only change.