### PR TITLE
fix(PRA-078): enforce store isolation on order events

### DIFF
--- a/backend/src/routes/v1/orders.ts
+++ b/backend/src/routes/v1/orders.ts
@@ -503,24 +503,27 @@ ordersRouter.get("/stores/:storeId/orders/:orderId/events", requireDeviceToken, 
   const pool = getPool();
   if (!pool) return res.status(503).json({ error: "database unavailable" });
 
+  const storeId = getStoreIdFromDevice(req);
   const { orderId } = req.params;
 
   try {
+    // PRA-078: JOIN with purchase_orders to enforce store isolation
     const result = await pool.query(
       `SELECT
-        id,
-        purchase_order_id as "orderId",
-        event_type as "eventType",
-        from_status as "fromStatus",
-        to_status as "toStatus",
-        actor_id as "actorId",
-        actor_type as "actorType",
-        metadata,
-        created_at as "createdAt"
-      FROM orders.order_events
-      WHERE purchase_order_id = $1
-      ORDER BY created_at ASC`,
-      [orderId]
+        oe.id,
+        oe.purchase_order_id as "orderId",
+        oe.event_type as "eventType",
+        oe.from_status as "fromStatus",
+        oe.to_status as "toStatus",
+        oe.actor_id as "actorId",
+        oe.actor_type as "actorType",
+        oe.metadata,
+        oe.created_at as "createdAt"
+      FROM orders.order_events oe
+      JOIN orders.purchase_orders po ON po.id = oe.purchase_order_id
+      WHERE oe.purchase_order_id = $1 AND po.store_id = $2
+      ORDER BY oe.created_at ASC`,
+      [orderId, storeId]
     );
 
     return res.json({


### PR DESCRIPTION
## Summary
- `GET /orders/:orderId/events` was querying `order_events` by `purchase_order_id` only, without verifying the order belongs to the requesting device's store
- Added JOIN with `purchase_orders` table and `WHERE po.store_id = $storeId` (derived from device JWT via `getStoreIdFromDevice()`)
- All other order endpoints already enforce store isolation — this was the only gap

## Audit
- **Ticket:** PRA-078 (Multi-Store Isolation Verification)
- **Finding:** 1 LOW severity — order events endpoint missing store_id verification
- **47 files audited** across admin, POS, retailer-admin, supplier, gateway routes
- All other areas CLEAN

## Test plan
- [ ] Typecheck passes (verified locally)
- [ ] Order events endpoint returns events only for orders belonging to the device's store

🤖 Generated with [Claude Code](https://claude.com/claude-code)