### PR TITLE
fix(UIUX-W4): Wave 4 P1 UI/nav fixes — 12 tickets

### DIFF
--- a/retailer-admin/src/pages/AnalyticsPage.tsx
+++ b/retailer-admin/src/pages/AnalyticsPage.tsx
@@ -50,8 +50,8 @@ export default function AnalyticsPage() {
 
   // Payment breakdown percentages
   const paymentTotal = data ? (data.paymentBreakdown.cash + data.paymentBreakdown.upi + data.paymentBreakdown.credit) : 0;
-  const cashPct = paymentTotal > 0 ? Math.round((data!.paymentBreakdown.cash / paymentTotal) * 100) : 0;
-  const upiPct = paymentTotal > 0 ? Math.round((data!.paymentBreakdown.upi / paymentTotal) * 100) : 0;
+  const cashPct = paymentTotal > 0 && data ? Math.round((data.paymentBreakdown.cash / paymentTotal) * 100) : 0;
+  const upiPct = paymentTotal > 0 && data ? Math.round((data.paymentBreakdown.upi / paymentTotal) * 100) : 0;
   const creditPct = paymentTotal > 0 ? 100 - cashPct - upiPct : 0;
 
   return (

--- a/src/components/ui/BackHeader.tsx
+++ b/src/components/ui/BackHeader.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect } from "react";
 import { BackHandler, Platform, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 import { useNavigation } from "@react-navigation/native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 
 import { theme } from "../../theme";
@@ -13,6 +14,7 @@ interface BackHeaderProps {
 
 export function BackHeader({ title, onBack }: BackHeaderProps) {
   const navigation = useNavigation();
+  const insets = useSafeAreaInsets();
 
   const handleBack = () => {
     if (onBack) {
@@ -35,7 +37,7 @@ export function BackHeader({ title, onBack }: BackHeaderProps) {
   }, [onBack]);
 
   return (
-    <View style={styles.header}>
+    <View style={[styles.header, { paddingTop: 8 + insets.top }]}>
       <TouchableOpacity
         onPress={handleBack}
         style={styles.backButton}

--- a/src/screens/AIInsightsScreen.tsx
+++ b/src/screens/AIInsightsScreen.tsx
@@ -2,8 +2,9 @@
 // Shows alerts, forecasts, slow movers, expiring products, price comparisons
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, FlatList, Pressable, StyleSheet, RefreshControl, ActivityIndicator } from 'react-native';
+import { View, Text, FlatList, Pressable, StyleSheet, RefreshControl, ActivityIndicator, BackHandler, Platform } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { theme } from '../theme';
 import * as aiApi from '../services/api/aiApi';
 
@@ -14,6 +15,18 @@ interface Props {
 }
 
 export default function AIInsightsScreen({ onBack }: Props) {
+  const insets = useSafeAreaInsets();
+
+  // UIUX-POS-004: Android hardware back button support
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onBack();
+      return true;
+    });
+    return () => sub.remove();
+  }, [onBack]);
+
   const [tab, setTab] = useState<Tab>('alerts');
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -174,7 +187,7 @@ export default function AIInsightsScreen({ onBack }: Props) {
   return (
     <View style={styles.container}>
       {/* Header */}
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: 12 + insets.top }]}>
         <Pressable onPress={onBack} style={styles.backBtn}>
           <MaterialCommunityIcons name="arrow-left" size={24} color={theme.colors.textPrimary} />
         </Pressable>

--- a/src/screens/BnplDuesScreen.tsx
+++ b/src/screens/BnplDuesScreen.tsx
@@ -6,7 +6,9 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  BackHandler,
   Linking,
+  Platform,
   Pressable,
   RefreshControl,
   ScrollView,
@@ -42,6 +44,16 @@ interface BnplDuesScreenProps {
 export function BnplDuesScreen({ onBack }: BnplDuesScreenProps) {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
+
+  // UIUX-POS-004: Android hardware back button support
+  useEffect(() => {
+    if (Platform.OS !== "android" || !onBack) return;
+    const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+      onBack();
+      return true;
+    });
+    return () => sub.remove();
+  }, [onBack]);
 
   // State
   const [loading, setLoading] = useState(true);

--- a/src/screens/BulkPurchaseCreditScreen.tsx
+++ b/src/screens/BulkPurchaseCreditScreen.tsx
@@ -2,8 +2,9 @@
 // Browse available credit offers and apply for bulk purchase financing
 
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, Text, FlatList, Pressable, StyleSheet, RefreshControl, ActivityIndicator, Alert as RNAlert } from 'react-native';
+import { View, Text, FlatList, Pressable, StyleSheet, RefreshControl, ActivityIndicator, Alert as RNAlert, BackHandler, Platform } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { theme } from '../theme';
 // UIUX-POS-009: Use apiClient instead of raw fetch (handles auth refresh, rate limiting, error handling)
 import { apiClient } from '../services/api/apiClient';
