### PR TITLE
fix(PRA-063): respect backend buyEnabled flag + legacy format fallback

### DIFF
--- a/src/services/api/uiStatusApi.ts
+++ b/src/services/api/uiStatusApi.ts
@@ -65,7 +65,7 @@ function parseUiStatusResponse(raw: unknown): UiStatusResponse {
       features: {
         scan_lookup_v2: (features.scanLookupV2 as boolean) ?? true,
         reorderEnabled: (features.reorderEnabled as boolean) ?? true,
-        buyEnabled: true,
+        buyEnabled: (features.buyEnabled as boolean) ?? true,
         inventoryEnabled: true,
         suppliersEnabled: true,
         ordersEnabled: true,
@@ -92,7 +92,7 @@ function parseUiStatusResponse(raw: unknown): UiStatusResponse {
     // SA-P2-003: Version enforcement from flat format
     forceUpdate: (obj.forceUpdate as boolean) ?? false,
     minAppVersion: (obj.minAppVersion as string) ?? null,
-    features: obj.features as UiStatusResponse['features'],
+    features: (obj.features as UiStatusResponse['features']) ?? getDefaultUiStatus().features,
   };
 }
 


### PR DESCRIPTION
## Summary
- **buyEnabled hardcoded to `true`** in POS v5 nested format parser (line 68), ignoring backend's `features.buyEnabled` value. SuperAdmin toggling buy feature OFF had no effect on POS devices.
- **Legacy flat format** had no fallback for undefined `features` object (line 95), causing settingsStore to never update feature flags when using older API response format.

## Files Changed
- `src/services/api/uiStatusApi.ts` — 2 lines changed

## Test Plan
- [ ] Toggle buyEnabled=false in SuperAdmin → verify POS hides BUY tab within 60s
- [ ] Verify reorderEnabled, creditEnabled, bnplEnabled still respect backend values
- [ ] Verify offline/error default still enables all features (permissive fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)