### PR TITLE
fix(PRA-007): add category breakdown to retailer analytics

### DIFF
--- a/backend/src/routes/v1/retailer-admin/inventory.ts
+++ b/backend/src/routes/v1/retailer-admin/inventory.ts
@@ -5,6 +5,7 @@
 
 import { Router, Request, Response } from "express";
 import { getPool } from "../../../db/client";
+import { fetchProductsAnalytics } from "../../../services/analytics/analyticsService";
 
 // Git SHA and build time for health endpoint
 const GIT_SHA = process.env['GIT_SHA'] || 'dev';
@@ -349,6 +350,83 @@ retailerAdminInventoryRouter.get("/analytics/sales", async (req: Request, res: R
       });
     }
     return res.status(500).json({ success: false, error: { code: "ANALYTICS_FAILED", message: "Failed to load analytics" } });
+  }
+});
+
+// =============================================================================
+// PRA-007: PRODUCT ANALYTICS WITH CATEGORY BREAKDOWN
+// Ports superadmin groupBy=category to retailer via shared analyticsService
+// =============================================================================
+
+/**
+ * GET /api/v1/retailer-admin/analytics/products
+ * PRA-007: Product analytics with category breakdown for retailer dashboard
+ *
+ * Query params:
+ * - from: ISO date string (YYYY-MM-DD), defaults to 7 days ago
+ * - to: ISO date string (YYYY-MM-DD), defaults to today
+ * - groupBy: 'category' | 'day' | 'hour' (default 'category')
+ *
+ * Returns: top products, sales by group (category/time), new products created
+ * Store isolation: storeId derived from JWT via x-actor-id (never from query)
+ */
+retailerAdminInventoryRouter.get("/analytics/products", async (req: Request, res: Response) => {
+  const pool = getPool();
+  if (!pool) return res.status(503).json({ error: "database unavailable" });
+
+  const storeId = getStoreId(req);
+  if (!storeId) {
+    return res.status(401).json({ error: "Store not identified" });
+  }
+
+  const today = new Date().toISOString().split('T')[0];
+  const weekAgo = new Date(Date.now() - 7 * 86400000).toISOString().split('T')[0];
+  const fromDate = (req.query.from as string) || weekAgo;
+  const toDate = (req.query.to as string) || today;
+  const groupBy = (req.query.groupBy as string) || 'category';
+
+  // Validate dates
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(fromDate) || !/^\d{4}-\d{2}-\d{2}$/.test(toDate)) {
+    return res.status(400).json({ error: "Invalid date format. Use YYYY-MM-DD." });
+  }
+
+  try {
+    // Reuse shared analytics service — storeId from JWT ensures store isolation
+    const result = await fetchProductsAnalytics({
+      storeId,
+      from: fromDate,
+      to: toDate,
+      groupBy,
+      limit: 20,
+    });
+
+    return res.json({
+      success: true,
+      data: {
+        from: result.range.from,
+        to: result.range.to,
+        groupBy: result.group_by,
+        salesByGroup: result.sales_by_group,
+        topProducts: result.top_products.map(p => ({
+          productId: p.product_id,
+          productName: p.name,
+          category: p.category,
+          qtySold: p.quantity,
+          totalAmount: p.total_minor,
+        })),
+        newProductsCount: result.new_products_created_count,
+        missingFields: result.missing_fields,
+      },
+    });
+  } catch (error: any) {
+    console.error("[PRA-007] Product analytics error:", error.message);
+    if (error.message === "database unavailable") {
+      return res.status(503).json({ error: "database unavailable" });
+    }
+    return res.status(500).json({
+      success: false,
+      error: { code: "ANALYTICS_FAILED", message: "Failed to load product analytics" },
+    });
   }
 });
 

--- a/retailer-admin/src/api/store.ts
+++ b/retailer-admin/src/api/store.ts
@@ -171,6 +171,50 @@ export async function fetchSalesAnalytics(accessToken: string, from?: string, to
   return data;
 }
 
