### PR TITLE
fix(PRA-082): enforce JWT on chat and credit gateway routes

### DIFF
--- a/backend/services/api-gateway/src/middleware/jwtAuth.ts
+++ b/backend/services/api-gateway/src/middleware/jwtAuth.ts
@@ -79,6 +79,8 @@ const JWT_REQUIRED_PREFIXES = [
   '/api/v1/platform',
   '/api/v1/suppliers',
   '/api/v1/documents',
+  '/api/v1/chat',     // PRA-082: Chat routes need JWT for x-user-id/x-actor-id headers
+  '/api/v1/credit',   // PRA-082: Credit provider routes need JWT for store context
 ];
 
 // Public paths within JWT-required prefixes (no auth needed)


### PR DESCRIPTION
## PRA-082: Gateway Auth Enforcement

### Findings Fixed
- **082-001 (MEDIUM)**: `/api/v1/chat` not in JWT_REQUIRED_PREFIXES — chat backend needs x-user-id/x-actor-id headers from JWT validation
- **082-002 (MEDIUM)**: `/api/v1/credit` not in JWT_REQUIRED_PREFIXES — credit routes need store context from JWT

### Fix
Added both prefixes to `JWT_REQUIRED_PREFIXES` array in `jwtAuth.ts`.

### Verification
- `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)