### PR TITLE
fix(WA-003): production-grade WhatsApp hardening

### DIFF
--- a/backend/src/routes/v1/webhooks/whatsappWebhook.ts
+++ b/backend/src/routes/v1/webhooks/whatsappWebhook.ts
@@ -9,15 +9,6 @@ import { getWebhookVerifyToken } from "../../../services/whatsappService";
 
 export const whatsappWebhookRouter = Router();
 
-// Delivery status progression order (for atomic idempotent updates)
-const STATUS_ORDER: Record<string, number> = {
-  queued: 0,
-  sent: 1,
-  delivered: 2,
-  read: 3,
-  failed: 4,
-};
-
 const WHATSAPP_APP_SECRET = process.env.WHATSAPP_APP_SECRET || "";
 
 // =============================================================================
@@ -106,7 +97,12 @@ whatsappWebhookRouter.post("/whatsapp", async (req: Request, res: Response) => {
 
 async function processStatusUpdate(
   pool: ReturnType<typeof getPool>,
-  status: { id?: string; status?: string; timestamp?: string }
+  status: {
+    id?: string;
+    status?: string;
+    timestamp?: string;
+    errors?: Array<{ code?: number; title?: string }>;
+  }
 ): Promise<void> {
   if (!pool) return;
 
@@ -119,8 +115,6 @@ async function processStatusUpdate(
   const mappedStatus = mapMetaStatus(newStatus);
   if (!mappedStatus) return;
 
-  const newOrder = STATUS_ORDER[mappedStatus] ?? -1;
-
   // Use Meta's timestamp if available (more accurate than server time)
   const eventTime = status.timestamp
     ? new Date(parseInt(status.timestamp, 10) * 1000)
@@ -131,6 +125,10 @@ async function processStatusUpdate(
     // Only progresses forward in lifecycle (queued→sent→delivered→read)
     // "failed" can overwrite queued/sent but NOT delivered/read
     if (mappedStatus === "failed") {
+      // Extract error code from Meta's errors array (e.g., 131026 = "Message Undeliverable")
+      const errorCode = status.errors?.[0]?.code
+        ? String(status.errors[0].code)
+        : status.errors?.[0]?.title || "unknown";
       // Failed can only overwrite queued or sent (not delivered/read)
       await pool.query(
         `UPDATE whatsapp.message_logs
@@ -139,7 +137,7 @@ async function processStatusUpdate(
              updated_at = NOW()
          WHERE wamid = $3
            AND delivery_status IN ('queued', 'sent')`,
-        [mappedStatus, status.status || null, wamid]
+        [mappedStatus, errorCode, wamid]
       );
     } else if (mappedStatus === "delivered") {
       await pool.query(

--- a/backend/src/services/whatsappService.ts
+++ b/backend/src/services/whatsappService.ts
@@ -30,8 +30,8 @@ const rateLimitMap = new Map<string, number[]>();
 const RATE_LIMIT_PER_MIN = 3;
 const RATE_LIMIT_PER_HOUR = 10;
 
-// Clean up old entries every 10 minutes
-setInterval(() => {
+// Clean up old entries every 10 minutes (unref to not block process exit)
+const cleanupTimer = setInterval(() => {
   const cutoff = Date.now() - 3600_000;
   for (const [phone, timestamps] of rateLimitMap) {
     const recent = timestamps.filter((t) => t > cutoff);
@@ -42,6 +42,9 @@ setInterval(() => {
     }
   }
 }, 600_000);
+if (typeof cleanupTimer === "object" && "unref" in cleanupTimer) {
+  cleanupTimer.unref();
+}
 
 function checkRateLimit(phone: string): boolean {
   const now = Date.now();
@@ -157,6 +160,10 @@ export async function sendTextMessage(params: {
 
   if (!checkRateLimit(phone)) {
     return { sent: false, errorCode: "RATE_LIMITED", errorMessage: "Too many messages to this number" };
+  }
+
+  if (params.body.length > 4096) {
+    return { sent: false, errorCode: "MESSAGE_TOO_LONG", errorMessage: "Message exceeds 4096 character limit" };
   }
 
   const body = {

--- a/retailer-admin/src/pages/InvoicesPage.tsx
+++ b/retailer-admin/src/pages/InvoicesPage.tsx
@@ -362,12 +362,14 @@ export default function InvoicesPage() {
                     Download PDF
                   </button>
                   {/* WA-002: sellerPhone now included in API response for direct WhatsApp linking */}
+                  {detail.sellerPhone && (
                   <button
                     onClick={() => {
                       const amount = fmt(detail.totalAmountMinor);
                       const msg = `Regarding invoice #${detail.invoiceNumber}, amount: ${amount}. Status: ${detail.status.toUpperCase()}.`;
-                      const phone = detail.sellerPhone ? detail.sellerPhone.replace(/\D/g, '') : '';
-                      window.open(`https://wa.me/${phone}?text=${encodeURIComponent(msg)}`, '_blank');
+                      const phone = detail.sellerPhone!.replace(/\D/g, '');
+                      if (phone.length < 10) return;
+                      window.open(`https://wa.me/${phone}?text=${encodeURIComponent(msg)}`, '_blank', 'noopener,noreferrer');
                     }}
                     style={{
                       padding: "6px 16px", background: "#f0fdf4", color: "#15803d",
@@ -379,6 +381,7 @@ export default function InvoicesPage() {
                     <WhatsAppIcon size={16} />
                     WhatsApp
                   </button>
+                  )}
                 </div>
               </>
             )}

--- a/retailer-admin/src/pages/PurchaseOrdersPage.tsx
+++ b/retailer-admin/src/pages/PurchaseOrdersPage.tsx
@@ -305,14 +305,16 @@ export default function PurchaseOrdersPage() {
             )}
 
             {/* WA-002: WhatsApp Follow-up Button — uses supplierPhone from API when available */}
+            {selectedPO.supplierPhone && (
             <div style={{ marginBottom: '1rem' }}>
               <button
                 onClick={() => {
                   const expected = selectedPO.expectedDeliveryDate ? new Date(selectedPO.expectedDeliveryDate).toLocaleDateString('en-IN') : 'N/A';
                   const status = selectedPO.status.charAt(0).toUpperCase() + selectedPO.status.slice(1);
                   const msg = `Follow-up on PO #${selectedPO.poNumber}. Status: ${status}. Expected delivery: ${expected}.`;
-                  const phone = selectedPO.supplierPhone ? selectedPO.supplierPhone.replace(/\D/g, '') : '';
-                  window.open(`https://wa.me/${phone}?text=${encodeURIComponent(msg)}`, '_blank');
+                  const phone = selectedPO.supplierPhone!.replace(/\D/g, '');
+                  if (phone.length < 10) return;
+                  window.open(`https://wa.me/${phone}?text=${encodeURIComponent(msg)}`, '_blank', 'noopener,noreferrer');
                 }}
                 style={{
                   padding: '6px 16px', background: '#f0fdf4', color: '#15803d',
@@ -326,6 +328,7 @@ export default function PurchaseOrdersPage() {
                 WhatsApp Follow-up
               </button>
             </div>
+            )}
 
             {/* Line Items */}
             {selectedPO.items && selectedPO.items.length > 0 && (

--- a/src/screens/CustomerListScreen.tsx
+++ b/src/screens/CustomerListScreen.tsx
@@ -319,11 +319,13 @@ export default function CustomerListScreen({ onBack }: CustomerListScreenProps) 
                 <Text style={styles.profileName}>{selectedCustomer.name}</Text>
                 <View style={styles.profilePhoneRow}>
                   <Text style={styles.profilePhone}>{selectedCustomer.phone}</Text>
+                  {selectedCustomer.phone && selectedCustomer.phone.replace(/\D/g, "").length >= 10 && (
                   <Pressable
                     style={styles.whatsappIconButton}
                     onPress={() => {
+                      const name = selectedCustomer.name || "Customer";
                       const message = encodeURIComponent(
-                        `Hi ${selectedCustomer.name}, greetings from SuperMandi!`
+                        `Hi ${name}, greetings from SuperMandi!`
                       );
                       const phone = selectedCustomer.phone.replace(/\D/g, "");
                       // wa.me universal link works on both Android and iOS
@@ -336,6 +338,7 @@ export default function CustomerListScreen({ onBack }: CustomerListScreenProps) 
                   >
                     <MaterialCommunityIcons name="whatsapp" size={20} color="#25D366" />
                   </Pressable>
+                  )}
                 </View>
                 {selectedCustomer.email && (
                   <Text style={styles.profileEmail}>{selectedCustomer.email}</Text>

--- a/src/screens/MenuScreen.tsx
+++ b/src/screens/MenuScreen.tsx
@@ -860,7 +860,11 @@ export default function MenuScreen() {
       <Pressable
         style={styles.menuItem}
         onPress={() => {
-          const supportPhone = process.env.EXPO_PUBLIC_SUPPORT_PHONE || "919876543210";
+          const supportPhone = process.env.EXPO_PUBLIC_SUPPORT_PHONE;
+          if (!supportPhone) {
+            Alert.alert("Support Unavailable", "Support phone not configured. Please contact support via email.");
+            return;
+          }
           const message = encodeURIComponent(
             `Hi SuperMandi Support,\n\nStore: ${opStatus.storeName || "N/A"}\nDevice: ${opStatus.deviceLabel || "N/A"}\n\nI need help with: `
           );

--- a/supermandi-superadmin/src/api/whatsapp.ts
+++ b/supermandi-superadmin/src/api/whatsapp.ts
@@ -34,11 +34,20 @@ export interface WhatsAppStats {
   last7d: number;
 }
 
+async function parseErrorBody(res: Response): Promise<string> {
+  try {
+    const body = await res.json();
+    return body?.error || body?.message || `HTTP ${res.status}`;
+  } catch {
+    return `HTTP ${res.status}`;
+  }
+}
+
 export async function fetchWhatsAppStatus(): Promise<{ configured: boolean }> {
   const res = await fetchWithTimeout(`${API_BASE}/api/v1/admin/whatsapp/status`, {
     headers: { ...getAuthHeaders() },
   });
-  if (!res.ok) throw new Error(`Failed: ${res.status}`);
+  if (!res.ok) throw new Error(await parseErrorBody(res));
   return res.json();
 }
 
@@ -46,7 +55,7 @@ export async function fetchWhatsAppStats(): Promise<WhatsAppStats> {
   const res = await fetchWithTimeout(`${API_BASE}/api/v1/admin/whatsapp/stats`, {
     headers: { ...getAuthHeaders() },
   });
-  if (!res.ok) throw new Error(`Failed: ${res.status}`);
+  if (!res.ok) throw new Error(await parseErrorBody(res));
   return res.json();
 }
 
@@ -69,7 +78,7 @@ export async function fetchWhatsAppLogs(params?: {
   const res = await fetchWithTimeout(`${API_BASE}/api/v1/admin/whatsapp/logs?${qs}`, {
     headers: { ...getAuthHeaders() },
   });
-  if (!res.ok) throw new Error(`Failed: ${res.status}`);
+  if (!res.ok) throw new Error(await parseErrorBody(res));
   return res.json();
 }
 
@@ -87,7 +96,9 @@ export async function sendWhatsAppMessage(params: {
     },
     body: JSON.stringify(params),
   });
-  return res.json();
+  const data = await res.json();
+  if (!res.ok && !data.error) data.error = `HTTP ${res.status}`;
+  return data;
 }
 
 export async function sendWhatsAppBroadcast(params: {
@@ -103,5 +114,6 @@ export async function sendWhatsAppBroadcast(params: {
     },
     body: JSON.stringify(params),
   });
+  if (!res.ok) throw new Error(await parseErrorBody(res));
   return res.json();
 }

--- a/supermandi-superadmin/src/tabs/WhatsAppTab.tsx
+++ b/supermandi-superadmin/src/tabs/WhatsAppTab.tsx
@@ -269,11 +269,11 @@ export function WhatsAppTab() {
             </select>
             <button
               onClick={handleBroadcast}
-              disabled={broadcasting}
+              disabled={broadcasting || !broadcastPhones.trim() || !broadcastMessage.trim()}
               style={{
                 padding: "6px 16px", background: "#f59e0b", color: "#fff", border: "none",
-                borderRadius: 4, cursor: broadcasting ? "default" : "pointer", fontSize: "0.85rem",
-                fontWeight: 600, opacity: broadcasting ? 0.6 : 1,
+                borderRadius: 4, cursor: (broadcasting || !broadcastPhones.trim() || !broadcastMessage.trim()) ? "default" : "pointer", fontSize: "0.85rem",
+                fontWeight: 600, opacity: (broadcasting || !broadcastPhones.trim() || !broadcastMessage.trim()) ? 0.6 : 1,
               }}
             >
               {broadcasting ? "Sending..." : "Send Broadcast"}
@@ -360,8 +360,8 @@ export function WhatsAppTab() {
                       <span style={{
                         padding: "2px 8px", borderRadius: 10, fontSize: "0.7rem", fontWeight: 600,
                         background: sc.bg, color: sc.color,
-                      }}>
-                        {log.deliveryStatus}
+                      }} title={log.deliveryErrorCode || undefined}>
+                        {log.deliveryStatus}{log.deliveryStatus === "failed" && log.deliveryErrorCode ? ` (${log.deliveryErrorCode})` : ""}
                       </span>
                     </td>
                     <td style={{ padding: "6px 8px", fontSize: "0.75rem", color: "#64748b" }}>{log.contextType || "—"}</td>

--- a/supplier-portal/src/app/(dashboard)/invoices/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/invoices/page.tsx
@@ -262,13 +262,15 @@ export default function InvoicesPage() {
                     Download PDF
                   </button>
                   {/* WA-002: buyerPhone now included in API response for direct WhatsApp linking */}
+                  {detail.buyerPhone && (
                   <button
                     onClick={() => {
                       const amount = `${'\u20B9'}${(detail.totalAmountMinor / 100).toFixed(2)}`;
                       const due = detail.dueDate ? new Date(detail.dueDate).toLocaleDateString('en-IN') : 'N/A';
                       const msg = `Payment reminder for invoice #${detail.invoiceNumber}, amount: ${amount}. Due: ${due}.`;
-                      const phone = detail.buyerPhone ? detail.buyerPhone.replace(/\D/g, '') : '';
-                      window.open(`https://wa.me/${phone}?text=${encodeURIComponent(msg)}`, '_blank');
+                      const phone = detail.buyerPhone!.replace(/\D/g, '');
+                      if (phone.length < 10) return;
+                      window.open(`https://wa.me/${phone}?text=${encodeURIComponent(msg)}`, '_blank', 'noopener,noreferrer');
                     }}
                     className="inline-flex items-center gap-1.5 px-4 py-2 bg-green-50 text-green-700 border border-green-200 rounded-lg text-sm hover:bg-green-100 transition-colors"
                     title="Send payment reminder via WhatsApp"
@@ -276,6 +278,7 @@ export default function InvoicesPage() {
                     <WhatsAppIcon size={16} />
                     Payment Reminder
                   </button>
+                  )}
                 </div>
               </>
             )}


### PR DESCRIPTION
## Summary
- Guard all wa.me buttons on phone presence (hide instead of opening blank wa.me)
- Add `noopener,noreferrer` to all `window.open` calls for security
- Parse Meta webhook errors array for proper `delivery_error_code`
- Remove hardcoded fallback support phone from POS
- Disable broadcast button when inputs empty
- Parse API error bodies in superadmin client
- Add message length validation in backend service
- Show error codes in dashboard for failed messages

## Files changed (9)
**Backend (3)**
- `whatsappWebhook.ts` — proper error code extraction from Meta errors array
- `whatsappService.ts` — message length validation, timer unref
- No migration needed

**Retailer-Admin (2)**
- `PurchaseOrdersPage.tsx` — phone guard + noopener
- `InvoicesPage.tsx` — phone guard + noopener

**Supplier-Portal (1)**
- `invoices/page.tsx` — phone guard + noopener

**SuperAdmin (2)**
- `whatsapp.ts` — error body parsing
- `WhatsAppTab.tsx` — broadcast disable, error code display

**POS (2)**
- `MenuScreen.tsx` — remove hardcoded phone
- `CustomerListScreen.tsx` — phone validation guard

## Test plan
- [ ] CI gates pass (typecheck, lint, build, unit tests)
- [ ] wa.me buttons hidden when phone is null/missing
- [ ] wa.me links open with noopener,noreferrer
- [ ] Broadcast button disabled when fields empty
- [ ] Failed messages show error code in dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)