### PR TITLE
fix(PRA-090): Dockerfile HEALTHCHECK + port consistency

### DIFF
--- a/backend/Dockerfile.main
+++ b/backend/Dockerfile.main
@@ -74,5 +74,9 @@ ENV BUILD_TIME=$BUILD_TIME
 
 EXPOSE 3010
 
+# PRA-090: Health check consistent with other Dockerfiles
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
+  CMD wget --no-verbose --tries=1 --spider http://localhost:${PORT}/health || exit 1
+
 # Entrypoint: runs migrations then starts server
 CMD ["./scripts/docker-entrypoint.sh"]

--- a/supplier-portal/Dockerfile
+++ b/supplier-portal/Dockerfile
@@ -69,10 +69,11 @@ RUN chown -R nodejs:nodejs /app
 USER nodejs
 
 # Environment
+# PRA-090: Cloud Run overrides PORT to 8080 at runtime; default matches Cloud Run
 ENV NODE_ENV=production
-ENV PORT=3001
+ENV PORT=8080
 
-EXPOSE 3001
+EXPOSE 8080
 
 # SUP-ROOT-001: Health check uses /supplier/ path (basePath + trailingSlash in next.config.js)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \


### PR DESCRIPTION
## PRA-090: Cloud Run Deployment Config

### Findings Fixed
- **090-001 (LOW)**: `Dockerfile.main` had no HEALTHCHECK instruction (inconsistent with all other Dockerfiles)
- **090-002 (LOW)**: `supplier-portal/Dockerfile` used `PORT=3001` / `EXPOSE 3001` but Cloud Run overrides to 8080

### Changes
| File | Fix |
|------|-----|
| `backend/Dockerfile.main` | Added HEALTHCHECK (wget /health) |
| `supplier-portal/Dockerfile` | Changed PORT/EXPOSE from 3001 to 8080 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)