### PR TITLE
fix(STAGING-READINESS-2): supplier-portal test fixes + state file + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,19 @@ retailer-admin/coverage/
 supermandi-superadmin/coverage/
 supplier-portal/coverage/
 coverage/
+
+# Research / reference text files (payment gateway docs, RBI circulars, etc.)
+cashfree_*.txt
+decentro_*.txt
+hdfc_*.txt
+juspay_*.txt
+npci_*.txt
+open_*.txt
+paytm_*.txt
+paytmpayments_*.txt
+payu_*.txt
+phonepe_*.txt
+razorpay_*.txt
+razorpayx_*.txt
+rbi_*.txt
+tmp_*.txt

--- a/RELEASES/CLAUDE_CURRENT_STATE.json
+++ b/RELEASES/CLAUDE_CURRENT_STATE.json
@@ -1,7 +1,7 @@
 {
-  "version": "30.0",
-  "lastUpdated": "2026-02-18T01:30:00+05:30",
-  "currentPhase": "DEPLOY-READY — Part 18 deployment discipline written. 437 tickets awaiting GCP staging deploy.",
+  "version": "31.0",
+  "lastUpdated": "2026-02-19T00:30:00+05:30",
+  "currentPhase": "DEPLOY-READY — All code complete (Phases 1-14, 500+ tickets). Awaiting operator staging deploy.",
   "currentTicket": null,
   "ticketQueue": [
     "FIX-001"
@@ -269,7 +269,7 @@
       "11E_SupplierP0P1": "9/9 DONE (4 false positive)",
       "11F_POS_P0P1": "12/12 DONE (1 false positive)",
       "11G_SuperAdminP0P1": "8/8 DONE (3 false positive)",
-      "11H_P2Polish": "17/17 DONE (4 code fixes + 6 false positive)"
+      "11H_P2Polish": "17/17 DONE (11 code fixes + 6 false positive)"
     }
   },
   "wa001_WhatsAppCloudAPI": {
@@ -292,7 +292,7 @@
     "auditMethod": "Full test-suite read of all 250+ test files across entire repo",
     "auditDate": "2026-02-17",
     "completedDate": "2026-02-18",
-    "firstCommit": "3a4c5b1",
+    "firstCommit": "d10f897",
     "lastCommit": "cad2273",
     "mergedPRs": "PR #250 → #263 (14 PRs for 17 code-fix ticket IDs)",
     "breakdown": {
@@ -320,7 +320,7 @@
   "deployGateStatus": {
     "phaseA_preDeployAudit": {
       "A001_cleanGit": "PASS — main branch, up to date with origin",
-      "A002_headSHA": "PASS — HEAD is 575a2d3 (WA-003 hardening)",
+      "A002_headSHA": "PASS — HEAD is 61337c5 (STAGING-READINESS build/typecheck fixes)",
       "A003_typecheck": "PASS — all 4 packages zero errors (backend, retailer, supplier, superadmin)",
       "A004_build": "PENDING — CI does actual Docker builds",
       "A005_tests": "PENDING — CI runs full test suite",
@@ -390,7 +390,7 @@
   "phase14_UIUXProductionAudit": {
     "range": "UIUX-RET-001→020, UIUX-SUP-001→020, UIUX-SA-001→027, UIUX-POS-001→042, UIUX-XPLAT-001→006",
     "count": 115,
-    "status": "Wave 1 DONE (15 P0 fixes, PR #282). Wave 2 IN PROGRESS (P1 wiring fixes).",
+    "status": "COMPLETE — All 5 waves merged (PRs #282-#286). 115 tickets audited, ~90 code fixes applied.",
     "auditFile": "RELEASES/UIUX_PRODUCTION_AUDIT.md",
     "rawFindings": 176,
     "afterTriage": 115,
@@ -410,6 +410,14 @@
       "E_CrossPlatform": { "range": "UIUX-XPLAT-001→006", "count": 6, "P0": 2, "P1": 1, "P2": 3 }
     },
     "executionWaves": 5,
+    "mergedPRs": {
+      "wave1_P0": "PR #282 — 15 P0 critical fixes",
+      "wave2_P1_wiring": "PR #283 — 16 P1 wiring fixes",
+      "wave3_P1_ux": "PR #284 — 17 P1 UX safety fixes",
+      "wave4_P1_nav": "PR #285 — 12 P1 UI/nav fixes",
+      "wave5_P2_polish": "PR #286 — 35 P2 polish fixes"
+    },
+    "tags": ["prestage-UIUX-W1-2026-02-18_1200IST", "prestage-UIUX-W2-2026-02-18", "prestage-UIUX-W3-2026-02-18", "prestage-UIUX-W4-2026-02-18", "prestage-UIUX-W5-2026-02-18"],
     "prioritySplit": { "P0_CRITICAL": 13, "P1_HIGH": 52, "P2_MEDIUM": 50 },
     "topP0Findings": [
       "UIUX-SUP-001/002: Profile, Chat, BNPL pages unreachable (missing sidebar nav)",
@@ -422,10 +430,24 @@
       "UIUX-XPLAT-002: Retailer dashboard displays all amounts 100x too large"
     ]
   },
-  "nextAction": "Execute Wave 2 (P1 wiring fixes): SA-005/006/007/014, POS-007→018, XPLAT-003",
+  "nextAction": "ALL CODE COMPLETE. FIX-001 (staging deploy) requires operator. 19 tickets await external APIs.",
+  "productionHardeningDeferred": {
+    "status": "DONE — PR #288 merged (853a7d8)",
+    "date": "2026-02-18",
+    "scope": "176 files changed (+1669/-1441)",
+    "items": [
+      "919 console.log → structured logger (142 backend files)",
+      "240 catch(e: any) → catch(unknown) + asError() (67 files)",
+      "5 dead code files removed (sessionService, authApi, transactionsApi + tests)",
+      "CreditScreen TODO resolved (credit utilization computed from real data)",
+      "7 broken import orderings fixed"
+    ],
+    "pr": "#288"
+  },
   "lastActions": [
-    "Wave 1 DONE: 15 P0 fixes merged (PR #282, tag prestage-UIUX-W1-2026-02-18_1200IST). SUP-007/014 also fixed as side effects.",
-    "Wave 2 IN PROGRESS: P1 wiring bugs — wrong endpoints, stale closures, missing auth.",
-    "Backend wiring audit: 67/67 endpoints verified, 10/10 services PASS. 1 P0 gateway CORS, 4 P1 gateway gaps identified."
+    "Production Hardening Deferred Fixes DONE: PR #288 merged (structured logging, type safety, dead code removal).",
+    "Phase 14 UIUX Re-Audit: PR #287 merged (2 P0 wiring fixes, 3 P1, 7 P2).",
+    "Phase 14 UIUX Audit v2 COMPLETE: All 5 waves merged (PRs #282-#286, 115 tickets).",
+    "All codeable work DONE. Next: Operator triggers staging deploy (FIX-001)."
   ]
 }

--- a/supplier-portal/src/__tests__/pages/dashboard/layout.test.tsx
+++ b/supplier-portal/src/__tests__/pages/dashboard/layout.test.tsx
@@ -78,7 +78,7 @@ jest.mock('../../../components/LimitedModeBanner', () => {
   };
 });
 
-// Mock lucide-react
+// Mock lucide-react — must include ALL icons imported by layout.tsx
 jest.mock('lucide-react', () => {
   const React = require('react');
   const mockIcon = (name: string) => (props: any) =>
@@ -95,6 +95,8 @@ jest.mock('lucide-react', () => {
     Menu: mockIcon('Menu'),
     X: mockIcon('X'),
     Bell: mockIcon('Bell'),
+    MessageSquare: mockIcon('MessageSquare'),
+    CreditCard: mockIcon('CreditCard'),
   };
 });
 

--- a/supplier-portal/src/__tests__/pages/dashboard/profile.test.tsx
+++ b/supplier-portal/src/__tests__/pages/dashboard/profile.test.tsx
@@ -11,30 +11,33 @@ jest.mock('react-hot-toast', () => ({
   }),
 }));
 
