### PR TITLE
fix(FIX-062): sanitize supplier search input

### DIFF
--- a/supermandi-superadmin/src/App.tsx
+++ b/supermandi-superadmin/src/App.tsx
@@ -762,7 +762,7 @@ export default function App() {
     try {
       const [pendingRes, verifiedRes, products, bankChangesRes] = await Promise.all([
         fetchPendingSuppliers(),
-        fetchVerifiedSuppliers({ search: supplierSearch || undefined }),
+        fetchVerifiedSuppliers({ search: supplierSearch?.trim() || undefined }),
         fetchPendingProducts(),
         fetchBankChanges()
       ]);


### PR DESCRIPTION
## FIX-062: Fix input sanitization in supplier search

### Problem
Search input sent to API without trimming whitespace.

### Fix
Added `.trim()` to `supplierSearch` before passing to `fetchVerifiedSuppliers`. URLSearchParams already handles URL encoding, and backend should use parameterized queries for SQL safety.

### Risk
Low — only trims whitespace.