### PR TITLE
fix(SCR-POS-002): X-App-Version header fixes post-update race condition

### DIFF
--- a/backend/src/routes/v1/pos/uiStatus.ts
+++ b/backend/src/routes/v1/pos/uiStatus.ts
@@ -16,6 +16,12 @@ posUiStatusRouter.get("/ui-status", requireDeviceTokenAllowInactive, async (req,
 
   const status = (req as any).posDeviceStatus as PosDeviceStatusContext;
 
+  // SA-P2-003-FIX: Prefer X-App-Version header over DB value to avoid
+  // race condition after Play Store update (DB may still have old version)
+  const headerAppVersion = typeof req.headers["x-app-version"] === "string"
+    ? req.headers["x-app-version"].trim()
+    : null;
+
   const result = await pool.query(
     `
     SELECT pending_outbox_count,
@@ -30,6 +36,11 @@ posUiStatusRouter.get("/ui-status", requireDeviceTokenAllowInactive, async (req,
   );
   const row = result.rows[0] ?? {};
   const nowIso = new Date().toISOString();
+
+  // Use header version if available (always fresh), fall back to DB version
+  const effectiveAppVersion = headerAppVersion && headerAppVersion !== "unknown"
+    ? headerAppVersion
+    : (row.app_version || "0.0.0");
 
   let storeName: string | null = null;
   let storeCode: string | null = null; // STORECODE-003
@@ -121,8 +132,9 @@ posUiStatusRouter.get("/ui-status", requireDeviceTokenAllowInactive, async (req,
               const dbVersion = ffRow.payload_json?.version ? String(ffRow.payload_json.version) : null;
               minAppVersionValue = autoVersion || dbVersion || null;
               if (minAppVersionValue) {
-                const deviceVersion = row.app_version || "0.0.0";
-                forceUpdate = compareSemver(deviceVersion, minAppVersionValue) < 0;
+                // SA-P2-003-FIX: Use effectiveAppVersion (header-first) to avoid
+                // post-update race condition where DB still has old version
+                forceUpdate = compareSemver(effectiveAppVersion, minAppVersionValue) < 0;
               }
             }
             break;
@@ -133,10 +145,18 @@ posUiStatusRouter.get("/ui-status", requireDeviceTokenAllowInactive, async (req,
     }
   }
 
-  await pool.query(
-    `UPDATE pos_devices SET last_seen_online = NOW(), updated_at = NOW() WHERE id = $1`,
-    [status.deviceId]
-  );
+  // SA-P2-003-FIX: Also persist header app_version to DB so it stays current
+  if (headerAppVersion && headerAppVersion !== "unknown") {
+    await pool.query(
+      `UPDATE pos_devices SET last_seen_online = NOW(), app_version = $2, updated_at = NOW() WHERE id = $1`,
+      [status.deviceId, headerAppVersion]
+    );
+  } else {
+    await pool.query(
+      `UPDATE pos_devices SET last_seen_online = NOW(), updated_at = NOW() WHERE id = $1`,
+      [status.deviceId]
+    );
+  }
 
   const pending =
     typeof row.pending_outbox_count === "number" && Number.isFinite(row.pending_outbox_count)

--- a/src/services/api/uiStatusApi.ts
+++ b/src/services/api/uiStatusApi.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL } from "../../config/api";
 import { getDeviceToken, getDeviceSession } from "../deviceSession";
+import { getDeviceMeta } from "../deviceInfo";
 import { useSettingsStore } from "../../stores/settingsStore";
 
 export type UiStatusResponse = {
@@ -140,6 +141,7 @@ export async function fetchUiStatus(): Promise<UiStatusResponse> {
     const response = await fetch(`${API_BASE_URL}/api/v1/pos/ui-status`, {
       headers: {
         "X-Device-Token": deviceToken,
+        "X-App-Version": getDeviceMeta().appVersion ?? "unknown",
       },
     });
 


### PR DESCRIPTION
## Summary
- **Bug**: After Play Store update, first `fetchUiStatus()` returns `forceUpdate:true` because DB still has old `app_version` (metadata PATCH hasn't completed yet). User sees "Update Required" screen again after just updating.
- **Fix**: Frontend sends `X-App-Version` header with every ui-status request. Backend prefers header value over DB value for version comparison.
- **Bonus**: Backend also persists header version to DB, keeping `pos_devices.app_version` always current.

## Files changed
- `src/services/api/uiStatusApi.ts` — adds `X-App-Version` header to fetch call
- `backend/src/routes/v1/pos/uiStatus.ts` — reads header, uses for comparison, persists to DB

## Test plan
- [ ] Frontend typecheck passes
- [ ] Backend typecheck passes
- [ ] After app update: first ui-status call returns `forceUpdate: false` (no loop)
- [ ] DB `pos_devices.app_version` updated on every ui-status poll

🤖 Generated with [Claude Code](https://claude.com/claude-code)