### PR TITLE
fix(UIUX-W1): Wave 1 P0 critical fixes — 15 tickets

### DIFF
--- a/retailer-admin/src/pages/DashboardPage.tsx
+++ b/retailer-admin/src/pages/DashboardPage.tsx
@@ -664,7 +664,7 @@ export default function DashboardPage() {
                 textAlign: 'center',
               }}>
                 <div style={{ fontSize: '1.5rem', fontWeight: '700', color: '#059669' }}>
-                  {formatRupees(dailySummary.totalSales)}
+                  {formatCurrency(dailySummary.totalSales)}
                 </div>
                 <div style={{ fontSize: '0.75rem', color: '#64748b', marginTop: '0.25rem' }}>Total Sales</div>
               </div>
@@ -690,7 +690,7 @@ export default function DashboardPage() {
                 textAlign: 'center',
               }}>
                 <div style={{ fontSize: '1.5rem', fontWeight: '700', color: '#d97706' }}>
-                  {formatRupees(dailySummary.averageBillValue)}
+                  {formatCurrency(dailySummary.averageBillValue)}
                 </div>
                 <div style={{ fontSize: '0.75rem', color: '#64748b', marginTop: '0.25rem' }}>Avg Bill</div>
               </div>
@@ -722,17 +722,17 @@ export default function DashboardPage() {
                 <span style={{ color: '#64748b', fontWeight: '500' }}>Payment Modes:</span>
                 {dailySummary.paymentBreakdown.cash > 0 && (
                   <span style={{ color: '#059669' }}>
-                    💵 Cash: {formatRupees(dailySummary.paymentBreakdown.cash)}
+                    💵 Cash: {formatCurrency(dailySummary.paymentBreakdown.cash)}
                   </span>
                 )}
                 {dailySummary.paymentBreakdown.upi > 0 && (
                   <span style={{ color: '#2563eb' }}>
-                    📱 UPI: {formatRupees(dailySummary.paymentBreakdown.upi)}
+                    📱 UPI: {formatCurrency(dailySummary.paymentBreakdown.upi)}
                   </span>
                 )}
                 {dailySummary.paymentBreakdown.card > 0 && (
                   <span style={{ color: '#7c3aed' }}>
-                    💳 Card: {formatRupees(dailySummary.paymentBreakdown.card)}
+                    💳 Card: {formatCurrency(dailySummary.paymentBreakdown.card)}
                   </span>
                 )}
               </div>

--- a/src/screens/BnplDuesScreen.tsx
+++ b/src/screens/BnplDuesScreen.tsx
@@ -298,7 +298,8 @@ export function BnplDuesScreen({ onBack }: BnplDuesScreenProps) {
         setPaymentModal((prev) => ({ ...prev, paying: false }));
       }
     },
-    [paymentModal.drawdown, loadData, startAutoPolling]
+    // UIUX-POS-002: payAmountText is read inside callback — must be in deps to avoid stale closure
+    [paymentModal.drawdown, paymentModal.payAmountText, loadData, startAutoPolling]
   );
 
   // Confirm UPI payment with UTR

--- a/src/screens/DailyClosingScreen.tsx
+++ b/src/screens/DailyClosingScreen.tsx
@@ -77,22 +77,23 @@ export default function DailyClosingScreen({ onBack }: DailyClosingScreenProps) 
   const [actualCash, setActualCash] = useState("");
   const [refreshing, setRefreshing] = useState(false);
 