-// Mock auth context
+// Mock auth context — stable reference to prevent infinite useEffect loop
+// (profile page has useEffect([supplier]) which re-runs if supplier is a new object each render)
+const mockSupplier = {
+  businessName: 'Test Supplier Co',
+  gstin: '22AAAAA0000A1Z5',
+  verificationStatus: 'verified',
+  contactName: 'John Doe',
+  email: 'john@test.com',
+  phone: '+919876543210',
+  address: '123 Main St',
+  city: 'Mumbai',
+  state: 'Maharashtra',
+  pincode: '400001',
+  bankDetails: {
+    accountName: 'Test Supplier',
+    accountNumber: '1234567890',
+    ifscCode: 'HDFC0001234',
+    bankName: 'HDFC Bank',
+  },
+  bankVerificationStatus: null,
+  emailVerified: true,
+};
+const mockRefreshProfile = jest.fn();
 jest.mock('../../../lib/auth', () => ({
   useAuth: () => ({
-    supplier: {
-      businessName: 'Test Supplier Co',
-      gstin: '22AAAAA0000A1Z5',
-      verificationStatus: 'verified',
-      contactName: 'John Doe',
-      email: 'john@test.com',
-      phone: '+919876543210',
-      address: '123 Main St',
-      city: 'Mumbai',
-      state: 'Maharashtra',
-      pincode: '400001',
-      bankDetails: {
-        accountName: 'Test Supplier',
-        accountNumber: '1234567890',
-        ifscCode: 'HDFC0001234',
-        bankName: 'HDFC Bank',
-      },
-      bankVerificationStatus: null,
-      emailVerified: true,
-    },
-    refreshProfile: jest.fn(),
+    supplier: mockSupplier,
+    refreshProfile: mockRefreshProfile,
   }),
 }));
 


