### PR TITLE
fix(PRA-087): store isolation defense-in-depth on order DELETEs

### DIFF
--- a/backend/src/routes/v1/orders.ts
+++ b/backend/src/routes/v1/orders.ts
@@ -703,16 +703,20 @@ ordersRouter.delete("/stores/:storeId/orders/:orderId", requireDeviceToken, asyn
     try {
       await client.query("BEGIN");
 
-      // Delete order items first
+      // PRA-087: Delete order items with store_id defense-in-depth via EXISTS subquery
       await client.query(
-        `DELETE FROM orders.purchase_order_items WHERE order_id = $1`,
-        [orderId]
+        `DELETE FROM orders.purchase_order_items
+         WHERE order_id = $1
+           AND EXISTS (SELECT 1 FROM orders.purchase_orders WHERE id = $1 AND store_id = $2)`,
+        [orderId, storeId]
       );
 
-      // Delete order events
+      // PRA-087: Delete order events with store_id defense-in-depth via EXISTS subquery
       await client.query(
-        `DELETE FROM orders.order_events WHERE purchase_order_id = $1`,
-        [orderId]
+        `DELETE FROM orders.order_events
+         WHERE purchase_order_id = $1
+           AND EXISTS (SELECT 1 FROM orders.purchase_orders WHERE id = $1 AND store_id = $2)`,
+        [orderId, storeId]
       );
 
       // Delete the order


### PR DESCRIPTION
## PRA-087: Backend Store Isolation Queries

### Findings Fixed
- **087-001 (CRITICAL)**: Order child-table DELETEs (`purchase_order_items`, `order_events`) lacked `store_id` in WHERE clause. While parent order was verified, child DELETEs had no defense-in-depth.

### Fix
Added `EXISTS (SELECT 1 FROM orders.purchase_orders WHERE id = $1 AND store_id = $2)` subquery to both child-table DELETEs, ensuring store ownership is re-verified at the SQL level.

### MEDIUM findings (087-002 through 087-004) — NOT fixed (mitigated)
These are UPDATE statements by primary key within SERIALIZABLE transactions that already verified store ownership via `SELECT ... FOR UPDATE`. The risk is theoretical-only and adding store_id would require schema changes to tables that don't have store_id columns.

### Verification
- `npx tsc --noEmit` passes (zero errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)