@@ -26,6 +27,18 @@ interface Props {
 // UIUX-POS-009: Replaced raw fetch with apiClient (auth refresh, rate limiting, error handling)
 
 export default function BulkPurchaseCreditScreen({ onBack }: Props) {
+  const insets = useSafeAreaInsets();
+
+  // UIUX-POS-004: Android hardware back button support
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onBack();
+      return true;
+    });
+    return () => sub.remove();
+  }, [onBack]);
+
   const [offers, setOffers] = useState<CreditOffer[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -115,7 +128,7 @@ export default function BulkPurchaseCreditScreen({ onBack }: Props) {
 
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: 12 + insets.top }]}>
         <Pressable onPress={onBack} style={styles.backBtn}>
           <MaterialCommunityIcons name="arrow-left" size={24} color={theme.colors.textPrimary} />
         </Pressable>

--- a/src/screens/ChatConversationScreen.tsx
+++ b/src/screens/ChatConversationScreen.tsx
@@ -4,9 +4,10 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   View, Text, FlatList, TextInput, Pressable, StyleSheet,
-  KeyboardAvoidingView, Platform, ActivityIndicator,
+  KeyboardAvoidingView, Platform, ActivityIndicator, BackHandler, AppState,
 } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { theme } from '../theme';
 import * as chatApi from '../services/api/chatApi';
 
@@ -23,6 +24,18 @@ export default function ChatConversationScreen({
   conversationId, conversationTitle, conversationType,
   currentUserId, currentUserName, onBack,
 }: Props) {
+  const insets = useSafeAreaInsets();
+
+  // UIUX-POS-004: Android hardware back button support
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onBack();
+      return true;
+    });
+    return () => sub.remove();
+  }, [onBack]);
+
   const [messages, setMessages] = useState<chatApi.ChatMessage[]>([]);
   const [loading, setLoading] = useState(true);
   const [sending, setSending] = useState(false);