+// PRA-007: Product analytics with category breakdown
+export interface CategorySalesGroup {
+  group: string;
+  total_minor: number;
+  quantity: number;
+}
+
+export interface ProductAnalytics {
+  from: string;
+  to: string;
+  groupBy: 'category' | 'day' | 'hour';
+  salesByGroup: CategorySalesGroup[];
+  topProducts: Array<{
+    productId: string;
+    productName: string;
+    category: string | null;
+    qtySold: number;
+    totalAmount: number;
+  }>;
+  newProductsCount: number;
+  missingFields: string[];
+}
+
+export async function fetchProductAnalytics(
+  accessToken: string,
+  from?: string,
+  to?: string,
+  groupBy: string = 'category'
+): Promise<ApiResponse<ProductAnalytics>> {
+  const params = new URLSearchParams();
+  if (from) params.set('from', from);
+  if (to) params.set('to', to);
+  params.set('groupBy', groupBy);
+  const qs = params.toString();
+  const response = await authFetch(`${API_BASE}/analytics/products?${qs}`, accessToken);
+
+  if (response.status === 401) throw new Error('Unauthorized');
+  if (!response.ok) throw new Error('Failed to fetch product analytics');
+
+  const data = await safeJson<ApiResponse<ProductAnalytics>>(response);
+  if (!data) throw new Error('Invalid response from server');
+  return data;
+}
+
 // FE-RETAILER-CAT-001: Categories from FMCG taxonomy
 export interface FmcgCategory {
   id: string;

--- a/retailer-admin/src/pages/AnalyticsPage.tsx
+++ b/retailer-admin/src/pages/AnalyticsPage.tsx
@@ -1,7 +1,8 @@
 // T-212: Sales Analytics Dashboard for Retailer Admin
+// PRA-007: Added category breakdown via shared analyticsService
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../lib/AuthContext';
-import { fetchSalesAnalytics, SalesAnalytics } from '../api/store';
+import { fetchSalesAnalytics, SalesAnalytics, fetchProductAnalytics, ProductAnalytics } from '../api/store';
 import Breadcrumb from '../components/Breadcrumb';
 import { formatCurrency } from '../lib/formatters';
 
@@ -20,6 +21,7 @@ export default function AnalyticsPage() {
   const [from, setFrom] = useState(defaults.from);
   const [to, setTo] = useState(defaults.to);
   const [data, setData] = useState<SalesAnalytics | null>(null);
+  const [categoryData, setCategoryData] = useState<ProductAnalytics | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -28,8 +30,12 @@ export default function AnalyticsPage() {
     setLoading(true);
     setError(null);
     try {
-      const result = await fetchSalesAnalytics(accessToken, from, to);
-      setData(result.data);
+      const [salesResult, categoryResult] = await Promise.all([
+        fetchSalesAnalytics(accessToken, from, to),
+        fetchProductAnalytics(accessToken, from, to, 'category'),
+      ]);
+      setData(salesResult.data);
+      setCategoryData(categoryResult.data);
     } catch (e: any) {
       setError(e.message || 'Failed to load analytics');
     } finally {
@@ -201,6 +207,43 @@ export default function AnalyticsPage() {
               )}
             </div>
           </div>
+
+          {/* PRA-007: Category Breakdown */}
+          {categoryData && categoryData.salesByGroup.length > 0 && (
+            <div className="bg-white rounded-xl border border-slate-200 p-4 mb-6">
+              <h2 className="font-semibold text-slate-700 mb-4">Sales by Category</h2>
+              {categoryData.missingFields.includes('variants.category') && (
+                <p className="text-xs text-amber-600 mb-3">
+                  Category data is incomplete — some products may appear as &quot;Uncategorized&quot;.
+                </p>
+              )}
+              <div className="space-y-2">
+                {categoryData.salesByGroup.map((cat, i) => {
+                  const maxTotal = categoryData.salesByGroup[0]?.total_minor || 1;
+                  const pct = Math.round((cat.total_minor / maxTotal) * 100);
+                  return (
+                    <div key={cat.group || i} className="flex items-center gap-3">
+                      <span className="text-sm text-slate-600 w-32 truncate shrink-0" title={cat.group}>
+                        {cat.group}
+                      </span>
+                      <div className="flex-1 bg-slate-100 rounded-full h-5 overflow-hidden">
+                        <div
+                          className="bg-indigo-500 h-full rounded-full transition-all"
+                          style={{ width: `${Math.max(pct, 2)}%` }}
+                        />
+                      </div>
+                      <span className="text-sm font-medium text-slate-700 w-24 text-right shrink-0">
+                        {formatCurrency(cat.total_minor)}
+                      </span>
+                      <span className="text-xs text-slate-400 w-16 text-right shrink-0">
+                        {cat.quantity} sold
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
         </>
       )}
 


### PR DESCRIPTION
## Summary
- Ports category breakdown analytics from superadmin to retailer-admin dashboard
- New `GET /api/v1/retailer-admin/analytics/products?groupBy=category` endpoint calling shared `fetchProductsAnalytics`
- Frontend: typed API client + horizontal bar chart showing sales by category with amounts and quantities sold

## Security
- Store isolation: `storeId` derived from JWT via `x-actor-id` header (never from query params)
- `groupBy` parameter validated via `validateAnalyticsGroupBy()` whitelist (prevents SQL injection)
- Full auth middleware chain: `validateGatewayHeaders` → `requireStoreOwnership` → `verifyStoreExists` → `requireActiveStore` → `requireActiveUser`

## Files Changed
- `backend/src/routes/v1/retailer-admin/inventory.ts` — new `/analytics/products` endpoint
- `retailer-admin/src/api/store.ts` — `ProductAnalytics` types + `fetchProductAnalytics()` function
- `retailer-admin/src/pages/AnalyticsPage.tsx` — category breakdown UI section

## Test plan
- [ ] Verify `GET /analytics/products?groupBy=category` returns `salesByGroup` with category names
- [ ] Verify `missingFields` includes `variants.category` when all products are Uncategorized
- [ ] Verify UI renders horizontal bars with correct proportions
- [ ] Verify store isolation — response only includes data for the authenticated store

🤖 Generated with [Claude Code](https://claude.com/claude-code)