### PR TITLE
fix(WA-IMPORT): repair broken import syntax in WhatsApp routes

### DIFF
--- a/backend/src/routes/v1/admin/whatsapp.ts
+++ b/backend/src/routes/v1/admin/whatsapp.ts
@@ -5,8 +5,8 @@
 import { Router, Request, Response } from "express";
 import { requireAdminToken } from "../../../middleware/adminToken";
 import { getPool } from "../../../db/client";
-import {
 import { log } from "../../../lib/logger";
+import {
   isWhatsAppConfigured,
   sendTextMessage,
   normalizePhone,

--- a/backend/src/routes/v1/pos/whatsapp.ts
+++ b/backend/src/routes/v1/pos/whatsapp.ts
@@ -5,8 +5,8 @@ import { Router, Request, Response } from "express";
 import { requireDeviceToken } from "../../../middleware/deviceToken";
 import { requireActiveStore } from "../../../middleware/storeStatusGate";
 import { getPool } from "../../../db/client";
-import {
 import { log } from "../../../lib/logger";
+import {
   isWhatsAppConfigured,
   sendTextMessage,
   sendBillReceipt,


### PR DESCRIPTION
## Summary
- PR #288 logger migration script inserted `import { log }` inside multiline import blocks in 2 WhatsApp route files
- This created TypeScript syntax errors that would crash both POS and admin WhatsApp endpoints
- Moves the `log` import to a standalone statement above the multiline import

## Files Fixed
- `backend/src/routes/v1/pos/whatsapp.ts` — POS send-bill, send-message endpoints
- `backend/src/routes/v1/admin/whatsapp.ts` — Admin send, broadcast, logs, stats endpoints

## Verification
- `npx tsc --noEmit` passes with zero errors
- No other broken import patterns found (multiline grep across entire codebase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)