### PR TITLE
fix(TQ-014): add test:integration script for standalone POS tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:watch": "jest --config jest.config.js --watch",
     "test:coverage": "jest --config jest.config.js --coverage",
     "test:e2e": "npx playwright test --config e2e-tests/playwright.config.ts",
+    "test:integration": "node src/services/stockCap.integration.test.js && node src/services/scan/sellFirstOnboarding.integration.test.js && node src/services/stockService.integration.test.js && node src/services/saleScope.test.js && npx tsx src/stores/purchaseDraftLogic.test.ts",
     "pre-commit-check": "node scripts/pre-commit-check.js",
     "build:check": "node scripts/build-check.js",
     "apk:check": "node scripts/apk-readiness-check.js",

--- a/src/stores/purchaseDraftLogic.test.ts
+++ b/src/stores/purchaseDraftLogic.test.ts
@@ -39,3 +39,7 @@ export function runPurchaseDraftLogicTests(): void {
   assert(items.length === 1, "Expected barcode fallback to merge when productId is new");
   assert(items[0].quantity === 2, "Expected quantity to increment via barcode fallback");
 }
+
+// Self-execute when run directly (e.g., via `npx tsx`)
+runPurchaseDraftLogicTests();
+console.log("[PASS] purchaseDraftLogic — all assertions passed");


### PR DESCRIPTION
## Summary
- Add `pnpm test:integration` script to run 5 standalone POS integration tests
- These tests use `node:assert` and `vm.runInNewContext` — not Jest format
- Previously invisible to `pnpm test`, now discoverable via `pnpm test:integration`
- Files: stockCap, sellFirstOnboarding, stockService, saleScope, purchaseDraftLogic

## Test plan
- [x] Script chains all 5 test files with `&&`
- [x] purchaseDraftLogic.test.ts now self-executes when run directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)