@@ -30,15 +43,26 @@ export default function ChatConversationScreen({
   const [error, setError] = useState<string | null>(null);
   const flatListRef = useRef<FlatList>(null);
 
-  const fetchMessages = useCallback(async () => {
-    setError(null);
+  const hasMarkedRead = useRef(false);
+  const appStateRef = useRef(AppState.currentState);
+
+  const fetchMessages = useCallback(async (isPolling = false) => {
+    if (!isPolling) setError(null);
     try {
       const result = await chatApi.getMessages(conversationId);
-      setMessages(result.messages || []);
-      // Mark as read
-      chatApi.markAsRead(conversationId).catch(() => {});
+      const newMessages = result.messages || [];
+      // Only update state if message list actually changed (prevents scroll jump)
+      setMessages(prev => {
+        if (prev.length === newMessages.length && prev[0]?.id === newMessages[0]?.id) return prev;
+        return newMessages;
+      });
+      // Mark as read only once on mount, not every poll
+      if (!hasMarkedRead.current) {
+        hasMarkedRead.current = true;
+        chatApi.markAsRead(conversationId).catch(() => {});
+      }
     } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Failed to load messages');
+      if (!isPolling) setError(err instanceof Error ? err.message : 'Failed to load messages');
     } finally {
       setLoading(false);
     }
@@ -46,9 +70,17 @@ export default function ChatConversationScreen({
 
   useEffect(() => {
     fetchMessages();
-    // Poll for new messages every 5 seconds (Socket.io will replace this)
-    const interval = setInterval(fetchMessages, 5000);
-    return () => clearInterval(interval);
+    // UIUX-POS-026: Poll every 15s (was 5s), pause when app backgrounded
+    const interval = setInterval(() => {
+      if (appStateRef.current === 'active') fetchMessages(true);
+    }, 15000);
+    const appStateSub = AppState.addEventListener('change', (state) => {
+      appStateRef.current = state;
+    });
+    return () => {
+      clearInterval(interval);
+      appStateSub.remove();
+    };
   }, [fetchMessages]);
 
   const handleSend = useCallback(async () => {
@@ -144,7 +176,7 @@ export default function ChatConversationScreen({
       keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}
     >
       {/* Header */}
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: 12 + insets.top }]}>
         <Pressable onPress={onBack} style={styles.backBtn}>
           <MaterialCommunityIcons name="arrow-left" size={24} color={theme.colors.textPrimary} />
         </Pressable>

--- a/src/screens/ChatListScreen.tsx
+++ b/src/screens/ChatListScreen.tsx
@@ -4,8 +4,10 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import {
   View, Text, FlatList, Pressable, StyleSheet, RefreshControl, ActivityIndicator,
+  BackHandler, Platform,
 } from 'react-native';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { theme } from '../theme';
 import * as chatApi from '../services/api/chatApi';
 
@@ -16,6 +18,18 @@ interface Props {
 }
 
 export default function ChatListScreen({ onSelectConversation, onContactSupport, onBack }: Props) {
+  const insets = useSafeAreaInsets();
+
+  // UIUX-POS-004: Android hardware back button support
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+    const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+      onBack();
+      return true;
+    });
+    return () => sub.remove();
+  }, [onBack]);
+
   const [conversations, setConversations] = useState<chatApi.Conversation[]>([]);
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
@@ -103,7 +117,7 @@ export default function ChatListScreen({ onSelectConversation, onContactSupport,
   return (
     <View style={styles.container}>
       {/* Header */}
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: 12 + insets.top }]}>
         <Pressable onPress={onBack} style={styles.backBtn}>
           <MaterialCommunityIcons name="arrow-left" size={24} color={theme.colors.textPrimary} />
         </Pressable>

--- a/src/screens/CreditScreen.tsx
+++ b/src/screens/CreditScreen.tsx
@@ -5,6 +5,8 @@ import React, { useCallback, useEffect, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
+  BackHandler,
+  Platform,
   Pressable,
   RefreshControl,
   ScrollView,
@@ -46,6 +48,16 @@ type TabId = "offers" | "loans" | "history";
 export function CreditScreen({ onBack }: CreditScreenProps) {
   const { t } = useTranslation();
   const insets = useSafeAreaInsets();
+
+  // UIUX-POS-004: Android hardware back button support
+  useEffect(() => {
+    if (Platform.OS !== "android" || !onBack) return;
+    const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+      onBack();
+      return true;
+    });
+    return () => sub.remove();
+  }, [onBack]);
 
   // Tab state
   const [activeTab, setActiveTab] = useState<TabId>("offers");

--- a/src/screens/PaymentScreen.tsx
+++ b/src/screens/PaymentScreen.tsx
@@ -16,6 +16,7 @@ import {
 import { useNavigation, useRoute, type RouteProp } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import QRCode from "react-native-qrcode-svg";
 
 import { useCartStore } from "../stores/cartStore";
@@ -132,6 +133,7 @@ const computeSaleTotals = (items: CartItem[], cartDiscount: CartDiscount | null)
 const PaymentScreen = () => {
   const navigation = useNavigation<PaymentScreenNavigationProp>();
   const route = useRoute<PaymentScreenRouteProp>();
+  const insets = useSafeAreaInsets();
   const { items, lockCart, unlockCart, locked, discount, removeItem } = useCartStore();
   const [selectedMode, setSelectedMode] = useState<PaymentMode>("UPI");
   const [saleId, setSaleId] = useState<string | null>(null);
@@ -899,7 +901,7 @@ const PaymentScreen = () => {
 
   return (
     <View style={styles.container}>
-      <View style={styles.header}>
+      <View style={[styles.header, { paddingTop: 16 + insets.top }]}>
         <View>
           <Text style={styles.headerTitle}>Payment</Text>
           {billRef && <Text style={styles.billRef}>Bill #{billRef}</Text>}

--- a/src/screens/ReorderScreen.tsx
+++ b/src/screens/ReorderScreen.tsx
@@ -176,15 +176,22 @@ export default function ReorderScreen({ onNavigateToBuy }: ReorderScreenProps) {
     async (id: string, reason: string) => {
       if (!storeId) return;
 
-      await reorderApi.dismissPendingReorder(storeId, id, reason);
+      try {
+        await reorderApi.dismissPendingReorder(storeId, id, reason);
 
-      // Remove from list
-      setPendingReorders((prev) => prev.filter((p) => p.id !== id));
-      setSelectedIds((prev) => {
-        const next = new Set(prev);
-        next.delete(id);
-        return next;
-      });
+        // Remove from list
+        setPendingReorders((prev) => prev.filter((p) => p.id !== id));
+        setSelectedIds((prev) => {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        });
+      } catch (err) {
+        Alert.alert(
+          "Dismiss Failed",
+          err instanceof Error ? err.message : "Could not dismiss reorder. Please try again."
+        );
+      }
     },
     [storeId]
   );

--- a/src/screens/SalesStatementScreen.tsx
+++ b/src/screens/SalesStatementScreen.tsx
@@ -10,6 +10,8 @@ import {
   FlatList,
   ActivityIndicator,
   RefreshControl,
+  BackHandler,
+  Platform,
 } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -119,6 +121,17 @@ function SalesDayCard({ day }: { day: DailySales }) {
 
 export default function SalesStatementScreen({ onBack, onNavigateToSell }: SalesStatementScreenProps) {
   const insets = useSafeAreaInsets();
+
+  // UIUX-POS-004: Android hardware back button support
+  useEffect(() => {
+    if (Platform.OS !== "android") return;
+    const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+      onBack();
+      return true;
+    });
+    return () => sub.remove();
+  }, [onBack]);
+
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [dailySales, setDailySales] = useState<DailySales[]>([]);

--- a/src/screens/StaffLoginScreen.tsx
+++ b/src/screens/StaffLoginScreen.tsx
@@ -2,7 +2,10 @@
 import React, { useState, useRef } from "react";
 import {
   Alert,
+  KeyboardAvoidingView,
+  Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   TextInput,
@@ -60,7 +63,14 @@ export default function StaffLoginScreen({ storeName }: Props) {
   };
 
   return (
-    <View style={styles.container}>
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === "ios" ? "padding" : undefined}
+    >
+      <ScrollView
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+      >
       <View style={styles.card}>
         <View style={styles.iconWrap}>
           <MaterialCommunityIcons name="account-lock" size={48} color={theme.colors.primary} />
@@ -113,7 +123,8 @@ export default function StaffLoginScreen({ storeName }: Props) {
           </Text>
         </Pressable>
       </View>
-    </View>
+      </ScrollView>
+    </KeyboardAvoidingView>
   );
 }
 
@@ -121,6 +132,9 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: theme.colors.background,
+  },
+  scrollContent: {
+    flexGrow: 1,
     justifyContent: "center",
     paddingHorizontal: 24,
   },

--- a/src/screens/StockStatementScreen.tsx
+++ b/src/screens/StockStatementScreen.tsx
@@ -10,6 +10,8 @@ import {
   FlatList,
   ActivityIndicator,
   RefreshControl,
+  BackHandler,
+  Platform,
 } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
@@ -75,6 +77,17 @@ function StockCard({ item }: { item: StockItem }) {
 
 export default function StockStatementScreen({ onBack }: StockStatementScreenProps) {
   const insets = useSafeAreaInsets();
+
+  // UIUX-POS-004: Android hardware back button support
+  useEffect(() => {
+    if (Platform.OS !== "android") return;
+    const sub = BackHandler.addEventListener("hardwareBackPress", () => {
+      onBack();
+      return true;
+    });
+    return () => sub.remove();
+  }, [onBack]);
+
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [stockItems, setStockItems] = useState<StockItem[]>([]);

--- a/supplier-portal/src/app/(dashboard)/upload/page.tsx
+++ b/supplier-portal/src/app/(dashboard)/upload/page.tsx
@@ -181,7 +181,7 @@ export default function UploadPage() {
               />
             </label>
             <p className="text-sm text-slate-400 mt-4">
-              Supported format: CSV (max 10MB)
+              Supported format: CSV (max 5MB)
             </p>
           </div>
         )}


### PR DESCRIPTION
## Summary

Wave 4 of Phase 14 UI/UX Production Readiness Audit — **12 P1 UI/navigation tickets** across all portals.

**Theme**: Android BackHandler for hardware back button, SafeArea insets for notched devices, KeyboardAvoidingView for form screens, and polling optimization.

### Web Portals (2 tickets)
- **RET-003**: AnalyticsPage `data!` non-null assertion → safe `data &&` guard
- **SUP-009**: Upload help text "max 10MB" → "max 5MB" (matches actual validation)

### POS — BackHeader Component (1 ticket)
- **POS-005**: BackHeader now includes `useSafeAreaInsets().top` — fixes 11+ screens using this component on notched devices

### POS — BackHandler + SafeArea (8 screens)
- **POS-004/006**: BulkPurchaseCreditScreen, ChatListScreen, ChatConversationScreen, AIInsightsScreen — both BackHandler and SafeArea insets added
- **POS-004**: BnplDuesScreen, CreditScreen, SalesStatementScreen, StockStatementScreen — BackHandler added (SafeArea already present)

### POS — SafeArea Only (1 screen)
- **POS-006**: PaymentScreen — SafeArea insets on header (BackHandler already present)

### POS — Other Fixes (3 tickets)
- **POS-023**: StaffLoginScreen — wrapped in KeyboardAvoidingView + ScrollView
- **POS-025**: ReorderScreen — dismiss handler now has try/catch with Alert on failure
- **POS-026**: ChatConversationScreen — polling reduced from 5s to 15s, pauses when backgrounded, markAsRead only on mount, skips update if messages unchanged

### Verified Already Done
- **SUP-007**: Notifications page already has error state with retry button

### Skipped
- **POS-024**: InwardScreen uses FlatList which handles keyboard scrolling natively

## Test plan
- [ ] POS: Verify Android hardware back button works on all modified screens
- [ ] POS: Verify header doesn't overlap status bar on notched devices (BackHeader + custom headers)
- [ ] POS: Verify StaffLoginScreen keyboard doesn't cover login button
- [ ] POS: Verify ReorderScreen shows error Alert when dismiss API fails
- [ ] POS: Verify ChatConversation doesn't scroll-jump on poll, pauses when backgrounded
- [ ] Retailer Admin: Verify AnalyticsPage loads without crash when data is null
- [ ] Supplier Portal: Verify upload page shows "max 5MB" help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)