### PR TITLE
fix(PRA-086): wrap multi-write operations in transactions

### DIFF
--- a/backend/src/routes/v1/admin/applications.ts
+++ b/backend/src/routes/v1/admin/applications.ts
@@ -483,26 +483,38 @@ adminApplicationsRouter.post(
         });
       }
 
-      // Update application
-      const adminNote = `Rejected by ${adminId}: ${rejectionReason.trim()}`;
-      await pool.query(
-        `UPDATE auth.applications
-         SET status = 'NEEDS_FIX',
-             rejection_reason = $1,
-             admin_notes = $2,
-             reviewed_at = NOW(),
-             needs_fix_at = NOW(),
-             expires_at = NOW() + INTERVAL '30 days'
-         WHERE id = $3`,
-        [rejectionReason.trim(), adminNote, id]
-      );
+      // PRA-086: Wrap UPDATE + status log INSERT in transaction
+      const client = await pool.connect();
+      try {
+        await client.query("BEGIN");
 
-      // Log status change
-      await pool.query(
-        `INSERT INTO auth.application_status_log (application_id, old_status, new_status, change_reason)
-         VALUES ($1, $2, 'NEEDS_FIX', $3)`,
-        [id, app.status, rejectionReason.trim()]
-      ).catch(() => { /* status_log table may not exist yet */ });
+        const adminNote = `Rejected by ${adminId}: ${rejectionReason.trim()}`;
+        await client.query(
+          `UPDATE auth.applications
+           SET status = 'NEEDS_FIX',
+               rejection_reason = $1,
+               admin_notes = $2,
+               reviewed_at = NOW(),
+               needs_fix_at = NOW(),
+               expires_at = NOW() + INTERVAL '30 days'
+           WHERE id = $3`,
+          [rejectionReason.trim(), adminNote, id]
+        );
+
+        // Log status change (table may not exist yet — handle gracefully)
+        await client.query(
+          `INSERT INTO auth.application_status_log (application_id, old_status, new_status, change_reason)
+           VALUES ($1, $2, 'NEEDS_FIX', $3)`,
+          [id, app.status, rejectionReason.trim()]
+        ).catch(() => { /* status_log table may not exist yet */ });
+
+        await client.query("COMMIT");
+      } catch (txErr) {
+        await client.query("ROLLBACK");
+        throw txErr;
+      } finally {
+        client.release();
+      }
 
       res.json({
         success: true,

--- a/backend/src/routes/v1/admin/documents.ts
+++ b/backend/src/routes/v1/admin/documents.ts
@@ -206,42 +206,57 @@ router.patch("/:id/verify", async (req: Request, res: Response, next: NextFuncti
       return;
     }
 
-    const result = await pool.query(
-      `UPDATE platform.documents
-       SET status = 'approved',
-           verified_by = $2::uuid,
-           verified_at = NOW(),
-           rejection_reason = NULL,
-           updated_at = NOW()
-       WHERE id = $1::uuid AND deleted_at IS NULL
-       RETURNING id, entity_type, entity_id, document_type, status`,
-      [id, adminId]
-    );
+    // PRA-086: Wrap verify + entity status update in transaction
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
 
-    if (result.rows.length === 0) {
-      res.status(404).json({
-        error: 'NOT_FOUND',
-        message: 'Document not found or already deleted',
+      const result = await client.query(
+        `UPDATE platform.documents
+         SET status = 'approved',
+             verified_by = $2::uuid,
+             verified_at = NOW(),
+             rejection_reason = NULL,
+             updated_at = NOW()
+         WHERE id = $1::uuid AND deleted_at IS NULL
+         RETURNING id, entity_type, entity_id, document_type, status`,
+        [id, adminId]
+      );
+
+      if (result.rows.length === 0) {
+        await client.query("ROLLBACK");
+        client.release();
+        res.status(404).json({
+          error: 'NOT_FOUND',
+          message: 'Document not found or already deleted',
+        });
+        return;
+      }
+
+      const doc = result.rows[0];
+
+      // Update entity kyc_complete flag if all docs approved
+      await updateEntityDocumentStatus(client, doc.entity_type, doc.entity_id);
+
+      await client.query("COMMIT");
+
+      res.json({
+        success: true,
+        document: {
+          id: doc.id,
+          entity_type: doc.entity_type,
+          entity_id: doc.entity_id,
+          document_type: doc.document_type,
+          status: doc.status,
+        },
+        message: 'Document approved successfully',
       });
-      return;
+    } catch (txErr) {
+      await client.query("ROLLBACK");
+      throw txErr;
+    } finally {
+      client.release();
     }
-
-    const doc = result.rows[0];
-
-    // Update entity kyc_complete flag if all docs approved
-    await updateEntityDocumentStatus(pool, doc.entity_type, doc.entity_id);
-
-    res.json({
-      success: true,
-      document: {
-        id: doc.id,
-        entity_type: doc.entity_type,
-        entity_id: doc.entity_id,
-        document_type: doc.document_type,
-        status: doc.status,
-      },
-      message: 'Document approved successfully',
-    });
   } catch (error) {
     next(error);
   }
@@ -271,30 +286,46 @@ router.patch("/:id/reject", async (req: Request, res: Response, next: NextFuncti
       return;
     }
 
-    const result = await pool.query(
-      `UPDATE platform.documents
-       SET status = 'rejected',
-           verified_by = $2::uuid,
-           verified_at = NOW(),
-           rejection_reason = $3,
-           updated_at = NOW()
-       WHERE id = $1::uuid AND deleted_at IS NULL
-       RETURNING id, entity_type, entity_id, document_type, status, rejection_reason`,
-      [id, adminId, reason.trim()]
-    );
+    // PRA-086: Wrap reject + entity status update in transaction
+    const client = await pool.connect();
+    let doc: any;
+    try {
+      await client.query("BEGIN");
 
-    if (result.rows.length === 0) {
-      res.status(404).json({
-        error: 'NOT_FOUND',
-        message: 'Document not found or already deleted',
-      });
-      return;
+      const result = await client.query(
+        `UPDATE platform.documents
+         SET status = 'rejected',
+             verified_by = $2::uuid,
+             verified_at = NOW(),
+             rejection_reason = $3,
+             updated_at = NOW()
+         WHERE id = $1::uuid AND deleted_at IS NULL
+         RETURNING id, entity_type, entity_id, document_type, status, rejection_reason`,
+        [id, adminId, reason.trim()]
+      );
+
+      if (result.rows.length === 0) {
+        await client.query("ROLLBACK");
+        client.release();
+        res.status(404).json({
+          error: 'NOT_FOUND',
+          message: 'Document not found or already deleted',
+        });
+        return;
+      }
+
+      doc = result.rows[0];
+
+      // Update entity kyc_complete flag
+      await updateEntityDocumentStatus(client, doc.entity_type, doc.entity_id);
+
+      await client.query("COMMIT");
+    } catch (txErr) {
+      await client.query("ROLLBACK");
+      throw txErr;
+    } finally {
+      client.release();
     }
-
-    const doc = result.rows[0];
-
-    // Update entity kyc_complete flag
-    await updateEntityDocumentStatus(pool, doc.entity_type, doc.entity_id);
 
     res.json({
       success: true,

--- a/backend/src/routes/v1/documents.ts
+++ b/backend/src/routes/v1/documents.ts
@@ -244,54 +244,68 @@ router.post("/upload", upload.single('file'), async (req: Request, res: Response
     // Get uploaded_by from auth context
     const uploadedBy = (req as any).userId || (req as any).storeId || (req as any).supplierId || null;
 
-    // Upsert document (replace existing if same type)
-    const result = await pool.query(
-      `INSERT INTO platform.documents (
-        entity_type,
-        entity_id,
-        document_type,
-        file_path,
-        file_name,
-        file_size,
-        content_type,
-        status,
-        uploaded_by,
-        uploaded_at
-      ) VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, 'pending', $8::uuid, NOW())
-      ON CONFLICT (entity_type, entity_id, document_type) WHERE deleted_at IS NULL
-      DO UPDATE SET
-        file_path = EXCLUDED.file_path,
-        file_name = EXCLUDED.file_name,
-        file_size = EXCLUDED.file_size,
-        content_type = EXCLUDED.content_type,
-        status = 'pending',
-        rejection_reason = NULL,
-        verified_by = NULL,
-        verified_at = NULL,
-        uploaded_by = EXCLUDED.uploaded_by,
-        uploaded_at = NOW(),
-        updated_at = NOW()
-      RETURNING id, entity_type, entity_id, document_type, file_name, file_size, content_type, status, created_at`,
-      [
-        entity_type,
-        entity_id,
-        document_type,
-        gcsObjectKey,
-        req.file.originalname,
-        req.file.size,
-        req.file.mimetype,
-        uploadedBy
-      ]
-    );
+    // PRA-086: Wrap document upsert + audit log in transaction
+    const client = await pool.connect();
+    let doc: any;
+    try {
+      await client.query("BEGIN");
 
-    const doc = result.rows[0];
+      // Upsert document (replace existing if same type)
+      const result = await client.query(
+        `INSERT INTO platform.documents (
+          entity_type,
+          entity_id,
+          document_type,
+          file_path,
+          file_name,
+          file_size,
+          content_type,
+          status,
+          uploaded_by,
+          uploaded_at
+        ) VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, 'pending', $8::uuid, NOW())
+        ON CONFLICT (entity_type, entity_id, document_type) WHERE deleted_at IS NULL
+        DO UPDATE SET
+          file_path = EXCLUDED.file_path,
+          file_name = EXCLUDED.file_name,
+          file_size = EXCLUDED.file_size,
+          content_type = EXCLUDED.content_type,
+          status = 'pending',
+          rejection_reason = NULL,
+          verified_by = NULL,
+          verified_at = NULL,
+          uploaded_by = EXCLUDED.uploaded_by,
+          uploaded_at = NOW(),
+          updated_at = NOW()
+        RETURNING id, entity_type, entity_id, document_type, file_name, file_size, content_type, status, created_at`,
+        [
+          entity_type,
+          entity_id,
+          document_type,
+          gcsObjectKey,
+          req.file.originalname,
+          req.file.size,
+          req.file.mimetype,
+          uploadedBy
+        ]
+      );
 
-    // Log the upload action
-    await pool.query(
-      `INSERT INTO platform.document_audit (document_id, action, new_status, actor_id, actor_type)
-       VALUES ($1, 'uploaded', 'pending', $2::uuid, 'user')`,
-      [doc.id, uploadedBy]
-    );
+      doc = result.rows[0];
+
+      // Log the upload action
+      await client.query(
+        `INSERT INTO platform.document_audit (document_id, action, new_status, actor_id, actor_type)
+         VALUES ($1, 'uploaded', 'pending', $2::uuid, 'user')`,
+        [doc.id, uploadedBy]
+      );
+
+      await client.query("COMMIT");
+    } catch (txErr) {
+      await client.query("ROLLBACK");
+      throw txErr;
+    } finally {
+      client.release();
+    }
 
     res.status(201).json({
       document_id: doc.id,

--- a/backend/src/routes/v1/orders.ts
+++ b/backend/src/routes/v1/orders.ts
@@ -698,23 +698,36 @@ ordersRouter.delete("/stores/:storeId/orders/:orderId", requireDeviceToken, asyn
       });
     }
 
-    // Delete order items first
-    await pool.query(
-      `DELETE FROM orders.purchase_order_items WHERE order_id = $1`,
-      [orderId]
-    );
+    // PRA-086: Wrap all deletes in a transaction to prevent partial orphans
+    const client = await pool.connect();
+    try {
+      await client.query("BEGIN");
 
-    // Delete order events
-    await pool.query(
-      `DELETE FROM orders.order_events WHERE purchase_order_id = $1`,
-      [orderId]
-    );
+      // Delete order items first
+      await client.query(
+        `DELETE FROM orders.purchase_order_items WHERE order_id = $1`,
+        [orderId]
+      );
 
-    // Delete the order
-    await pool.query(
-      `DELETE FROM orders.purchase_orders WHERE id = $1 AND store_id = $2`,
-      [orderId, storeId]
-    );
+      // Delete order events
+      await client.query(
+        `DELETE FROM orders.order_events WHERE purchase_order_id = $1`,
+        [orderId]
+      );
+
+      // Delete the order
+      await client.query(
+        `DELETE FROM orders.purchase_orders WHERE id = $1 AND store_id = $2`,
+        [orderId, storeId]
+      );
+
+      await client.query("COMMIT");
+    } catch (txErr) {
+      await client.query("ROLLBACK");
+      throw txErr;
+    } finally {
+      client.release();
+    }
 
     // GL-PO-001: Return 204 No Content on successful delete
     return res.status(204).send();


### PR DESCRIPTION
## PRA-086: Backend Transaction Safety

### Findings Fixed
- **086-001 (CRITICAL)**: Order deletion — 3 sequential `pool.query` DELETEs without transaction. If middle DELETE fails, items orphaned.
- **086-002 (MEDIUM)**: Document upload INSERT + audit log INSERT without transaction.
- **086-003 (MEDIUM)**: Document verify/reject + updateEntityDocumentStatus multi-step without transaction.
- **086-004 (MEDIUM)**: Application reject UPDATE + INSERT status_log without transaction.

### Changes
| File | Fix |
|------|-----|
| `backend/src/routes/v1/orders.ts` | Wrap 3 DELETEs in BEGIN/COMMIT/ROLLBACK |
| `backend/src/routes/v1/documents.ts` | Wrap INSERT doc + INSERT audit in transaction |
| `backend/src/routes/v1/admin/documents.ts` | Wrap verify/reject + entity status update in transaction |
| `backend/src/routes/v1/admin/applications.ts` | Wrap UPDATE + status log INSERT in transaction |

### Verification
- `npx tsc --noEmit` passes (zero errors)
- All transactions use try/catch with ROLLBACK on error
- All clients properly released in finally blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)