+  // UIUX-POS-003: All deps that are read inside the callback must be listed
   useEffect(() => {
     void fetchSummary(selectedDate);
-  }, [selectedDate]);
+  }, [selectedDate, fetchSummary]);
 
   useEffect(() => {
     if (activeTab === "HISTORY") {
       void fetchHistory();
     }
-  }, [activeTab]);
+  }, [activeTab, fetchHistory]);
 
   useEffect(() => {
     if (error) {
       Alert.alert(t("common.error"), error);
       clearError();
     }
-  }, [error]);
+  }, [error, t, clearError]);
 
   const handleRefresh = useCallback(() => {
     setRefreshing(true);

--- a/src/screens/ShiftScreen.tsx
+++ b/src/screens/ShiftScreen.tsx
@@ -93,22 +93,23 @@ export default function ShiftScreen({ onBack }: ShiftScreenProps) {
   const [closingCash, setClosingCash] = useState("");
   const [endNotes, setEndNotes] = useState("");
 
+  // UIUX-POS-003: All deps that are read inside the callback must be listed
   useEffect(() => {
     void fetchCurrentShift();
-  }, []);
+  }, [fetchCurrentShift]);
 
   useEffect(() => {
     if (activeTab === "HISTORY") {
       void fetchHistory();
     }
-  }, [activeTab]);
+  }, [activeTab, fetchHistory]);
 
   useEffect(() => {
     if (error) {
       Alert.alert("Error", error);
       clearError();
     }
-  }, [error]);
+  }, [error, clearError]);
 
   const handleRefresh = useCallback(() => {
     setRefreshing(true);

--- a/src/screens/SuccessPrintScreenV2.tsx
+++ b/src/screens/SuccessPrintScreenV2.tsx
@@ -39,14 +39,19 @@ export default function SuccessPrintScreenV2() {
   const route = useRoute<Rt>();
   const { items, total, subtotal, discountAmount, discount, clearCart, unlockCart } = useCartStore();
 
+  // UIUX-POS-001: useRef MUST be unconditional (Rules of Hooks).
+  // These are fallbacks when route params don't provide billId/transactionId.
+  const fallbackBillRef = useRef(Date.now().toString().slice(-6));
+  const fallbackTxnRef = useRef(`${Date.now()}-${Math.random().toString(16).slice(2)}`);
+
   const saleItems = route.params?.saleItems ?? items;
   const saleTotalMinor = route.params?.saleTotalMinor ?? total;
   const currency = route.params?.saleCurrency ?? saleItems[0]?.currency ?? "INR";
   const paymentMode = route.params?.paymentMode ?? "CASH";
-  const billNumber = route.params?.billId ?? useRef(Date.now().toString().slice(-6)).current;
+  const billNumber = route.params?.billId ?? fallbackBillRef.current;
   const isPartialSale = route.params?.partialSale === true;
   // For reconciliation: tie receipt/print outcomes to a bill id.
-  const transactionId = route.params?.transactionId ?? useRef(`${Date.now()}-${Math.random().toString(16).slice(2)}`).current;
+  const transactionId = route.params?.transactionId ?? fallbackTxnRef.current;
 
   const [printStatus, setPrintStatus] = useState<"idle" | "printing" | "success" | "failed">("idle");
   const [operatorStoreId, setOperatorStoreId] = useState<string | null>(null);

--- a/supermandi-superadmin/src/tabs/AIInsightsTab.tsx
+++ b/supermandi-superadmin/src/tabs/AIInsightsTab.tsx
@@ -2,6 +2,8 @@
 // Shows AI-powered anomalies, alerts, and customer insights across stores
 
 import { useState, useEffect, useCallback } from 'react';
+// UIUX-SA-002: Use centralized auth instead of wrong 'superadmin_token' key
+import { getSessionToken, fetchWithTimeout } from '../api/authToken';
 
 interface AnomalyEvent {
   id: string;
@@ -25,9 +27,10 @@ interface Alert {
   createdAt: string;
 }
 
+// UIUX-SA-002: Centralized auth via getSessionToken (reads 'supermandi_admin_session')
 async function apiFetch(url: string, options?: RequestInit) {
-  const token = localStorage.getItem('superadmin_token') || '';
-  const res = await fetch(url, {
+  const token = getSessionToken() || '';
+  const res = await fetchWithTimeout(url, {
     ...options,
     headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}`, ...options?.headers },
   });

--- a/supermandi-superadmin/src/tabs/CreditProvidersTab.tsx
+++ b/supermandi-superadmin/src/tabs/CreditProvidersTab.tsx
@@ -3,6 +3,8 @@
 // T-281: Provider Health Monitoring
 
 import { useState, useEffect, useCallback } from 'react';
+// UIUX-SA-003: Use centralized auth instead of wrong 'superadmin_token' key
+import { getSessionToken, fetchWithTimeout } from '../api/authToken';
 
 interface ProviderConfig {
   id: string;
@@ -40,9 +42,10 @@ function fmt(minorStr: string | number): string {
   return new Intl.NumberFormat('en-IN', { style: 'currency', currency: 'INR', minimumFractionDigits: 0 }).format((minor || 0) / 100);
 }
 
+// UIUX-SA-003: Centralized auth via getSessionToken (reads 'supermandi_admin_session')
 async function apiFetch(url: string, options?: RequestInit) {
-  const token = localStorage.getItem('superadmin_token') || '';
-  const res = await fetch(url, {
+  const token = getSessionToken() || '';
+  const res = await fetchWithTimeout(url, {
     ...options,
     headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}`, ...options?.headers },
   });

--- a/supermandi-superadmin/src/tabs/SupportQueueTab.tsx
+++ b/supermandi-superadmin/src/tabs/SupportQueueTab.tsx
@@ -3,6 +3,8 @@
 // T-302: Message template management UI
 
 import { useState, useEffect, useCallback } from 'react';
+// UIUX-SA-001: Use centralized auth (getSessionToken + fetchWithTimeout) instead of wrong 'superadmin_token' key
+import { getSessionToken, fetchWithTimeout } from '../api/authToken';
 
 interface SupportConversation {
   id: string;
@@ -35,9 +37,11 @@ interface MessageTemplate {
   isActive: boolean;
 }
 
+// UIUX-SA-001: Centralized auth via getSessionToken (reads 'supermandi_admin_session')
+// UIUX-SA-004: All chat admin routes use /api/v1/admin/chat/ prefix
 async function apiFetch(url: string, options?: RequestInit) {
-  const token = localStorage.getItem('superadmin_token') || '';
-  const res = await fetch(url, {
+  const token = getSessionToken() || '';
+  const res = await fetchWithTimeout(url, {
     ...options,
     headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}`, ...options?.headers },
   });
@@ -70,7 +74,7 @@ export function SupportQueueTab() {
     setLoading(true);
     setError(null);
     try {
-      const result = await apiFetch(`/api/v1/chat/support/queue?status=${statusFilter}&limit=100`);
+      const result = await apiFetch(`/api/v1/admin/chat/support/queue?status=${statusFilter}&limit=100`);
       setConversations(result.conversations || []);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to load');
@@ -81,7 +85,7 @@ export function SupportQueueTab() {
 
   const fetchTemplates = useCallback(async () => {
     try {
-      const result = await apiFetch('/api/v1/chat/templates');
+      const result = await apiFetch('/api/v1/admin/chat/templates');
       setTemplates(result.templates || []);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Failed to load templates');
@@ -96,7 +100,7 @@ export function SupportQueueTab() {
   const selectConversation = async (convId: string) => {
     setSelectedConvId(convId);
     try {
-      const result = await apiFetch(`/api/v1/chat/conversations/${convId}/messages?limit=100`);
+      const result = await apiFetch(`/api/v1/admin/chat/conversations/${convId}/messages?limit=100`);
       setMessages((result.messages || []).slice().reverse());
     } catch {
       setMessages([]);
@@ -106,7 +110,7 @@ export function SupportQueueTab() {
   const sendReply = async () => {
     if (!replyText.trim() || !selectedConvId) return;
     try {
-      await apiFetch(`/api/v1/chat/conversations/${selectedConvId}/messages`, {
+      await apiFetch(`/api/v1/admin/chat/conversations/${selectedConvId}/messages`, {
         method: 'POST',
         body: JSON.stringify({ content: replyText.trim(), messageType: 'text' }),
       });
@@ -120,7 +124,7 @@ export function SupportQueueTab() {
 
   const assignToMe = async (convId: string) => {
     try {
-      await apiFetch(`/api/v1/chat/support/${convId}/assign`, {
+      await apiFetch(`/api/v1/admin/chat/support/${convId}/assign`, {
         method: 'POST',
         body: JSON.stringify({ agentName: 'Admin' }),
       });
@@ -133,7 +137,7 @@ export function SupportQueueTab() {
 
   const resolveConversation = async (convId: string) => {
     try {
-      await apiFetch(`/api/v1/chat/support/${convId}/resolve`, { method: 'POST' });
+      await apiFetch(`/api/v1/admin/chat/support/${convId}/resolve`, { method: 'POST' });
       fetchQueue();
       setSelectedConvId(null);
       setMessages([]);

--- a/supplier-portal/src/app/(dashboard)/bnpl-orders/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/bnpl-orders/page.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 // T-280: Supplier-Side BNPL Visibility
-// Shows which purchase orders are BNPL-backed (payment guaranteed)
+// UIUX-SUP-003: Replaced undefined CSS classes with Tailwind utilities
+// UIUX-SUP-004: Replaced raw fetch() with apiFetch for auth + 401 redirect + timeout
 
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import Breadcrumb from '@/components/Breadcrumb';
 import EmptyState from '@/components/EmptyState';
 import { formatCurrency } from '@/lib/formatters';
+import { apiFetch } from '@/lib/api';
 import { ShieldCheck, Package } from 'lucide-react';
 
 interface BnplOrder {
@@ -39,10 +41,10 @@ async function fetchBnplOrders(status?: string): Promise<{ orders: BnplOrder[]; 
   if (status) params.set('status', status);
   params.set('limit', '100');
 
-  const res = await fetch(`/api/v1/supplier/bnpl/backed-orders?${params}`, { credentials: 'include' });
-  if (!res.ok) throw new Error(`Failed: ${res.status}`);
-  const json = await res.json();
-  return { orders: json.orders || [], summary: json.summary || {} };
+  const json = await apiFetch<{ orders: BnplOrder[]; summary: BnplSummary }>(
+    `/api/v1/supplier/bnpl/backed-orders?${params}`
+  );
+  return { orders: json.orders || [], summary: json.summary || {} as BnplSummary };
 }
 
 function fmtDate(iso: string): string {
@@ -51,14 +53,20 @@ function fmtDate(iso: string): string {
   return `${d}/${m}/${y}`;
 }
 
-function statusBadge(status: string) {
-  switch (status) {
-    case 'active': return { className: 'badge badge-info', label: 'Active' };
-    case 'partial': return { className: 'badge badge-warning', label: 'Partial' };
-    case 'overdue': return { className: 'badge badge-danger', label: 'Overdue' };
-    case 'paid': return { className: 'badge badge-success', label: 'Paid' };
-    default: return { className: 'badge', label: status };
-  }
+const statusBadgeStyles: Record<string, string> = {
+  active: 'bg-blue-100 text-blue-700',
+  partial: 'bg-amber-100 text-amber-700',
+  overdue: 'bg-red-100 text-red-700',
+  paid: 'bg-green-100 text-green-700',
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const styles = statusBadgeStyles[status] || 'bg-slate-100 text-slate-600';
+  return (
+    <span className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${styles}`}>
+      {status.charAt(0).toUpperCase() + status.slice(1)}
+    </span>
+  );
 }
 
 export default function BnplOrdersPage() {
@@ -76,105 +84,109 @@ export default function BnplOrdersPage() {
     <div>
       <Breadcrumb items={[{ label: 'Dashboard', href: '/dashboard' }, { label: 'BNPL Orders' }]} />
 
-      <div className="page-header">
-        <h1 className="page-title">BNPL-Backed Orders</h1>
-        <p className="text-muted" style={{ marginTop: '0.25rem' }}>
+      <div className="mt-4 mb-6">
+        <h1 className="text-xl font-bold text-slate-900">BNPL-Backed Orders</h1>
+        <p className="text-sm text-slate-500 mt-1">
           Orders financed through credit providers — payment guaranteed
         </p>
       </div>
 
       {/* Summary Cards */}
       {summary && (
-        <div className="stats-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: '1rem', marginBottom: '1.5rem' }}>
-          <div className="card" style={{ padding: '1rem' }}>
-            <div className="text-muted" style={{ fontSize: '0.8rem' }}>Total Financed</div>
-            <div style={{ fontSize: '1.25rem', fontWeight: 700 }}>{formatCurrency(summary.totalFinancedMinor / 100)}</div>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+          <div className="bg-white rounded-lg border border-slate-200 p-4">
+            <div className="text-xs text-slate-500">Total Financed</div>
+            <div className="text-lg font-bold mt-1">{formatCurrency(summary.totalFinancedMinor)}</div>
           </div>
-          <div className="card" style={{ padding: '1rem' }}>
-            <div className="text-muted" style={{ fontSize: '0.8rem' }}>Outstanding</div>
-            <div style={{ fontSize: '1.25rem', fontWeight: 700, color: summary.outstandingMinor > 0 ? '#dc2626' : undefined }}>
-              {formatCurrency(summary.outstandingMinor / 100)}
+          <div className="bg-white rounded-lg border border-slate-200 p-4">
+            <div className="text-xs text-slate-500">Outstanding</div>
+            <div className={`text-lg font-bold mt-1 ${summary.outstandingMinor > 0 ? 'text-red-600' : ''}`}>
+              {formatCurrency(summary.outstandingMinor)}
             </div>
           </div>
-          <div className="card" style={{ padding: '1rem' }}>
-            <div className="text-muted" style={{ fontSize: '0.8rem' }}>Repaid</div>
-            <div style={{ fontSize: '1.25rem', fontWeight: 700, color: '#16a34a' }}>{formatCurrency(summary.totalRepaidMinor / 100)}</div>
+          <div className="bg-white rounded-lg border border-slate-200 p-4">
+            <div className="text-xs text-slate-500">Repaid</div>
+            <div className="text-lg font-bold mt-1 text-green-600">{formatCurrency(summary.totalRepaidMinor)}</div>
           </div>
-          <div className="card" style={{ padding: '1rem' }}>
-            <div className="text-muted" style={{ fontSize: '0.8rem' }}>Active Orders</div>
-            <div style={{ fontSize: '1.25rem', fontWeight: 700 }}>{summary.activeOrders}</div>
+          <div className="bg-white rounded-lg border border-slate-200 p-4">
+            <div className="text-xs text-slate-500">Active Orders</div>
+            <div className="text-lg font-bold mt-1">{summary.activeOrders}</div>
           </div>
         </div>
       )}
 
       {/* Filter */}
-      <div style={{ display: 'flex', gap: '0.5rem', marginBottom: '1rem' }}>
+      <div className="flex gap-2 mb-4">
         {['', 'active', 'overdue', 'paid'].map(s => (
           <button
             key={s}
-            className={`btn ${filterStatus === s ? 'btn-primary' : 'btn-secondary'}`}
+            className={`px-3 py-1.5 text-xs rounded-md border transition-colors ${
+              filterStatus === s
+                ? 'bg-primary-600 text-white border-primary-600'
+                : 'bg-white text-slate-600 border-slate-200 hover:bg-slate-50'
+            }`}
             onClick={() => setFilterStatus(s)}
-            style={{ fontSize: '0.8rem' }}
           >
-            {s || 'All'}
+            {s ? s.charAt(0).toUpperCase() + s.slice(1) : 'All'}
           </button>
         ))}
       </div>
 
       {/* Table */}
-      <div className="card" style={{ overflow: 'hidden' }}>
+      <div className="bg-white rounded-lg border border-slate-200 overflow-hidden">
         {isLoading ? (
-          <div style={{ padding: '2rem', textAlign: 'center', color: 'var(--text-muted)' }}>Loading...</div>
+          <div className="p-8 text-center text-slate-400">Loading...</div>
         ) : isError ? (
-          <div style={{ padding: '1rem', color: '#dc2626' }}>
+          <div className="p-4 text-red-600 flex items-center gap-2">
             Failed to load BNPL orders.
-            <button onClick={() => refetch()} className="btn btn-secondary" style={{ marginLeft: '0.5rem', fontSize: '0.8rem' }}>Retry</button>
+            <button onClick={() => refetch()} className="text-xs px-2 py-1 border border-slate-200 rounded hover:bg-slate-50">
+              Retry
+            </button>
           </div>
         ) : orders.length === 0 ? (
           <EmptyState icon={Package} title="No BNPL orders" description="No credit-backed orders found for the selected filter." />
         ) : (
-          <table className="table">
-            <thead>
-              <tr>
-                <th>Store</th>
-                <th>Provider</th>
-                <th style={{ textAlign: 'right' }}>Amount</th>
-                <th style={{ textAlign: 'right' }}>Outstanding</th>
-                <th>Due Date</th>
-                <th>Status</th>
-                <th>Guaranteed</th>
-              </tr>
-            </thead>
-            <tbody>
-              {orders.map(order => {
-                const badge = statusBadge(order.status);
-                return (
-                  <tr key={order.drawdownId}>
-                    <td>
-                      <div style={{ fontWeight: 500 }}>{order.storeName}</div>
-                      <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>{order.storeCode}</div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b-2 border-slate-200 bg-slate-50">
+                  <th className="text-left px-4 py-3 font-medium text-slate-600">Store</th>
+                  <th className="text-left px-4 py-3 font-medium text-slate-600">Provider</th>
+                  <th className="text-right px-4 py-3 font-medium text-slate-600">Amount</th>
+                  <th className="text-right px-4 py-3 font-medium text-slate-600">Outstanding</th>
+                  <th className="text-left px-4 py-3 font-medium text-slate-600">Due Date</th>
+                  <th className="text-left px-4 py-3 font-medium text-slate-600">Status</th>
+                  <th className="text-left px-4 py-3 font-medium text-slate-600">Guaranteed</th>
+                </tr>
+              </thead>
+              <tbody>
+                {orders.map(order => (
+                  <tr key={order.drawdownId} className="border-b border-slate-100 hover:bg-slate-50">
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-slate-900">{order.storeName}</div>
+                      <div className="text-xs text-slate-400">{order.storeCode}</div>
                     </td>
-                    <td>{order.providerName}</td>
-                    <td style={{ textAlign: 'right', fontFamily: 'monospace' }}>{formatCurrency(order.principalMinor / 100)}</td>
-                    <td style={{ textAlign: 'right', fontFamily: 'monospace', fontWeight: 600, color: order.outstandingMinor > 0 ? '#dc2626' : undefined }}>
-                      {formatCurrency(order.outstandingMinor / 100)}
+                    <td className="px-4 py-3 text-slate-700">{order.providerName}</td>
+                    <td className="px-4 py-3 text-right font-mono">{formatCurrency(order.principalMinor)}</td>
+                    <td className={`px-4 py-3 text-right font-mono font-semibold ${order.outstandingMinor > 0 ? 'text-red-600' : ''}`}>
+                      {formatCurrency(order.outstandingMinor)}
                     </td>
-                    <td>{fmtDate(order.dueDate)}</td>
-                    <td><span className={badge.className}>{badge.label}</span></td>
-                    <td>
+                    <td className="px-4 py-3 text-slate-600">{fmtDate(order.dueDate)}</td>
+                    <td className="px-4 py-3"><StatusBadge status={order.status} /></td>
+                    <td className="px-4 py-3">
                       {order.paymentGuaranteed ? (
-                        <span style={{ display: 'inline-flex', alignItems: 'center', gap: '0.25rem', color: '#16a34a', fontSize: '0.8rem' }}>
+                        <span className="inline-flex items-center gap-1 text-green-600 text-xs">
                           <ShieldCheck size={14} /> Yes
                         </span>
                       ) : (
-                        <span style={{ color: 'var(--text-muted)', fontSize: '0.8rem' }}>Internal</span>
+                        <span className="text-slate-400 text-xs">Internal</span>
                       )}
                     </td>
                   </tr>
-                );
-              })}
-            </tbody>
-          </table>
+                ))}
+              </tbody>
+            </table>
+          </div>
         )}
       </div>
     </div>

--- a/supplier-portal/src/app/(dashboard)/chat/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/chat/page.tsx
@@ -7,6 +7,8 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { MessageSquare, Send, ArrowLeft, Search, Headphones } from 'lucide-react';
 import EmptyState from '@/components/EmptyState';
+// UIUX-SUP-006: Use centralized apiFetch (auth via HttpOnly cookies, 401 redirect, 30s timeout)
+import { apiFetch as globalApiFetch } from '@/lib/api';
 
 interface Conversation {
   id: string;
@@ -35,14 +37,9 @@ interface ChatMessage {
   createdAt: string;
 }
 
-async function apiFetch(url: string, options?: RequestInit) {
-  const token = typeof window !== 'undefined' ? localStorage.getItem('supplier_token') || '' : '';
-  const res = await fetch(url, {
-    ...options,
-    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}`, ...options?.headers },
-  });
-  if (!res.ok) throw new Error(`API error: ${res.status}`);
-  return res.json();
+// UIUX-SUP-006: Thin wrapper adapting globalApiFetch to the JSON-in/JSON-out shape used by react-query below
+async function chatApiFetch(url: string, options?: RequestInit): Promise<unknown> {
+  return globalApiFetch(url, options);
 }
 
 function formatTime(iso: string | null): string {
@@ -66,7 +63,7 @@ export default function SupplierChatPage() {
   // Fetch conversations
   const { data: convData, isLoading: convLoading } = useQuery({
     queryKey: ['supplier-conversations'],
-    queryFn: () => apiFetch('/api/v1/chat/conversations?limit=100'),
+    queryFn: () => chatApiFetch('/api/v1/chat/conversations?limit=100'),
     refetchInterval: 10000,
   });
 
@@ -76,7 +73,7 @@ export default function SupplierChatPage() {
   // Fetch messages for selected conversation
   const { data: msgData, isLoading: msgLoading } = useQuery({
     queryKey: ['supplier-messages', selectedConvId],
-    queryFn: () => selectedConvId ? apiFetch(`/api/v1/chat/conversations/${selectedConvId}/messages?limit=100`) : null,
+    queryFn: () => selectedConvId ? chatApiFetch(`/api/v1/chat/conversations/${selectedConvId}/messages?limit=100`) : null,
     enabled: !!selectedConvId,
     refetchInterval: 5000,
   });
@@ -86,7 +83,7 @@ export default function SupplierChatPage() {
   // Mark as read when selecting conversation
   useEffect(() => {
     if (selectedConvId) {
-      apiFetch(`/api/v1/chat/conversations/${selectedConvId}/read`, { method: 'PATCH' }).catch(() => {});
+      chatApiFetch(`/api/v1/chat/conversations/${selectedConvId}/read`, { method: 'PATCH' }).catch(() => {});
     }
   }, [selectedConvId]);
 
@@ -98,7 +95,7 @@ export default function SupplierChatPage() {
   // Send message
   const sendMutation = useMutation({
     mutationFn: async (text: string) => {
-      return apiFetch(`/api/v1/chat/conversations/${selectedConvId}/messages`, {
+      return chatApiFetch(`/api/v1/chat/conversations/${selectedConvId}/messages`, {
         method: 'POST',
         body: JSON.stringify({ content: text, messageType: 'text' }),
       });

--- a/supplier-portal/src/app/(dashboard)/layout.tsx
+++ b/supplier-portal/src/app/(dashboard)/layout.tsx
@@ -11,7 +11,7 @@ import Modal from '@/components/Modal';
 // REG-AUTH-302: LIMITED MODE Banner
 import LimitedModeBanner from '@/components/LimitedModeBanner';
 // T-082: Lucide SVG nav icons  |  T-087: Mobile hamburger icons
-import { LayoutDashboard, Package, FileSpreadsheet, ShoppingCart, ClipboardList, DollarSign, Receipt, Menu, X, Bell } from 'lucide-react';
+import { LayoutDashboard, Package, FileSpreadsheet, ShoppingCart, ClipboardList, DollarSign, Receipt, Menu, X, Bell, MessageSquare, CreditCard, User } from 'lucide-react';
 import type { LucideIcon } from 'lucide-react';
 
 // T-082: Lucide SVG icons replace emoji strings
@@ -24,7 +24,9 @@ const navItems: { href: string; label: string; icon: LucideIcon }[] = [
   { href: '/earnings', label: 'Earnings', icon: DollarSign },
   { href: '/invoices', label: 'Invoices', icon: Receipt },  // T-073
   { href: '/notifications', label: 'Notifications', icon: Bell },  // Phase 8
-  // FIX-054: Profile page not yet implemented — removed to avoid 404
+  { href: '/chat', label: 'Chat', icon: MessageSquare },  // T-295
+  { href: '/bnpl-orders', label: 'BNPL Orders', icon: CreditCard },  // T-280
+  { href: '/profile', label: 'Profile', icon: User },  // UIUX-SUP-001: Profile page is fully implemented
 ];
 
 export default function DashboardLayout({

--- a/supplier-portal/src/app/(dashboard)/notifications/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/notifications/page.tsx
@@ -3,11 +3,13 @@
 /**
  * Phase 8: Supplier Portal Notifications Page
  * In-app notification center for suppliers
+ * UIUX-SUP-005: Replaced deprecated localStorage supplier_token with apiFetch
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import { Bell, Check, CheckCheck, RefreshCw, Truck, Package, AlertTriangle } from 'lucide-react';
 import Breadcrumb from '@/components/Breadcrumb';
+import { apiFetch } from '@/lib/api';
 
 interface Notification {
   id: string;
@@ -19,32 +21,25 @@ interface Notification {
   createdAt: string;
 }
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE_URL || '';
-
 export default function NotificationsPage() {
   const [notifications, setNotifications] = useState<Notification[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [offset, setOffset] = useState(0);
   const limit = 20;
 
   const fetchNotifications = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
-      const token = typeof window !== 'undefined' ? localStorage.getItem('supplier_token') : null;
-      if (!token) return;
-
-      const res = await fetch(`${API_BASE}/api/v1/supplier/notifications?limit=${limit}&offset=${offset}`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-
-      if (res.ok) {
-        const data = await res.json();
-        setNotifications(data.data || []);
-        setTotal(data.pagination?.total || 0);
-      }
+      const data = await apiFetch<{ data: Notification[]; pagination?: { total: number } }>(
+        `/api/v1/supplier/notifications?limit=${limit}&offset=${offset}`
+      );
+      setNotifications(data.data || []);
+      setTotal(data.pagination?.total || 0);
     } catch (err) {
-      console.error('Failed to fetch notifications:', err);
+      setError(err instanceof Error ? err.message : 'Failed to fetch notifications');
     } finally {
       setLoading(false);
     }
@@ -53,27 +48,21 @@ export default function NotificationsPage() {
   useEffect(() => { fetchNotifications(); }, [fetchNotifications]);
 
   const markAsRead = async (id: string) => {
-    const token = localStorage.getItem('supplier_token');
-    if (!token) return;
     try {
-      await fetch(`${API_BASE}/api/v1/supplier/notifications/${id}/read`, {
-        method: 'PUT',
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await apiFetch(`/api/v1/supplier/notifications/${id}/read`, { method: 'PUT' });
       setNotifications((prev) => prev.map((n) => n.id === id ? { ...n, isRead: true } : n));
-    } catch { /* ignore */ }
+    } catch {
+      // Silently handle — notification still appears read in UI
+    }
   };
 
   const markAllAsRead = async () => {
-    const token = localStorage.getItem('supplier_token');
-    if (!token) return;
     try {
-      await fetch(`${API_BASE}/api/v1/supplier/notifications/read-all`, {
-        method: 'PUT',
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      await apiFetch('/api/v1/supplier/notifications/read-all', { method: 'PUT' });
       setNotifications((prev) => prev.map((n) => ({ ...n, isRead: true })));
-    } catch { /* ignore */ }
+    } catch {
+      // Silently handle
+    }
   };
 
   const getIcon = (type: string) => {
@@ -118,6 +107,17 @@ export default function NotificationsPage() {
 
       {loading ? (
         <div className="text-center py-12 text-gray-400">Loading notifications...</div>
+      ) : error ? (
+        <div className="text-center py-12">
+          <AlertTriangle size={48} className="text-red-300 mx-auto mb-4" />
+          <p className="text-red-600 mb-2">{error}</p>
+          <button
+            onClick={fetchNotifications}
+            className="text-sm px-3 py-1.5 border border-slate-200 rounded hover:bg-slate-50"
+          >
+            Retry
+          </button>
+        </div>
       ) : notifications.length === 0 ? (
         <div className="text-center py-12">
           <Bell size={48} className="text-gray-300 mx-auto mb-4" />

--- a/supplier-portal/src/app/(dashboard)/orders/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/orders/page.tsx
@@ -17,6 +17,7 @@ import { useAuth } from '@/lib/auth';
 import { WhatsAppIcon } from '@/components/WhatsAppIcon';
 
 const statusColors: Record<string, string> = {
+  submitted: 'bg-orange-100 text-orange-700',  // UIUX-XPLAT-001: Backend initial PO status
   pending: 'bg-yellow-100 text-yellow-700',
   confirmed: 'bg-blue-100 text-blue-700',
   shipped: 'bg-purple-100 text-purple-700',
@@ -33,7 +34,9 @@ const itemStatusColors: Record<string, string> = {
 };
 
 // GL-CRIT-0062: Allow shipment entry for pending status (not just confirmed)
+// UIUX-XPLAT-001: 'submitted' is the initial backend PO status before supplier confirms
 const statusFlow: Record<string, string[]> = {
+  submitted: ['confirmed', 'cancelled'],
   pending: ['confirmed', 'shipped', 'cancelled'],
   confirmed: ['shipped', 'cancelled'],
   shipped: ['delivered'],
@@ -299,7 +302,7 @@ export default function OrdersPage() {
       {/* Status Filters */}
       <div className="card mb-6">
         <div className="flex flex-wrap gap-2">
-          {['all', 'pending', 'confirmed', 'shipped', 'delivered', 'cancelled'].map(
+          {['all', 'submitted', 'pending', 'confirmed', 'shipped', 'delivered', 'cancelled'].map(
             (status) => (
               <button
                 key={status}


### PR DESCRIPTION
## Summary

Wave 1 of Phase 14 UI/UX Production Readiness Audit — all 15 P0 (critical) tickets across 4 portals + cross-platform.

### Supplier Portal (6 P0)
- **SUP-001/002**: Profile, Chat, BNPL Orders pages unreachable — added missing sidebar nav items
- **SUP-003/004**: BNPL Orders page rendered unstyled (undefined CSS classes) + used raw `fetch()` bypassing auth — full rewrite with Tailwind + `apiFetch`
- **SUP-005**: Notifications page read deprecated `supplier_token` from localStorage — replaced all 3 calls with `apiFetch`
- **SUP-006**: Chat page local `apiFetch` shadowed global, read deprecated token — replaced with global `apiFetch`

### SuperAdmin (4 P0)
- **SA-001/002/003**: SupportQueueTab, AIInsightsTab, CreditProvidersTab used wrong localStorage key (`superadmin_token` instead of `supermandi_admin_session`) — all API calls returned 401. Fixed with `getSessionToken()` + `fetchWithTimeout()` from centralized `authToken.ts`
- **SA-004**: SupportQueueTab called non-admin API routes (`/api/v1/chat/...`) — fixed to `/api/v1/admin/chat/...`

### POS App (3 P0)
- **POS-001**: SuccessPrintScreenV2 had conditional `useRef` calls (Rules of Hooks violation → potential crash) — moved to unconditional top-level refs
- **POS-002**: BnplDuesScreen `handleSelectPaymentMode` had stale closure on `payAmountText` — could submit wrong payment amount
- **POS-003**: DailyClosingScreen + ShiftScreen had 6 `useEffect` hooks with missing dependencies — stale closure risk

### Cross-Platform (2 P0)
- **XPLAT-001**: Supplier couldn't see or act on 'submitted' orders — added to statusColors, statusFlow, and filter tabs
- **XPLAT-002**: Retailer dashboard displayed all monetary amounts 100x too large — `formatRupees` (no division) → `formatCurrency` (divides by 100)

## Files Changed (13)
- `supplier-portal/src/app/(dashboard)/layout.tsx` — nav items
- `supplier-portal/src/app/(dashboard)/bnpl-orders/page.tsx` — full rewrite
- `supplier-portal/src/app/(dashboard)/notifications/page.tsx` — auth fix
- `supplier-portal/src/app/(dashboard)/chat/page.tsx` — auth fix
- `supplier-portal/src/app/(dashboard)/orders/page.tsx` — submitted status
- `supermandi-superadmin/src/tabs/SupportQueueTab.tsx` — auth + paths
- `supermandi-superadmin/src/tabs/AIInsightsTab.tsx` — auth fix
- `supermandi-superadmin/src/tabs/CreditProvidersTab.tsx` — auth fix
- `src/screens/SuccessPrintScreenV2.tsx` — useRef fix
- `src/screens/BnplDuesScreen.tsx` — stale closure fix
- `src/screens/DailyClosingScreen.tsx` — useEffect deps
- `src/screens/ShiftScreen.tsx` — useEffect deps
- `retailer-admin/src/pages/DashboardPage.tsx` — currency format fix

## Test plan
- [ ] Verify supplier portal sidebar shows Profile, Chat, BNPL Orders links
- [ ] Verify BNPL Orders page renders with Tailwind styling
- [ ] Verify notifications page loads with auth cookies (no 401)
- [ ] Verify chat page works without deprecated supplier_token
- [ ] Verify SuperAdmin SupportQueue/AIInsights/CreditProviders tabs load (no 401)
- [ ] Verify SupportQueueTab API calls go to /admin/chat/ routes
- [ ] Verify POS SuccessPrintScreenV2 doesn't crash on conditional refs
- [ ] Verify BnplDuesScreen payment amount is not stale
- [ ] Verify supplier orders page shows 'submitted' status filter and badge
- [ ] Verify retailer dashboard amounts are correct (not 100x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)