### PR TITLE
fix(UIUX-W3): Wave 3 P1 UX safety fixes — 17 tickets

### DIFF
--- a/retailer-admin/src/pages/DashboardPage.tsx
+++ b/retailer-admin/src/pages/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
 import { useAuth } from '../lib/AuthContext';
 import { authFetch, safeJson } from '../lib/api';
 import { useEscapeKey } from '../lib/hooks';
@@ -918,7 +919,7 @@ export default function DashboardPage() {
             onClick={() => {
               // GL-WF-031: Export inventory to CSV
               if (!inventory || inventory.length === 0) {
-                alert('No inventory data to export');
+                toast.error('No inventory data to export');
                 return;
               }
               const headers = ['Product Name', 'Barcode', 'Stock Qty', 'Purchase Value (Rs)', 'Sell Revenue (Rs)'];

--- a/retailer-admin/src/pages/DeviceActivationPage.tsx
+++ b/retailer-admin/src/pages/DeviceActivationPage.tsx
@@ -8,6 +8,8 @@ import { useAuth } from '../lib/AuthContext';
 import { authFetch, safeJson } from '../lib/api';
 // T-112: Breadcrumb navigation
 import Breadcrumb from '../components/Breadcrumb';
+// UIUX-RET-002: Styled modal instead of window.confirm
+import Modal from '../components/Modal';
 
 interface Device {
   id: string;
@@ -44,6 +46,8 @@ export default function DeviceActivationPage() {
   const [deactivatingDeviceId, setDeactivatingDeviceId] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // UIUX-RET-002: Styled confirmation modal for device toggle
+  const [toggleConfirm, setToggleConfirm] = useState<{ deviceId: string; currentlyActive: boolean } | null>(null);
 
   // Format activation code as user types (SM-XXXX-XX)
   const formatActivationCode = useCallback((value: string): string => {
@@ -174,13 +178,18 @@ export default function DeviceActivationPage() {
   };
 
   // RET-AUD-027: Handle device deactivation/reactivation
+  // UIUX-RET-002: Show styled Modal instead of window.confirm
   const handleToggleDevice = async (deviceId: string, currentlyActive: boolean) => {
     if (!accessToken) return;
 
+    setToggleConfirm({ deviceId, currentlyActive });
+  };
+
+  const confirmToggleDevice = async () => {
+    if (!toggleConfirm || !accessToken) return;
+    const { deviceId, currentlyActive } = toggleConfirm;
+    setToggleConfirm(null);
     const action = currentlyActive ? 'deactivate' : 'reactivate';
-    if (!window.confirm(`Are you sure you want to ${action} this device?${currentlyActive ? ' The device will need to be re-enrolled to use the POS again.' : ''}`)) {
-      return;
-    }
 
     setDeactivatingDeviceId(deviceId);
     setError(null);
@@ -216,6 +225,27 @@ export default function DeviceActivationPage() {
       background: 'linear-gradient(180deg, #f0f9ff 0%, #f8fafc 100%)',
       padding: '2rem',
     }}>
+      {/* UIUX-RET-002: Styled confirmation modal for device toggle */}
+      <Modal
+        isOpen={!!toggleConfirm}
+        onClose={() => setToggleConfirm(null)}
+        title={toggleConfirm?.currentlyActive ? 'Deactivate Device' : 'Reactivate Device'}
+        actions={
+          <>
+            <button className="btn-secondary" onClick={() => setToggleConfirm(null)}>Cancel</button>
+            <button className="btn-danger" onClick={confirmToggleDevice}>
+              {toggleConfirm?.currentlyActive ? 'Deactivate' : 'Reactivate'}
+            </button>
+          </>
+        }
+      >
+        <p style={{ color: '#475569', fontSize: '0.9rem', lineHeight: 1.5 }}>
+          {toggleConfirm?.currentlyActive
+            ? 'Are you sure you want to deactivate this device? The device will need to be re-enrolled to use the POS again.'
+            : 'Are you sure you want to reactivate this device?'}
+        </p>
+      </Modal>
+
       {/* T-112: Breadcrumb navigation */}
       <Breadcrumb items={[{ label: 'Home', path: `/s/${storeCode}` }, { label: 'Devices' }]} />
       {/* Header */}

--- a/src/screens/BnplDuesScreen.tsx
+++ b/src/screens/BnplDuesScreen.tsx
@@ -522,12 +522,23 @@ export function BnplDuesScreen({ onBack }: BnplDuesScreenProps) {
     [handlePayDrawdown, handleOpenDispute]
   );
 
-  // Loading state
+  // UIUX-POS-021: Show header with back button during loading (don't trap user)
   if (loading) {
     return (
-      <View style={[styles.container, styles.centerContent]}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
-        <Text style={styles.loadingText}>Loading BNPL Dues...</Text>
+      <View style={[styles.container, { paddingTop: insets.top }]}>
+        <View style={styles.header}>
+          {onBack && (
+            <Pressable style={styles.backButton} onPress={onBack}>
+              <MaterialCommunityIcons name="arrow-left" size={24} color={theme.colors.textPrimary} />
+            </Pressable>
+          )}
+          <Text style={styles.headerTitle}>{t("bnpl.title", "BNPL Dues")}</Text>
+          <View style={{ width: 40 }} />
+        </View>
+        <View style={styles.centerContent}>
+          <ActivityIndicator size="large" color={theme.colors.primary} />
+          <Text style={styles.loadingText}>Loading BNPL Dues...</Text>
+        </View>
       </View>
     );
   }

--- a/src/screens/CreditScreen.tsx
+++ b/src/screens/CreditScreen.tsx
@@ -499,14 +499,25 @@ export function CreditScreen({ onBack }: CreditScreenProps) {
     []
   );
 
-  // Loading state
+  // UIUX-POS-021: Show header with back button during loading (don't trap user)
   if (loading) {
     return (
-      <View style={[styles.container, styles.centerContent]}>
-        <ActivityIndicator size="large" color={theme.colors.primary} />
-        <Text style={styles.loadingText}>
-          {t("credit.loading", "Loading Credit Info...")}
-        </Text>
+      <View style={[styles.container, { paddingTop: insets.top }]}>
+        <View style={styles.header}>
+          {onBack && (
+            <Pressable style={styles.backButton} onPress={onBack}>
+              <MaterialCommunityIcons name="arrow-left" size={24} color={theme.colors.textPrimary} />
+            </Pressable>
+          )}
+          <Text style={styles.headerTitle}>{t("credit.title", "Credit")}</Text>
+          <View style={styles.headerRight} />
+        </View>
+        <View style={styles.centerContent}>
+          <ActivityIndicator size="large" color={theme.colors.primary} />
+          <Text style={styles.loadingText}>
+            {t("credit.loading", "Loading Credit Info...")}
+          </Text>
+        </View>
       </View>
     );
   }

--- a/src/screens/CustomerListScreen.tsx
+++ b/src/screens/CustomerListScreen.tsx
@@ -1,6 +1,6 @@
 // T-155: Customer Profiles Screen
 // List of all customers, search, detail view with purchase history, add/edit customer
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -64,6 +64,8 @@ export default function CustomerListScreen({ onBack }: CustomerListScreenProps) 
 
   const [searchQuery, setSearchQuery] = useState("");
   const [refreshing, setRefreshing] = useState(false);
+  // UIUX-POS-020: Debounce search timer ref
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [showDetail, setShowDetail] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const [showEditModal, setShowEditModal] = useState(false);
@@ -86,10 +88,16 @@ export default function CustomerListScreen({ onBack }: CustomerListScreenProps) 
     }
   }, [error]);
 
+  // UIUX-POS-020: 300ms debounced search to reduce API calls
   const handleSearch = useCallback(
     (text: string) => {
       setSearchQuery(text);
-      void fetchCustomers(text || undefined);
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+      searchTimerRef.current = setTimeout(() => {
+        void fetchCustomers(text || undefined);
+      }, 300);
     },
     [fetchCustomers]
   );

--- a/src/screens/KhataScreen.tsx
+++ b/src/screens/KhataScreen.tsx
@@ -1,6 +1,6 @@
 // T-154: Khata (Credit Book) Screen
 // Main list of customers with credit/debit balance, ledger view, add credit/payment modals
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -63,6 +63,8 @@ export default function KhataScreen({ onBack }: KhataScreenProps) {
   } = useKhataStore();
 
   const [searchQuery, setSearchQuery] = useState("");
+  // UIUX-POS-020: Debounce search to avoid firing API on every keystroke
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [showLedger, setShowLedger] = useState(false);
   const [showCreditModal, setShowCreditModal] = useState(false);
@@ -92,10 +94,16 @@ export default function KhataScreen({ onBack }: KhataScreenProps) {
     }
   }, [error]);
 
+  // UIUX-POS-020: 300ms debounced search to reduce API calls
   const handleSearch = useCallback(
     (text: string) => {
       setSearchQuery(text);
-      void fetchCustomers(text || undefined);
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current);
+      }
+      searchTimerRef.current = setTimeout(() => {
+        void fetchCustomers(text || undefined);
+      }, 300);
     },
     [fetchCustomers]
   );

