### PR TITLE
fix(FIX-061): add ARIA labels to product status filters

### DIFF
--- a/supplier-portal/src/app/(dashboard)/products/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/products/page.tsx
@@ -698,6 +698,9 @@ export default function ProductsPage() {
                     ? 'bg-primary-600 text-white'
                     : 'bg-slate-100 text-slate-600 hover:bg-slate-200'
                 }`}
+                role="tab"
+                aria-pressed={statusFilter === status}
+                aria-label={`Filter by ${status === 'all' ? 'all statuses' : status}`}
               >
                 {status === 'all' ? 'All' : status.charAt(0).toUpperCase() + status.slice(1)}
               </button>


### PR DESCRIPTION
## FIX-061: Fix missing ARIA labels on product status filters

### Problem
Status filter buttons lack `aria-pressed` attributes. Screen readers don't know which filter is active.

### Fix
Added `role="tab"`, `aria-pressed`, and `aria-label` to status filter buttons.

### Risk
Low — accessibility-only change.