### PR TITLE
fix(FIX-058): clear search history on store change/re-enrollment

### DIFF
--- a/src/services/deviceSession.ts
+++ b/src/services/deviceSession.ts
@@ -1,5 +1,6 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SecureStore from "expo-secure-store";
+import { clearAllHistory } from "./searchHistory";
 
 const SESSION_KEY = "supermandi.device.session.v1";
 
@@ -180,6 +181,8 @@ export async function clearDeviceSession(): Promise<void> {
     }
   }
   await AsyncStorage.removeItem(SESSION_KEY);
+  // FIX-058: Clear search history on session clear to prevent cross-store leakage
+  await clearAllHistory();
   console.log(`[deviceSession] Session cleared`);
 }
 

--- a/src/services/searchHistory.ts
+++ b/src/services/searchHistory.ts
@@ -68,3 +68,19 @@ export async function clearHistory(storeId: string): Promise<void> {
     console.warn("[searchHistory] Failed to clear history:", error);
   }
 }
+
+/**
+ * FIX-058: Clear ALL search history across all stores.
+ * Called on device re-enrollment or logout to prevent cross-store leakage.
+ */
+export async function clearAllHistory(): Promise<void> {
+  try {
+    const allKeys = await AsyncStorage.getAllKeys();
+    const historyKeys = allKeys.filter((k) => k.startsWith(STORAGE_KEY));
+    if (historyKeys.length > 0) {
+      await AsyncStorage.multiRemove(historyKeys);
+    }
+  } catch (error) {
+    console.warn("[searchHistory] Failed to clear all history:", error);
+  }
+}


### PR DESCRIPTION
## FIX-058: Clear search history on store change

### Problem
Search history persists in AsyncStorage after device re-enrollment. Previous store's history keys remain accessible.

### Fix
- Added `clearAllHistory()` to searchHistory service that removes all history keys (`supermandi.sell.searchHistory.v1.*`)
- Called from `clearDeviceSession()` so re-enrollment/logout wipes all search history

### Risk
Low — existing per-store key isolation already prevents cross-store reads. This adds cleanup on session clear.