--- a/src/screens/ReturnScreen.tsx
+++ b/src/screens/ReturnScreen.tsx
@@ -201,6 +201,8 @@ export default function ReturnScreen({ onBack }: ReturnScreenProps) {
   // ==========================================================================
 
   const handleProcessReturn = useCallback(async () => {
+    // UIUX-POS-019: Guard against double-tap — reject if already processing
+    if (processing) return;
     if (!sale || !reason || !refundMethod || selectedItems.length === 0) return;
 
     setProcessing(true);
@@ -225,7 +227,7 @@ export default function ReturnScreen({ onBack }: ReturnScreenProps) {
     } finally {
       setProcessing(false);
     }
-  }, [sale, reason, refundMethod, selectedItems, returnQuantities]);
+  }, [sale, reason, refundMethod, selectedItems, returnQuantities, processing]);
 
   // ==========================================================================
   // STEP 4: SUCCESS

--- a/src/screens/ShiftScreen.tsx
+++ b/src/screens/ShiftScreen.tsx
@@ -118,18 +118,31 @@ export default function ShiftScreen({ onBack }: ShiftScreenProps) {
     promise.finally(() => setRefreshing(false));
   }, [activeTab, fetchCurrentShift, fetchHistory]);
 
-  const handleStartShift = useCallback(async () => {
+  // UIUX-POS-022: Confirm before starting shift (records opening cash + timestamp)
+  const handleStartShift = useCallback(() => {
     const cashStr = openingCash.trim();
     const openingCashMinor = Math.round(parseFloat(cashStr) * 100);
     if (!cashStr || isNaN(openingCashMinor) || openingCashMinor < 0) {
       Alert.alert("Invalid Amount", "Please enter the opening cash amount.");
       return;
     }
-    const success = await startShift({ openingCashMinor });
-    if (success) {
-      setOpeningCash("");
-      Alert.alert("Shift Started", "Your shift has been started successfully.");
-    }
+    Alert.alert(
+      "Start Shift",
+      `Start shift with opening cash of \u20B9${(openingCashMinor / 100).toFixed(2)}?`,
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Start",
+          onPress: async () => {
+            const success = await startShift({ openingCashMinor });
+            if (success) {
+              setOpeningCash("");
+              Alert.alert("Shift Started", "Your shift has been started successfully.");
+            }
+          },
+        },
+      ]
+    );
   }, [openingCash, startShift]);
 
   const handleEndShift = useCallback(async () => {

--- a/supermandi-superadmin/src/App.tsx
+++ b/supermandi-superadmin/src/App.tsx
@@ -3042,7 +3042,7 @@ export default function App() {
       )}
 
       {tab === "payments" && (
-        <PaymentsTab paymentEvents={paymentEvents} />
+        <PaymentsTab paymentEvents={paymentEvents} loading={eventsLoading} error={eventsError || null} />
       )}
 
       {tab === "users" && (

--- a/supermandi-superadmin/src/tabs/CreditProvidersTab.tsx
+++ b/supermandi-superadmin/src/tabs/CreditProvidersTab.tsx
@@ -7,6 +7,8 @@ import { useState, useEffect, useCallback } from 'react';
 import { getSessionToken, fetchWithTimeout } from '../api/authToken';
 // UIUX-SA-007: Use parseError for sanitized error messages instead of generic 'API error: {status}'
 import { parseError } from '../api/errorSanitizer';
+// UIUX-SA-011: Styled confirmation dialog for provider toggle
+import { ConfirmDialog, type ConfirmDialogConfig } from '../components/ConfirmDialog';
 
 interface ProviderConfig {
   id: string;
@@ -61,6 +63,8 @@ export function CreditProvidersTab() {
   const [health, setHealth] = useState<HealthStatus[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // UIUX-SA-011: Confirmation dialog state
+  const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogConfig | null>(null);
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
@@ -83,16 +87,28 @@ export function CreditProvidersTab() {
 
   useEffect(() => { fetchAll(); }, [fetchAll]);
 
-  const toggleProvider = async (providerId: string, currentActive: boolean) => {
-    try {
-      await apiFetch(`/api/v1/admin/credit-providers/${providerId}`, {
-        method: 'PATCH',
-        body: JSON.stringify({ is_active: !currentActive }),
-      });
-      fetchAll();
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Failed to update');
-    }
+  const toggleProvider = (providerId: string, currentActive: boolean) => {
+    const provName = providers.find(p => p.provider_id === providerId)?.provider_name || providerId;
+    setConfirmDialog({
+      title: currentActive ? 'Disable Credit Provider' : 'Enable Credit Provider',
+      message: currentActive
+        ? `Disable "${provName}"? This will stop all new credit applications through this provider.`
+        : `Enable "${provName}"? This will allow new credit applications through this provider.`,
+      confirmLabel: currentActive ? 'Disable' : 'Enable',
+      variant: currentActive ? 'danger' : 'info',
+      onConfirm: async () => {
+        setConfirmDialog(null);
+        try {
+          await apiFetch(`/api/v1/admin/credit-providers/${providerId}`, {
+            method: 'PATCH',
+            body: JSON.stringify({ is_active: !currentActive }),
+          });
+          fetchAll();
+        } catch (err: unknown) {
+          setError(err instanceof Error ? err.message : 'Failed to update');
+        }
+      },
+    });
   };
 
   if (loading) return <div style={{ padding: '2rem', color: '#64748b' }}>Loading finance dashboard...</div>;
@@ -106,6 +122,7 @@ export function CreditProvidersTab() {
 
   return (
     <div style={{ padding: '1.5rem' }}>
+      {confirmDialog && <ConfirmDialog {...confirmDialog} onCancel={() => setConfirmDialog(null)} />}
       <h2 style={{ margin: '0 0 1.5rem', fontSize: '1.25rem', fontWeight: 600 }}>Finance & Credit Providers</h2>
 
       {error && (

--- a/supermandi-superadmin/src/tabs/InvoicesTab.tsx
+++ b/supermandi-superadmin/src/tabs/InvoicesTab.tsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useState } from "react";
 import type { InvoiceListItem, InvoiceDetail, InvoiceListFilters, InvoiceModel, InvoiceType, InvoiceStatus } from "../api/invoices";
 import { listInvoices, getInvoice, issueInvoice, cancelInvoice, downloadInvoicePdf } from "../api/invoices";
 import { formatDateTime } from "../lib/formatters";
+// UIUX-SA-008: Styled confirmation dialog instead of bare confirm()
+import { ConfirmDialog, type ConfirmDialogConfig } from "../components/ConfirmDialog";
 
 function formatMinor(minor: number): string {
   return "\u20B9" + (minor / 100).toFixed(2);
@@ -30,6 +32,8 @@ export function InvoicesTab() {
   // Detail modal
   const [detail, setDetail] = useState<InvoiceDetail | null>(null);
   const [detailLoading, setDetailLoading] = useState(false);
+  // UIUX-SA-008: Confirmation dialog state
+  const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogConfig | null>(null);
   const [actionLoading, setActionLoading] = useState(false);
 
   const refresh = useCallback(async () => {
@@ -80,18 +84,26 @@ export function InvoicesTab() {
     }
   };
 
-  const handleCancel = async (id: string) => {
-    if (!confirm("Cancel this invoice?")) return;
-    setActionLoading(true);
-    try {
-      await cancelInvoice(id);
-      await refresh();
-      if (detail?.id === id) setDetail(null);
-    } catch (err: any) {
-      setError(err.message || "Failed to cancel invoice");
-    } finally {
-      setActionLoading(false);
-    }
+  const handleCancel = (id: string) => {
+    setConfirmDialog({
+      title: "Cancel Invoice",
+      message: "Are you sure you want to cancel this invoice? This action is irreversible.",
+      confirmLabel: "Cancel Invoice",
+      variant: "danger",
+      onConfirm: async () => {
+        setConfirmDialog(null);
+        setActionLoading(true);
+        try {
+          await cancelInvoice(id);
+          await refresh();
+          if (detail?.id === id) setDetail(null);
+        } catch (err: any) {
+          setError(err.message || "Failed to cancel invoice");
+        } finally {
+          setActionLoading(false);
+        }
+      },
+    });
   };
 
   const handleDownload = async (id: string, invoiceNumber: string) => {
@@ -104,6 +116,8 @@ export function InvoicesTab() {
 
   return (
     <section className="card">
+      {/* UIUX-SA-008: Confirmation dialog */}
+      {confirmDialog && <ConfirmDialog {...confirmDialog} onCancel={() => setConfirmDialog(null)} loading={actionLoading} />}
       <div className="cardHeader">
         <div className="cardTitle">Invoices</div>
         <div className="muted">GST invoices across buy-resell and platform-fee models</div>

--- a/supermandi-superadmin/src/tabs/MonitoringTab.tsx
+++ b/supermandi-superadmin/src/tabs/MonitoringTab.tsx
@@ -1,6 +1,8 @@
 // T-223: Cloud Monitoring Dashboard for SuperAdmin
 import { useState, useEffect, useCallback } from "react";
 import { fetchHealthStatus, triggerTokenCleanup, type HealthResponse, type TokenCleanupResult } from "../api/monitoring";
+// UIUX-SA-009: Styled confirmation dialog instead of bare confirm()
+import { ConfirmDialog, type ConfirmDialogConfig } from "../components/ConfirmDialog";
 
 export function MonitoringTab() {
   const [health, setHealth] = useState<HealthResponse | null>(null);
@@ -9,6 +11,8 @@ export function MonitoringTab() {
   const [cleanupResult, setCleanupResult] = useState<TokenCleanupResult | null>(null);
   const [cleaningUp, setCleaningUp] = useState(false);
   const [autoRefresh, setAutoRefresh] = useState(false);
+  // UIUX-SA-009: Confirmation dialog state
+  const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogConfig | null>(null);
 
   const loadHealth = useCallback(async () => {
     setLoading(true);
@@ -32,18 +36,27 @@ export function MonitoringTab() {
     return () => clearInterval(interval);
   }, [autoRefresh, loadHealth]);
 
-  const handleCleanup = async () => {
-    if (!confirm("This will deactivate tokens unused for 90+ days and delete tokens inactive for 180+ days. Continue?")) return;
-    setCleaningUp(true);
-    setCleanupResult(null);
-    try {
-      const result = await triggerTokenCleanup();
-      setCleanupResult(result);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Token cleanup failed");
-    } finally {
-      setCleaningUp(false);
-    }
+  const handleCleanup = () => {
+    setConfirmDialog({
+      title: "Clean Up Expired Tokens",
+      message: "This will deactivate tokens unused for 90+ days and delete tokens inactive for 180+ days.",
+      detail: "This is a bulk auth operation affecting all stores.",
+      confirmLabel: "Run Cleanup",
+      variant: "warning",
+      onConfirm: async () => {
+        setConfirmDialog(null);
+        setCleaningUp(true);
+        setCleanupResult(null);
+        try {
+          const result = await triggerTokenCleanup();
+          setCleanupResult(result);
+        } catch (err) {
+          setError(err instanceof Error ? err.message : "Token cleanup failed");
+        } finally {
+          setCleaningUp(false);
+        }
+      },
+    });
   };
 
   const formatUptime = (seconds: number) => {
@@ -89,6 +102,7 @@ export function MonitoringTab() {
 
   return (
     <div style={{ padding: 24 }}>
+      {confirmDialog && <ConfirmDialog {...confirmDialog} onCancel={() => setConfirmDialog(null)} loading={cleaningUp} />}
       <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 20 }}>
         <div>
           <h2 style={{ margin: 0, fontSize: 20, fontWeight: 600 }}>System Monitoring</h2>

--- a/supermandi-superadmin/src/tabs/PaymentsTab.tsx
+++ b/supermandi-superadmin/src/tabs/PaymentsTab.tsx
@@ -5,9 +5,12 @@ import { formatDateTime } from "../lib/formatters";
 
 interface PaymentsTabProps {
   paymentEvents: PosEvent[];
+  // UIUX-SA-013: Accept loading/error from parent to avoid misleading empty state
+  loading?: boolean;
+  error?: string | null;
 }
 
-export function PaymentsTab({ paymentEvents }: PaymentsTabProps) {
+export function PaymentsTab({ paymentEvents, loading, error }: PaymentsTabProps) {
   return (
     <section className="card">
       <div className="cardHeader">
@@ -15,7 +18,12 @@ export function PaymentsTab({ paymentEvents }: PaymentsTabProps) {
         <div className="muted">Events where eventType starts with PAYMENT_</div>
       </div>
 
-      {paymentEvents.length === 0 ? (
+      {/* UIUX-SA-013: Show loading/error states instead of misleading empty state */}
+      {loading ? (
+        <div className="empty" style={{ color: '#64748b' }}>Loading payment events...</div>
+      ) : error ? (
+        <div className="empty" style={{ color: '#dc2626' }}>{error}</div>
+      ) : paymentEvents.length === 0 ? (
         <div className="empty">No payment events found for the current filters.</div>
       ) : (
         <div className="tableWrap">

--- a/supermandi-superadmin/src/tabs/QualityDashboardTab.tsx
+++ b/supermandi-superadmin/src/tabs/QualityDashboardTab.tsx
@@ -8,6 +8,8 @@ import {
   type TestResults,
   type ToolStatus,
 } from "../api/quality";
+// UIUX-SA-010: Styled confirmation dialog instead of bare confirm()
+import { ConfirmDialog, type ConfirmDialogConfig } from "../components/ConfirmDialog";
 
 export function QualityDashboardTab() {
   const [overview, setOverview] = useState<QualityOverview | null>(null);
@@ -16,6 +18,8 @@ export function QualityDashboardTab() {
   const [error, setError] = useState<string | null>(null);
   const [autoRefresh, setAutoRefresh] = useState(false);
   const [resettingMetrics, setResettingMetrics] = useState(false);
+  // UIUX-SA-010: Confirmation dialog state
+  const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogConfig | null>(null);
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -45,17 +49,26 @@ export function QualityDashboardTab() {
     return () => clearInterval(interval);
   }, [autoRefresh, loadData]);
 
-  const handleResetMetrics = async () => {
-    if (!confirm("This will reset all request metrics counters. Continue?")) return;
-    setResettingMetrics(true);
-    try {
-      await resetMetrics();
-      await loadData();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Metrics reset failed");
-    } finally {
-      setResettingMetrics(false);
-    }
+  const handleResetMetrics = () => {
+    setConfirmDialog({
+      title: "Reset Metrics",
+      message: "This will reset all request metrics counters to zero.",
+      detail: "Historical reporting data will be lost.",
+      confirmLabel: "Reset Metrics",
+      variant: "danger",
+      onConfirm: async () => {
+        setConfirmDialog(null);
+        setResettingMetrics(true);
+        try {
+          await resetMetrics();
+          await loadData();
+        } catch (err) {
+          setError(err instanceof Error ? err.message : "Metrics reset failed");
+        } finally {
+          setResettingMetrics(false);
+        }
+      },
+    });
   };
 
   const formatUptime = (seconds: number) => {
@@ -162,6 +175,7 @@ export function QualityDashboardTab() {
 
   return (
     <div style={{ padding: 24 }}>
+      {confirmDialog && <ConfirmDialog {...confirmDialog} onCancel={() => setConfirmDialog(null)} loading={resettingMetrics} />}
       {/* Header */}
       <div
         style={{

--- a/supermandi-superadmin/src/tabs/WhatsAppTab.tsx
+++ b/supermandi-superadmin/src/tabs/WhatsAppTab.tsx
@@ -11,6 +11,8 @@ import {
   type WhatsAppStats,
 } from "../api/whatsapp";
 import { formatDateTime } from "../lib/formatters";
+// UIUX-SA-012: Styled confirmation dialog for broadcast
+import { ConfirmDialog, type ConfirmDialogConfig } from "../components/ConfirmDialog";
 
 const STATUS_COLORS: Record<string, { bg: string; color: string }> = {
   sent:      { bg: "#dbeafe", color: "#1e40af" },
@@ -48,6 +50,8 @@ export function WhatsAppTab() {
   const [broadcastType, setBroadcastType] = useState<"retailer" | "supplier">("retailer");
   const [broadcasting, setBroadcasting] = useState(false);
   const [broadcastResult, setBroadcastResult] = useState<string | null>(null);
+  // UIUX-SA-012: Confirmation dialog state
+  const [confirmDialog, setConfirmDialog] = useState<ConfirmDialogConfig | null>(null);
 
   const limit = 25;
 
@@ -104,10 +108,7 @@ export function WhatsAppTab() {
     }
   };
 
-  const handleBroadcast = async () => {
-    const phones = broadcastPhones.split(/[,\n]/).map(p => p.trim()).filter(Boolean);
-    if (phones.length === 0 || !broadcastMessage.trim()) return;
-    if (phones.length > 50) { setBroadcastResult("Max 50 recipients"); return; }
+  const executeBroadcast = async (phones: string[]) => {
     setBroadcasting(true);
     setBroadcastResult(null);
     try {
@@ -125,11 +126,30 @@ export function WhatsAppTab() {
     }
   };
 
+  // UIUX-SA-012: Show confirmation before sending broadcast (WhatsApp messages are irrevocable)
+  const handleBroadcast = () => {
+    const phones = broadcastPhones.split(/[,\n]/).map(p => p.trim()).filter(Boolean);
+    if (phones.length === 0 || !broadcastMessage.trim()) return;
+    if (phones.length > 50) { setBroadcastResult("Max 50 recipients"); return; }
+    setConfirmDialog({
+      title: "Send WhatsApp Broadcast",
+      message: `Send this message to ${phones.length} recipient${phones.length > 1 ? "s" : ""}? WhatsApp messages cannot be unsent.`,
+      detail: `Preview: "${broadcastMessage.trim().slice(0, 80)}${broadcastMessage.trim().length > 80 ? "..." : ""}"`,
+      confirmLabel: `Send to ${phones.length}`,
+      variant: "warning",
+      onConfirm: () => {
+        setConfirmDialog(null);
+        executeBroadcast(phones);
+      },
+    });
+  };
+
   const totalPages = Math.ceil(total / limit);
   const currentPage = Math.floor(offset / limit) + 1;
 
   return (
     <div style={{ padding: "0.5rem 0" }}>
+      {confirmDialog && <ConfirmDialog {...confirmDialog} onCancel={() => setConfirmDialog(null)} loading={broadcasting} />}
       {/* Status Banner */}
       <div style={{
         display: "flex", alignItems: "center", gap: "0.75rem", marginBottom: "1rem",

--- a/supplier-portal/src/app/(dashboard)/chat/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/chat/page.tsx
@@ -5,6 +5,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
 import { MessageSquare, Send, ArrowLeft, Search, Headphones } from 'lucide-react';
 import EmptyState from '@/components/EmptyState';
 // UIUX-SUP-006: Use centralized apiFetch (auth via HttpOnly cookies, 401 redirect, 30s timeout)
@@ -104,6 +105,10 @@ export default function SupplierChatPage() {
       setMessageText('');
       queryClient.invalidateQueries({ queryKey: ['supplier-messages', selectedConvId] });
       queryClient.invalidateQueries({ queryKey: ['supplier-conversations'] });
+    },
+    // UIUX-SUP-008: Show error feedback instead of silently losing message
+    onError: (error: Error) => {
+      toast.error(error.message || 'Failed to send message. Please try again.');
     },
   });
 

--- a/supplier-portal/src/app/(dashboard)/invoices/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/invoices/page.tsx
@@ -5,6 +5,7 @@
 
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import toast from 'react-hot-toast';
 import { getSupplierInvoices, getSupplierInvoiceDetail, type SupplierInvoice, type SupplierInvoiceDetail } from '@/lib/api';
 import { formatCurrency, formatDate } from '@/lib/formatters';
 // T-113: Breadcrumb navigation
@@ -63,6 +64,8 @@ export default function InvoicesPage() {
       URL.revokeObjectURL(url);
     } catch (err) {
       console.error('PDF download failed:', err);
+      // UIUX-SUP-013: Show user feedback on PDF download failure
+      toast.error('Failed to download PDF. Please try again.');
     }
   };
 

--- a/supplier-portal/src/app/(dashboard)/kyc/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/kyc/page.tsx
@@ -34,6 +34,8 @@ export default function KycPage() {
   const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
   // AUDIT-SUP-017: Track last attempted file per doc type for retry on failure
   const [failedUploads, setFailedUploads] = useState<Record<string, File>>({});
+  // UIUX-SUP-015: Two-click delete confirmation state
+  const [pendingDelete, setPendingDelete] = useState<string | null>(null);
 
   // Bank verification form state
   const [bankForm, setBankForm] = useState({
@@ -339,11 +341,20 @@ export default function KycPage() {
                     <div className="flex items-center gap-2">
                       {existingDoc && (
                         <button
-                          onClick={() => deleteMutation.mutate(existingDoc.id)}
-                          className="text-red-600 hover:text-red-700 text-sm"
+                          onClick={() => {
+                            // UIUX-SUP-015: Confirm before deleting KYC document
+                            if (pendingDelete === existingDoc.id) {
+                              deleteMutation.mutate(existingDoc.id);
+                              setPendingDelete(null);
+                            } else {
+                              setPendingDelete(existingDoc.id);
+                            }
+                          }}
+                          className={`text-sm ${pendingDelete === existingDoc.id ? 'text-white bg-red-600 px-2 py-0.5 rounded' : 'text-red-600 hover:text-red-700'}`}
                           disabled={deleteMutation.isPending}
+                          onBlur={() => setPendingDelete(null)}
                         >
-                          Delete
+                          {pendingDelete === existingDoc.id ? 'Confirm Delete' : 'Delete'}
                         </button>
                       )}
 

--- a/supplier-portal/src/app/(dashboard)/orders/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/orders/page.tsx
@@ -90,6 +90,8 @@ export default function OrdersPage() {
   // T-246: Delivery confirmation state
   const [deliveryNotes, setDeliveryNotes] = useState('');
   const [showDeliveryForm, setShowDeliveryForm] = useState(false);
+  // UIUX-SUP-010: Confirmation state for shipping with pending items
+  const [pendingShipConfirm, setPendingShipConfirm] = useState<{ count: number } | null>(null);
 
   // GL-WF-063: Paginated orders query
   // PRA-REAUDIT: Added isError + refetch to prevent API failure showing as empty state
@@ -943,8 +945,28 @@ export default function OrdersPage() {
               )}
             </div>
 
+            {/* UIUX-SUP-010: Styled confirmation for shipping with pending items */}
+            {pendingShipConfirm && (
+              <div className="mt-4 p-4 bg-amber-50 border border-amber-200 rounded-lg">
+                <p className="text-sm font-medium text-amber-800 mb-2">
+                  {pendingShipConfirm.count} item(s) have not been marked as received.
+                </p>
+                <p className="text-xs text-amber-600 mb-3">Ship anyway? This cannot be undone.</p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setPendingShipConfirm(null)}
+                    className="px-3 py-1.5 text-xs border border-slate-200 rounded-md bg-white hover:bg-slate-50"
+                  >Cancel</button>
+                  <button
+                    onClick={() => { setPendingShipConfirm(null); setShowShipmentForm(true); }}
+                    className="px-3 py-1.5 text-xs bg-amber-600 text-white rounded-md hover:bg-amber-700"
+                  >Ship Anyway</button>
+                </div>
+              </div>
+            )}
+
             {/* Status Actions */}
-            {statusFlow[selectedOrder.status]?.length > 0 && !showShipmentForm && !showDeliveryForm && (
+            {statusFlow[selectedOrder.status]?.length > 0 && !showShipmentForm && !showDeliveryForm && !pendingShipConfirm && (
               <div className="mt-4">
                 <p className="text-sm text-slate-500 mb-3">Update Status</p>
                 <div className="flex gap-3">
@@ -955,12 +977,11 @@ export default function OrdersPage() {
                         // GL-CRIT-0062: Allow shipment from pending or confirmed status
                         if (newStatus === 'shipped' && (selectedOrder.status === 'confirmed' || selectedOrder.status === 'pending')) {
                           // GL-CRIT-0063: Warn if any items still pending
+                          // UIUX-SUP-010: Use styled confirmation instead of window.confirm
                           const pendingItems = selectedOrder.items.filter(item => item.status === 'pending' || !item.receivedQuantity);
                           if (pendingItems.length > 0) {
-                            const confirm = window.confirm(
-                              `${pendingItems.length} item(s) have not been marked as received. Ship anyway?`
-                            );
-                            if (!confirm) return;
+                            setPendingShipConfirm({ count: pendingItems.length });
+                            return;
                           }
                           // GL-WF-039: Show shipment form instead of directly updating
                           setShowShipmentForm(true);

--- a/supplier-portal/src/app/(dashboard)/profile/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/profile/page.tsx
@@ -86,8 +86,9 @@ export default function ProfilePage() {
   const handleBankSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     // AUDIT-SUP-013: Validate IFSC code format (4 letters + 0 + 6 alphanumeric)
+    // UIUX-SUP-012: Use toast.error instead of native alert()
     if (bankData.ifscCode && !/^[A-Z]{4}0[A-Z0-9]{6}$/.test(bankData.ifscCode)) {
-      alert('Invalid IFSC code format. Expected: 4 letters + 0 + 6 alphanumeric (e.g., HDFC0001234)');
+      toast.error('Invalid IFSC code format. Expected: 4 letters + 0 + 6 alphanumeric (e.g., HDFC0001234)');
       return;
     }
     updateProfileMutation.mutate({ bankDetails: bankData });


### PR DESCRIPTION
## Summary

Wave 3 of Phase 14 UI/UX Production Readiness Audit — **17 P1 UX safety tickets** across all 4 portals.

**Theme**: Replace bare `alert()`/`confirm()`/`window.confirm()` with proper UI patterns, add double-tap protection, search debounce, loading escape hatches, and destructive action confirmations.

### Retailer Admin (2 tickets)
- **RET-001**: `alert()` → `toast.error()` for inventory export feedback
- **RET-002**: `window.confirm()` → Modal component for device toggle

### SuperAdmin (6 tickets)
- **SA-008**: InvoicesTab `confirm()` → ConfirmDialog for invoice cancel
- **SA-009**: MonitoringTab `confirm()` → ConfirmDialog for token cleanup
- **SA-010**: QualityDashboardTab `confirm()` → ConfirmDialog for metrics reset
- **SA-011**: CreditProvidersTab `confirm()` → ConfirmDialog for provider toggle
- **SA-012**: WhatsAppTab `confirm()` → ConfirmDialog for broadcast (irrevocable)
- **SA-013**: PaymentsTab missing loading/error/empty states added

### Supplier Portal (5 tickets)
- **SUP-008**: Chat sendMutation `onError` → toast feedback
- **SUP-010**: Orders `window.confirm()` → styled inline confirmation banner
- **SUP-012**: Profile `alert()` → `toast.error()` for IFSC validation
- **SUP-013**: Invoices PDF download failure → toast feedback
- **SUP-015**: KYC delete → two-click confirmation pattern

### POS App (4 tickets)
- **POS-019**: ReturnScreen double-tap guard on processReturn
- **POS-020**: KhataScreen + CustomerListScreen 300ms search debounce
- **POS-021**: CreditScreen + BnplDuesScreen trapped loading → header with back button
- **POS-022**: ShiftScreen start shift → Alert.alert confirmation

### Dropped
- **SUP-011**: `history.pushState` navigation guard requires synchronous `confirm()` — no async modal alternative exists

## Test plan
- [ ] Retailer Admin: verify toast appears on empty export, modal on device toggle
- [ ] SuperAdmin: verify ConfirmDialog appears for all 5 destructive actions
- [ ] SuperAdmin: verify PaymentsTab shows loading/error/empty states
- [ ] Supplier Portal: verify inline confirmation on ship, toast on chat error/IFSC/PDF
- [ ] Supplier Portal: verify two-click delete on KYC documents
- [ ] POS: verify double-tap guard on return, debounced search, loading escape, shift confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)