### PR TITLE
fix(FIX-066): debounce useUrlState URL updates

### DIFF
--- a/supplier-portal/src/hooks/useUrlState.ts
+++ b/supplier-portal/src/hooks/useUrlState.ts
@@ -3,13 +3,14 @@
 'use client';
 
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 
 /**
  * Custom hook that syncs a single URL search parameter with React state.
  * Reading from URL is the source of truth — when user navigates back,
  * the URL changes and the component re-renders with the previous value.
  *
+ * FIX-066: Debounces URL updates to prevent excessive router.replace calls on every keystroke.
  * Uses Next.js App Router navigation (router.replace with scroll: false).
  *
  * @param key - The URL search parameter name (e.g., 'status', 'page')
@@ -21,16 +22,21 @@ export function useUrlState(key: string, defaultValue: string = ''): readonly [s
   const router = useRouter();
   const pathname = usePathname();
   const value = searchParams.get(key) ?? defaultValue;
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const setValue = useCallback((newValue: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    if (newValue === defaultValue || newValue === '') {
-      params.delete(key);
-    } else {
-      params.set(key, newValue);
-    }
-    const query = params.toString();
-    router.replace(`${pathname}${query ? '?' + query : ''}`, { scroll: false });
+    // FIX-066: Debounce URL updates (300ms) to prevent excessive history manipulation
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (newValue === defaultValue || newValue === '') {
+        params.delete(key);
+      } else {
+        params.set(key, newValue);
+      }
+      const query = params.toString();
+      router.replace(`${pathname}${query ? '?' + query : ''}`, { scroll: false });
+    }, 300);
   }, [key, defaultValue, searchParams, router, pathname]);
 
   return [value, setValue] as const;


### PR DESCRIPTION
## FIX-066: Fix useUrlState debounce for search

### Problem
`setValue` calls `router.replace` on every keystroke, creating excessive navigation events and potential performance issues.

### Fix
Added 300ms debounce via `useRef` timer. Clears previous timeout on each keystroke so URL only updates after user stops typing.

### Risk
Low — URL update is delayed by 300ms, which is imperceptible for search. Direct URL reads still work instantly.