### PR TITLE
fix(PRA-084): idempotent migration 160 + RLS gap coverage for 8 tables

### DIFF
--- a/backend/migrations/160_pra080_concurrency_constraints.sql
+++ b/backend/migrations/160_pra080_concurrency_constraints.sql
@@ -1,9 +1,19 @@
 -- PRA-080: Add missing concurrency safety constraints
 -- CONC-004: Add CHECK constraint on legacy store_inventory table
 -- Prevents negative stock at database level (defense-in-depth)
+-- PRA-084: Made idempotent with DO $$ guard
 
-ALTER TABLE store_inventory
-  ADD CONSTRAINT chk_store_inventory_qty CHECK (available_qty >= 0);
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE constraint_name = 'chk_store_inventory_qty'
+      AND table_name = 'store_inventory'
+  ) THEN
+    ALTER TABLE store_inventory
+      ADD CONSTRAINT chk_store_inventory_qty CHECK (available_qty >= 0);
+  END IF;
+END $$;
 
 -- CONC-002: Add unique index for stock-in idempotency (belt-and-suspenders with advisory lock)
 CREATE UNIQUE INDEX IF NOT EXISTS idx_inventory_ledger_stockin_idempotency

--- a/backend/migrations/161_pra084_rls_gap_coverage.sql
+++ b/backend/migrations/161_pra084_rls_gap_coverage.sql
@@ -1,0 +1,75 @@
+-- PRA-084: Add RLS to store-scoped tables missed by migration 149
+-- Tables from migrations 142, 143 (pre-149 but missed) and 150-159 (post-149)
+-- Uses the same rls_store_check() function created in migration 149
+
+-- =============================================================================
+-- 1. Enable RLS on missed tables
+-- =============================================================================
+
+-- Pre-149 tables (missed by 149)
+ALTER TABLE orders.purchase_cart_drafts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE orders.purchase_cart_drafts FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE orders.refunds ENABLE ROW LEVEL SECURITY;
+ALTER TABLE orders.refunds FORCE ROW LEVEL SECURITY;
+
+-- Post-149 tables with store_id NOT NULL
+ALTER TABLE orders.payment_reminders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE orders.payment_reminders FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE payments.repayment_schedules ENABLE ROW LEVEL SECURITY;
+ALTER TABLE payments.repayment_schedules FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE ai.alerts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai.alerts FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE ai.demand_forecasts ENABLE ROW LEVEL SECURITY;
+ALTER TABLE ai.demand_forecasts FORCE ROW LEVEL SECURITY;
+
+-- Post-149 tables with store_id NULLABLE (allow NULL = system/superadmin rows)
+ALTER TABLE chat.conversations ENABLE ROW LEVEL SECURITY;
+ALTER TABLE chat.conversations FORCE ROW LEVEL SECURITY;
+
+ALTER TABLE whatsapp.message_logs ENABLE ROW LEVEL SECURITY;
+ALTER TABLE whatsapp.message_logs FORCE ROW LEVEL SECURITY;
+
+-- =============================================================================
+-- 2. Create RLS policies (DROP IF EXISTS for idempotency)
+-- =============================================================================
+
+-- Orders schema
+DROP POLICY IF EXISTS rls_purchase_cart_drafts_store ON orders.purchase_cart_drafts;
+CREATE POLICY rls_purchase_cart_drafts_store ON orders.purchase_cart_drafts
+  FOR ALL USING (rls_store_check(store_id));
+
+DROP POLICY IF EXISTS rls_refunds_store ON orders.refunds;
+CREATE POLICY rls_refunds_store ON orders.refunds
+  FOR ALL USING (rls_store_check(store_id));
+
+DROP POLICY IF EXISTS rls_payment_reminders_store ON orders.payment_reminders;
+CREATE POLICY rls_payment_reminders_store ON orders.payment_reminders
+  FOR ALL USING (rls_store_check(store_id));
+
+-- Payments schema
+DROP POLICY IF EXISTS rls_repayment_schedules_store ON payments.repayment_schedules;
+CREATE POLICY rls_repayment_schedules_store ON payments.repayment_schedules
+  FOR ALL USING (rls_store_check(store_id));
+
+-- AI schema
+DROP POLICY IF EXISTS rls_ai_alerts_store ON ai.alerts;
+CREATE POLICY rls_ai_alerts_store ON ai.alerts
+  FOR ALL USING (rls_store_check(store_id));
+
+DROP POLICY IF EXISTS rls_ai_demand_forecasts_store ON ai.demand_forecasts;
+CREATE POLICY rls_ai_demand_forecasts_store ON ai.demand_forecasts
+  FOR ALL USING (rls_store_check(store_id));
+
+-- Chat schema (nullable store_id — allow rows where store_id IS NULL)
+DROP POLICY IF EXISTS rls_chat_conversations_store ON chat.conversations;
+CREATE POLICY rls_chat_conversations_store ON chat.conversations
+  FOR ALL USING (store_id IS NULL OR rls_store_check(store_id));
+
+-- WhatsApp schema (nullable store_id — allow superadmin-sent messages)
+DROP POLICY IF EXISTS rls_wa_message_logs_store ON whatsapp.message_logs;
+CREATE POLICY rls_wa_message_logs_store ON whatsapp.message_logs
+  FOR ALL USING (store_id IS NULL OR rls_store_check(store_id));


### PR DESCRIPTION
## PRA-084: Database Migrations Safety

### Findings Fixed
- **084-001 (MEDIUM)**: RLS migration 149 missed 8 store-scoped tables — new migration 161 adds RLS policies
- **084-003 (MEDIUM)**: Migration 160 `ADD CONSTRAINT` was not idempotent — wrapped in `DO $$ IF NOT EXISTS` guard

### Tables Added to RLS (migration 161)
| Table | store_id | Policy |
|-------|----------|--------|
| `orders.purchase_cart_drafts` | NOT NULL | Standard rls_store_check |
| `orders.refunds` | NOT NULL | Standard rls_store_check |
| `orders.payment_reminders` | NOT NULL | Standard rls_store_check |
| `payments.repayment_schedules` | NOT NULL | Standard rls_store_check |
| `ai.alerts` | NOT NULL | Standard rls_store_check |
| `ai.demand_forecasts` | NOT NULL | Standard rls_store_check |
| `chat.conversations` | NULLABLE | NULL OR rls_store_check |
| `whatsapp.message_logs` | NULLABLE | NULL OR rls_store_check |

### Verification
- All policies use existing `rls_store_check()` function from migration 149
- DROP POLICY IF EXISTS for idempotency (re-run safe)
- Nullable store_id tables allow NULL rows (system/superadmin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)