### PR DESCRIPTION
## Summary
- **FIX-SUP-TEST-001**: Add missing `MessageSquare` and `CreditCard` icon mocks to `layout.test.tsx` — layout imports 13 lucide icons but the mock only had 11, causing `IconComponent` to be `undefined` → 7 test failures
- **FIX-SUP-TEST-002**: Stabilize `useAuth` mock in `profile.test.tsx` with a stable object reference — the mock returned a new object on every call, triggering an infinite `useEffect([supplier])` loop → worker crash (exitCode=143)
- **FIX-STATE-001**: Fix 3 state file discrepancies — phantom SHA `3a4c5b1`→`d10f897`, stale HEAD SHA `575a2d3`→`61337c5`, tier description `4 code fixes`→`11 code fixes`
- **CLEANUP-001**: Add `.gitignore` patterns for 92 research `.txt` files (payment gateway docs, RBI circulars)

## Test Results
| Service | Suites | Tests | Status |
|---------|--------|-------|--------|
| backend | 52 | 928 | PASS |
| retailer-admin | 48 | 641 | PASS |
| supermandi-superadmin | 55 | 936 | PASS |
| supplier-portal | 34 | 365 | PASS |
| **TOTAL** | **189** | **2,870** | **ALL PASS** |

## Test plan
- [x] supplier-portal: 34 suites, 365 tests — ALL PASS (was 7 failures + 1 crash)
- [x] backend: 52 suites, 928 tests — zero regressions
- [x] retailer-admin: 48 suites, 641 tests — zero regressions
- [x] superadmin: 55 suites, 936 tests — zero regressions
- [x] Typecheck: all packages clean (zero errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)