### PR TITLE
fix(SCR-POS-1042): correct column name in price comparison SQL query

### DIFF
--- a/backend/src/services/ai/priceComparisonService.ts
+++ b/backend/src/services/ai/priceComparisonService.ts
@@ -44,14 +44,14 @@ export async function getStorePriceComparisons(storeId: string, opts: {
   const result = await pool.query(
     `SELECT sp.product_id, sp.display_name, sp.sell_price AS current_price,
             sup_p.id AS supplier_product_id, sup_p.supplier_id, sup_p.name AS supplier_product_name,
-            sup_p.price AS supplier_price, sup_p.moq,
+            sup_p.purchase_price AS supplier_price, sup_p.moq,
             s.company_name AS supplier_name
      FROM catalog.store_products sp
      JOIN catalog.supplier_product_map spm ON spm.product_id = sp.product_id
      JOIN catalog.supplier_products sup_p ON sup_p.id = spm.supplier_product_id AND sup_p.is_active = true
      JOIN platform.suppliers s ON s.id = sup_p.supplier_id
      WHERE ${conditions.join(' AND ')}
-     ORDER BY sp.display_name, sup_p.price ASC`,
+     ORDER BY sp.display_name, sup_p.purchase_price ASC`,
     params
   );
 


### PR DESCRIPTION
## Summary
- `priceComparisonService.ts` line 47 used `sup_p.price` but `catalog.supplier_products` has no `price` column — the actual column is `purchase_price` (per migration 004)
- This caused a PostgreSQL column-not-found error at runtime, making the AI Insights → Prices tab always return 500
- Fix: `sup_p.price` → `sup_p.purchase_price` in both SELECT and ORDER BY clauses

## Found During
Phase 15 Screen-by-Screen Atomic Audit — Screen 42 (AIInsightsScreen), Layer 4 backend trace

## Test plan
- [ ] Backend typecheck passes (verified locally)
- [ ] CI build green
- [ ] Verify Prices tab returns data on staging (requires supplier_products with purchase_price populated)
- [ ] Other AI tabs unaffected (Alerts, Forecasts, Slow Movers, Expiry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)