### PR TITLE
fix(PRA-079): harden auth cross-platform boundaries

### DIFF
--- a/backend/services/api-gateway/src/routes/testAuth.ts
+++ b/backend/services/api-gateway/src/routes/testAuth.ts
@@ -51,7 +51,8 @@ export function createTestAuthRouter(): Router {
   const router = Router();
 
   // STAGE-005: Only enable in development (disabled in staging AND production)
-  const isDevelopment = process.env.NODE_ENV === 'development' || !process.env.NODE_ENV;
+  // PRA-079: Require explicit 'development' — never enable when NODE_ENV is unset
+  const isDevelopment = process.env.NODE_ENV === 'development';
 
   if (!isDevelopment) {
     // Return router with no routes - all requests will 404

--- a/backend/services/auth-service/src/routes/auth.ts
+++ b/backend/services/auth-service/src/routes/auth.ts
@@ -243,7 +243,8 @@ router.post(
 
     // AUTH-REFRESH-001: Rotate refresh token - revoke old, issue new
     await revokeRefreshToken(tokenHash);
-    const { token: newRefreshToken } = generateRefreshToken(user.id);
+    // PRA-079: Carry actorType into rotated refresh token
+    const { token: newRefreshToken } = generateRefreshToken(user.id, user.actorType);
     const newRefreshTokenHash = hashRefreshToken(newRefreshToken);
     await createRefreshToken({
       userId: user.id,

--- a/backend/services/auth-service/src/services/jwtService.ts
+++ b/backend/services/auth-service/src/services/jwtService.ts
@@ -91,7 +91,7 @@ export function generateAccessToken(payload: AccessTokenPayload): string {
 /**
  * Generate a refresh token
  */
-export function generateRefreshToken(userId: string): { token: string; tokenId: string } {
+export function generateRefreshToken(userId: string, actorType?: string): { token: string; tokenId: string } {
   const tokenId = crypto.randomUUID();
 
   // Convert days to seconds
@@ -102,6 +102,8 @@ export function generateRefreshToken(userId: string): { token: string; tokenId: 
       sub: userId,
       tokenId,
       type: 'refresh',
+      // PRA-079: Include actorType to prevent cross-platform refresh token reuse
+      ...(actorType ? { actorType } : {}),
     },
     config.jwt.secret,
     {
@@ -129,7 +131,7 @@ export function generateTokenPair(
     permissions,
   });
 
-  const { token: refreshToken, tokenId: refreshTokenId } = generateRefreshToken(userId);
+  const { token: refreshToken, tokenId: refreshTokenId } = generateRefreshToken(userId, actorType);
 
   // Parse expiresIn to seconds
   const expiresIn = parseExpiresIn(config.jwt.accessTokenExpiresIn);

--- a/backend/src/routes/v1/documents.ts
+++ b/backend/src/routes/v1/documents.ts
@@ -170,6 +170,17 @@ router.post("/upload", upload.single('file'), async (req: Request, res: Response
       return;
     }
 
+    // PRA-079: Unauthenticated uploads restricted to 'application' entity type only
+    // Store/supplier document uploads require an authenticated session
+    const isAuthenticated = !!(req.headers['authorization'] || req.headers['x-admin-token'] || req.headers['x-device-token']);
+    if (!isAuthenticated && entity_type !== 'application') {
+      res.status(401).json({
+        error: 'AUTH_REQUIRED',
+        message: 'Authentication required for store/supplier document uploads',
+      });
+      return;
+    }
+
     // Validate document type
     const validTypes = getValidDocTypes(entity_type);
     if (!validTypes.includes(document_type)) {

--- a/backend/src/routes/v1/retailer-admin/auth.ts
+++ b/backend/src/routes/v1/retailer-admin/auth.ts
@@ -359,6 +359,7 @@ router.post("/auth/firebase-login", enhancedAuthProtection(), authRateLimiter, a
     const refreshPayload = {
       sub: user.id,
       type: 'refresh',
+      actorType: 'STORE',             // PRA-079: Prevent cross-platform refresh token reuse
       storeId: store.id,
       jti: refreshJti,                 // GO-LIVE-137: JWT ID for refresh token revocation
     };
@@ -555,6 +556,7 @@ router.post("/auth/firebase-otp-login", enhancedAuthProtection(), authRateLimite
     const refreshPayload = {
       sub: user.id,
       type: 'refresh',
+      actorType: 'STORE',             // PRA-079: Prevent cross-platform refresh token reuse
       jti: refreshJti,
     };
 
@@ -890,6 +892,7 @@ router.post("/auth/login", enhancedAuthProtection(), authRateLimiter, async (req
     const refreshPayload = {
       sub: user.id,
       type: 'refresh',
+      actorType: 'STORE',             // PRA-079: Prevent cross-platform refresh token reuse
       storeId: store.id,
       jti: refreshJti,
     };
@@ -1130,6 +1133,12 @@ router.post("/auth/refresh", async (req: Request, res: Response, next: NextFunct
 
     if (decoded.type !== 'refresh') {
       res.status(401).json({ error: "Invalid token type" });
+      return;
+    }
+
+    // PRA-079: Reject refresh tokens from other platforms (backward-compat: allow missing actorType)
+    if (decoded.actorType && decoded.actorType !== 'STORE') {
+      res.status(401).json({ error: "Invalid token for this endpoint" });
       return;
     }
 

--- a/backend/src/routes/v1/supplier/auth.ts
+++ b/backend/src/routes/v1/supplier/auth.ts
@@ -723,6 +723,7 @@ router.post("/auth/login", checkIpBlockMiddleware, loginRateLimiter, async (req:
     const refreshPayload = {
       sub: supplier.id,
       type: 'refresh',
+      actorType: 'SUPPLIER',          // PRA-079: Prevent cross-platform refresh token reuse
       jti: refreshJti,
     };
     const refreshToken = jwt.sign(refreshPayload, JWT_SECRET, {
@@ -1732,6 +1733,7 @@ router.post("/auth/firebase-login", checkIpBlockMiddleware, loginRateLimiter, as
     const refreshPayload = {
       sub: supplier.id,
       type: 'refresh',
+      actorType: 'SUPPLIER',          // PRA-079: Prevent cross-platform refresh token reuse
       jti: refreshJti,
     };
 
@@ -1791,11 +1793,11 @@ router.post("/auth/refresh", async (req: Request, res: Response, next: NextFunct
     }
 
     // Verify refresh token
-    let decoded: { sub: string; type: string; jti?: string; iat?: number };
+    let decoded: { sub: string; type: string; actorType?: string; jti?: string; iat?: number };
     try {
       decoded = jwt.verify(refreshToken, JWT_SECRET, {
         issuer: JWT_ISSUER,
-      }) as { sub: string; type: string; jti?: string; iat?: number };
+      }) as { sub: string; type: string; actorType?: string; jti?: string; iat?: number };
     } catch (error) {
       if (error instanceof jwt.TokenExpiredError) {
         res.status(401).json({ error: { code: 'TOKEN_EXPIRED', message: 'Refresh token expired. Please login again.' } });
@@ -1807,6 +1809,12 @@ router.post("/auth/refresh", async (req: Request, res: Response, next: NextFunct
 
     if (decoded.type !== 'refresh') {
       res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Invalid token type' } });
+      return;
+    }
+
+    // PRA-079: Reject refresh tokens from other platforms (backward-compat: allow missing actorType)
+    if (decoded.actorType && decoded.actorType !== 'SUPPLIER') {
+      res.status(401).json({ error: { code: 'INVALID_TOKEN', message: 'Invalid token for this endpoint' } });
       return;
     }
 


### PR DESCRIPTION
## Summary
- **AUTH-001 (MEDIUM):** Added `actorType` claim to all refresh tokens (retailer=STORE, supplier=SUPPLIER). Refresh endpoints now reject tokens from other platforms. Backward-compatible with existing tokens.
- **AUTH-002 (LOW):** Unauthenticated document uploads restricted to `application` entity type only. Store/supplier uploads require auth headers.
- **AUTH-003 (LOW):** Test auth routes now require explicit `NODE_ENV=development` — no longer enabled when NODE_ENV is unset.

## Files changed (6)
- `backend/services/auth-service/src/services/jwtService.ts` — actorType param in generateRefreshToken
- `backend/services/auth-service/src/routes/auth.ts` — pass actorType on token rotation
- `backend/src/routes/v1/retailer-admin/auth.ts` — actorType in 3 login paths + validation on refresh
- `backend/src/routes/v1/supplier/auth.ts` — actorType in 2 login paths + validation on refresh
- `backend/src/routes/v1/documents.ts` — auth check for non-application uploads
- `backend/services/api-gateway/src/routes/testAuth.ts` — strict NODE_ENV check

## Test plan
- [ ] Typecheck passes (verified locally)
- [ ] Retailer login → refresh → new token has actorType=STORE
- [ ] Supplier login → refresh → new token has actorType=SUPPLIER
- [ ] Supplier refresh token rejected at retailer refresh endpoint
- [ ] Unauthenticated POST to /documents/upload with entity_type=store returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)