### PR TITLE
feat(SA-ENROLL-UX): production-grade enrollment QR flow (#300)

### DIFF
--- a/backend/src/routes/v1/admin/deviceEnrollments.ts
+++ b/backend/src/routes/v1/admin/deviceEnrollments.ts
@@ -12,7 +12,8 @@ const DEMO_MAX_USES = 9999;
 // Production stores get single-use enrollment codes
 const PRODUCTION_MAX_USES = 1;
 
-const ENROLLMENT_TTL_MINUTES = 30;
+// SA-ENROLL-UX G4: Configurable production code expiry (default 24hr for field agents)
+const ENROLLMENT_TTL_MINUTES = parseInt(process.env.ENROLLMENT_TTL_MINUTES || "1440", 10);
 const CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
 
 // AUD-063-A FIX: Use crypto.randomBytes instead of Math.random() for secure code generation
@@ -64,7 +65,7 @@ adminDeviceEnrollmentRouter.get("/device-enrollments", requireAdminToken, async 
     const countResult = await pool.query(countQuery, countParams);
     const total = parseInt(countResult.rows[0]?.total || "0", 10);
 
-    // Get paginated data
+    // Get paginated data (SA-ENROLL-UX G5: include status + revocation fields)
     const dataQuery = `
       SELECT
         e.code as id,
@@ -76,7 +77,16 @@ adminDeviceEnrollmentRouter.get("/device-enrollments", requireAdminToken, async 
         e.max_uses,
         e.uses_count,
         e.created_at,
-        e.created_by
+        e.created_by,
+        e.revoked_at,
+        e.used_at,
+        e.last_used_at,
+        CASE
+          WHEN e.revoked_at IS NOT NULL THEN 'REVOKED'
+          WHEN e.expires_at < NOW() THEN 'EXPIRED'
+          WHEN COALESCE(e.uses_count, 0) >= COALESCE(e.max_uses, 1) THEN 'USED'
+          ELSE 'ACTIVE'
+        END as status
       FROM pos_device_enrollments e
       LEFT JOIN platform.stores s ON e.store_id::uuid = s.id
       ${whereClause}
@@ -156,5 +166,40 @@ adminDeviceEnrollmentRouter.post("/stores/:storeId/device-enrollments", requireA
   } catch (error) {
     log.error("[AdminEnrollment] Error creating enrollment:", error);
     return res.status(500).json({ error: "INTERNAL_ERROR", message: "Failed to create enrollment" });
+  }
+});
+
+// SA-ENROLL-UX G2: PATCH /api/v1/admin/device-enrollments/:code/revoke
+adminDeviceEnrollmentRouter.patch("/device-enrollments/:code/revoke", requireAdminToken, async (req, res) => {
+  try {
+    const code = typeof req.params.code === "string" ? req.params.code.trim() : "";
+    if (!code) {
+      return res.status(400).json({ error: "code is required" });
+    }
+
+    const pool = getPool();
+    if (!pool) return res.status(503).json({ error: "database unavailable" });
+
+    const result = await pool.query(
+      `UPDATE pos_device_enrollments
+       SET revoked_at = NOW(), updated_at = NOW()
+       WHERE code = $1 AND revoked_at IS NULL
+       RETURNING code, store_id, revoked_at, expires_at, max_uses, uses_count, created_at`,
+      [code]
+    );
+
+    if (result.rowCount === 0) {
+      const check = await pool.query(`SELECT code, revoked_at FROM pos_device_enrollments WHERE code = $1`, [code]);
+      if (check.rowCount === 0) {
+        return res.status(404).json({ error: "enrollment code not found" });
+      }
+      return res.status(409).json({ error: "enrollment code already revoked" });
+    }
+
+    log.info(`[AdminEnrollment] Revoked code=${code}`);
+    return res.json({ success: true, enrollment: result.rows[0] });
+  } catch (error) {
+    log.error("[AdminEnrollment] Error revoking enrollment:", error);
+    return res.status(500).json({ error: "INTERNAL_ERROR", message: "Failed to revoke enrollment" });
   }
 });

--- a/backend/src/services/enrollmentCodeService.ts
+++ b/backend/src/services/enrollmentCodeService.ts
@@ -18,7 +18,8 @@ import { log } from "../lib/logger";
 // =============================================================================
 
 const CODE_ALPHABET = "23456789ABCDEFGHJKLMNPQRSTUVWXYZ";
-const ENROLLMENT_TTL_MINUTES = 30;
+// SA-ENROLL-UX G4: Configurable production code expiry (default 24hr for field agents)
+const ENROLLMENT_TTL_MINUTES = parseInt(process.env.ENROLLMENT_TTL_MINUTES || "1440", 10);
 const DEMO_MAX_USES = 9999;
 const PRODUCTION_MAX_USES = 1;
 

--- a/supermandi-superadmin/src/App.tsx
+++ b/supermandi-superadmin/src/App.tsx
@@ -9,7 +9,7 @@ import { fetchAiHealth } from "./api/ai";
 import { hasValidSession, logout, refreshSession, startIdleTimeout, stopIdleTimeout, abortActiveRequests } from "./api/authToken";
 import { createStore, fetchStore, fetchStores, updateStore, changeStoreStatus, type StoreRecord } from "./api/stores";
 import { fetchDevices, patchDevice, type DeviceRecord } from "./api/devices";
-import { createDeviceEnrollment, type DeviceEnrollmentResponse } from "./api/deviceEnrollments";
+import { createDeviceEnrollment, revokeEnrollmentCode, fetchStoreEnrollments, type DeviceEnrollmentResponse, type EnrollmentRecord } from "./api/deviceEnrollments";
 import {
   fetchAnalyticsOverview,
   fetchAnalyticsDevices,
@@ -462,6 +462,11 @@ export default function App() {
   const [enrollment, setEnrollment] = useState<DeviceEnrollmentResponse | null>(null);
   const [enrollError, setEnrollError] = useState<string>("");
   const [enrollLoading, setEnrollLoading] = useState<boolean>(false);
+  // SA-ENROLL-UX: Enrollment revocation and per-store enrollment state
+  const [revokeLoading, setRevokeLoading] = useState<boolean>(false);
+  const [enrollmentForStoreLoading, setEnrollmentForStoreLoading] = useState<string>("");
+  const [storeEnrollments, setStoreEnrollments] = useState<Record<string, EnrollmentRecord[]>>({});
+  const [storeEnrollmentsLoading, setStoreEnrollmentsLoading] = useState<Record<string, boolean>>({});
   // ISSUE-MICRO-086: enrollNow state removed — timer moved to EnrollmentCountdown component
 
   // Analytics state
@@ -2484,6 +2489,54 @@ export default function App() {
     }
   }
 
+  // SA-ENROLL-UX G2: Revoke an enrollment code
+  async function handleRevokeEnrollment(code: string) {
+    if (!confirm(`Revoke enrollment code ${code}? This cannot be undone.`)) return;
+    setRevokeLoading(true);
+    try {
+      await revokeEnrollmentCode(code);
+      if (enrollment?.code === code) {
+        setEnrollment(null);
+      }
+      // Refresh any store enrollments that contain this code
+      for (const [sid, records] of Object.entries(storeEnrollments)) {
+        if (records.some((r) => r.code === code)) {
+          void loadStoreEnrollmentsHandler(sid);
+        }
+      }
+    } catch (e: any) {
+      setEnrollError(e?.message ? String(e.message) : "Failed to revoke enrollment code");
+    } finally {
+      setRevokeLoading(false);
+    }
+  }
+
+  // SA-ENROLL-UX G3: Generate enrollment from Stores tab
+  async function handleCreateEnrollmentForStore(storeId: string) {
+    setEnrollmentForStoreLoading(storeId);
+    try {
+      await createDeviceEnrollment(storeId);
+      await loadStoreEnrollmentsHandler(storeId);
+    } catch (e: any) {
+      setStoreDirectoryError(e?.message ? String(e.message) : "Failed to create enrollment");
+    } finally {
+      setEnrollmentForStoreLoading("");
+    }
+  }
+
+  // SA-ENROLL-UX G5: Load enrollment codes for a specific store
+  async function loadStoreEnrollmentsHandler(storeId: string) {
+    setStoreEnrollmentsLoading((prev) => ({ ...prev, [storeId]: true }));
+    try {
+      const records = await fetchStoreEnrollments(storeId);
+      setStoreEnrollments((prev) => ({ ...prev, [storeId]: records }));
+    } catch {
+      // Silently fail — enrollment codes are supplementary info
+    } finally {
+      setStoreEnrollmentsLoading((prev) => ({ ...prev, [storeId]: false }));
+    }
+  }
+
   // ISSUE-MICRO-086: enrollmentCountdown useMemo removed — rendered by EnrollmentCountdown component
 
   // =========================================================================
@@ -2897,6 +2950,9 @@ export default function App() {
           refreshDevices={refreshDevices}
           limit={limit}
           devices={devices}
+          storeDirectory={storeDirectory}
+          handleRevokeEnrollment={handleRevokeEnrollment}
+          revokeLoading={revokeLoading}
         />
       )}
 
@@ -2962,6 +3018,13 @@ export default function App() {
           handleBarcodeSheetShare={handleBarcodeSheetShare}
           stores={stores}
           limit={limit}
+          handleCreateEnrollmentForStore={handleCreateEnrollmentForStore}
+          enrollmentForStoreLoading={enrollmentForStoreLoading}
+          storeEnrollments={storeEnrollments}
+          loadStoreEnrollments={loadStoreEnrollmentsHandler}
+          storeEnrollmentsLoading={storeEnrollmentsLoading}
+          handleRevokeEnrollment={handleRevokeEnrollment}
+          revokeLoading={revokeLoading}
         />
       )}
 

--- a/supermandi-superadmin/src/api/deviceEnrollments.ts
+++ b/supermandi-superadmin/src/api/deviceEnrollments.ts
@@ -6,6 +6,26 @@ export type DeviceEnrollmentResponse = {
   code: string;
   expiresAt: string;
   qrPayload: string;
+  maxUses?: number;
+  isDemo?: boolean;
+};
+
+// SA-ENROLL-UX G5: Type for enrollment records from listing endpoint
+export type EnrollmentRecord = {
+  id: string;
+  code: string;
+  store_id: string;
+  store_name?: string | null;
+  store_code?: string | null;
+  expires_at: string;
+  max_uses: number;
+  uses_count: number;
+  created_at: string;
+  created_by: string;
+  revoked_at: string | null;
+  used_at: string | null;
+  last_used_at: string | null;
+  status: "ACTIVE" | "EXPIRED" | "USED" | "REVOKED";
 };
 
 function requireApiBase(): string {
@@ -14,7 +34,7 @@ function requireApiBase(): string {
 
 export async function createDeviceEnrollment(storeId: string): Promise<DeviceEnrollmentResponse> {
   const base = requireApiBase();
-  
+
   const res = await fetchWithTimeout(`${base}/api/v1/admin/stores/${encodeURIComponent(storeId)}/device-enrollments`, {
     method: "POST",
     headers: {
@@ -29,4 +49,47 @@ export async function createDeviceEnrollment(storeId: string): Promise<DeviceEnr
   }
 
   return (await res.json()) as DeviceEnrollmentResponse;
+}
+
+// SA-ENROLL-UX G2: Revoke an enrollment code
+export async function revokeEnrollmentCode(code: string): Promise<{ success: boolean }> {
+  const base = requireApiBase();
+
+  const res = await fetchWithTimeout(`${base}/api/v1/admin/device-enrollments/${encodeURIComponent(code)}/revoke`, {
+    method: "PATCH",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...getAuthHeaders()
+    }
+  });
+
+  if (!res.ok) {
+    throw new Error(await parseError(res));
+  }
+
+  return (await res.json()) as { success: boolean };
+}
+
+// SA-ENROLL-UX G5: Fetch enrollment codes for a specific store
+export async function fetchStoreEnrollments(storeId: string): Promise<EnrollmentRecord[]> {
+  const base = requireApiBase();
+
+  const res = await fetchWithTimeout(
+    `${base}/api/v1/admin/device-enrollments?storeId=${encodeURIComponent(storeId)}&limit=20`,
+    {
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        ...getAuthHeaders()
+      }
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(await parseError(res));
+  }
+
+  const data = (await res.json()) as { enrollments: EnrollmentRecord[] };
+  return data.enrollments;
 }

--- a/supermandi-superadmin/src/tabs/DevicesTab.tsx
+++ b/supermandi-superadmin/src/tabs/DevicesTab.tsx
@@ -31,6 +31,11 @@ interface DevicesTabProps {
   refreshDevices: (page: number) => void;
   limit: number;
   devices: Array<{ deviceId: string; storeId: string; lastSeen: string; lastEventType: string; eventCount: number }>;
+  // SA-ENROLL-UX G1: Store picker dropdown
+  storeDirectory: Array<{ id: string; name?: string | null; storeName?: string | null }>;
+  // SA-ENROLL-UX G2: Code revocation
+  handleRevokeEnrollment: (code: string) => void;
+  revokeLoading: boolean;
 }
 
 export function DevicesTab({
@@ -55,6 +60,10 @@ export function DevicesTab({
   refreshDevices,
   limit,
   devices,
+  // SA-ENROLL-UX G1 + G2
+  storeDirectory,
+  handleRevokeEnrollment,
+  revokeLoading,
 }: DevicesTabProps) {
   return (
     <section className="card">
@@ -67,13 +76,21 @@ export function DevicesTab({
 
       <div className="tableWrap" style={{ paddingTop: 0 }}>
         <div className="controls" style={{ gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))" }}>
+          {/* SA-ENROLL-UX G1: Store picker dropdown */}
           <div className="control">
-            <label>Store ID</label>
-            <input
+            <label>Store</label>
+            <select
               value={enrollStoreId}
               onChange={(e) => setEnrollStoreId(e.target.value)}
-              placeholder="e.g. store-1"
-            />
+              style={{ padding: "6px 10px", borderRadius: 4, border: "1px solid #ddd", fontSize: 13, minWidth: 260 }}
+            >
+              <option value="">-- Select a store --</option>
+              {storeDirectory.map((s) => (
+                <option key={s.id} value={s.id}>
+                  {s.name || s.storeName || s.id}
+                </option>
+              ))}
+            </select>
           </div>
           <div className="control">
             <label>&nbsp;</label>
@@ -124,6 +141,16 @@ export function DevicesTab({
                     title="Regenerate QR code with new enrollment"
                   >
                     {enrollLoading ? "Regenerating..." : "Regenerate QR"}
+                  </button>
+                  {/* SA-ENROLL-UX G2: Revoke enrollment code */}
+                  <button
+                    className="btnGhost"
+                    onClick={() => handleRevokeEnrollment(enrollment.code)}
+                    disabled={revokeLoading}
+                    title="Revoke this enrollment code so it can no longer be used"
+                    style={{ color: "#dc2626" }}
+                  >
+                    {revokeLoading ? "Revoking..." : "Revoke Code"}
                   </button>
                 </div>
               </div>

--- a/supermandi-superadmin/src/tabs/StoresTab.tsx
+++ b/supermandi-superadmin/src/tabs/StoresTab.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import type { StoreRecord } from "../api/stores";
 import type { GlobalFeatureFlag, StoreFeatureFlag } from "../api/featureFlags";
+import type { EnrollmentRecord } from "../api/deviceEnrollments";
 import { formatDateTime } from "../lib/formatters";
 import { WhatsAppIcon } from "../components/WhatsAppIcon";
 
@@ -75,6 +76,14 @@ interface StoresTabProps {
   // Store activity (derived from events)
   stores: Array<{ storeId: string; eventCount: number; lastSeen: string }>;
   limit: number;
+  // SA-ENROLL-UX G3 + G5: Enrollment from stores tab
+  handleCreateEnrollmentForStore: (storeId: string) => void;
+  enrollmentForStoreLoading: string;
+  storeEnrollments: Record<string, EnrollmentRecord[]>;
+  loadStoreEnrollments: (storeId: string) => void;
+  storeEnrollmentsLoading: Record<string, boolean>;
+  handleRevokeEnrollment: (code: string) => void;
+  revokeLoading: boolean;
 }
 
 export function StoresTab({
@@ -138,6 +147,14 @@ export function StoresTab({
   handleBarcodeSheetShare,
   stores,
   limit,
+  // SA-ENROLL-UX G3 + G5
+  handleCreateEnrollmentForStore,
+  enrollmentForStoreLoading,
+  storeEnrollments,
+  loadStoreEnrollments,
+  storeEnrollmentsLoading,
+  handleRevokeEnrollment,
+  revokeLoading,
 }: StoresTabProps) {
   return (
     <section className="card">
@@ -339,7 +356,7 @@ export function StoresTab({
                       <td>
                         <button
                           className="btnGhost"
-                          onClick={() => { const nextId = isExpanded ? null : s.id; setExpandedStoreId(nextId); if (nextId) loadStoreFeatureFlags(nextId); }}
+                          onClick={() => { const nextId = isExpanded ? null : s.id; setExpandedStoreId(nextId); if (nextId) { loadStoreFeatureFlags(nextId); loadStoreEnrollments(nextId); } }}
                           title={isExpanded ? "Hide details" : "Edit details"}
                         >
                           {s.contact_name || s.contact_phone ? `${s.contact_name ?? ""}` : "(none)"}
@@ -365,6 +382,16 @@ export function StoresTab({
                       <td style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
                         <button onClick={() => handleStoreNameSave(s.id)} disabled={storeNameSaving[s.id]}>
                           {storeNameSaving[s.id] ? "Saving..." : "Save"}
+                        </button>
+                        {/* SA-ENROLL-UX G3: Generate QR button per store */}
+                        <button
+                          className="btnGhost"
+                          onClick={() => handleCreateEnrollmentForStore(s.id)}
+                          disabled={enrollmentForStoreLoading === s.id}
+                          title="Generate enrollment QR code for this store"
+                          style={{ fontSize: 12, padding: "4px 8px" }}
+                        >
+                          {enrollmentForStoreLoading === s.id ? "..." : "QR"}
                         </button>
                         {/* SA-P0-001: Suspend/Reactivate buttons */}
                         {s.status === "ACTIVE" && (
@@ -481,6 +508,46 @@ export function StoresTab({
                                 ))}
                               </div>
                             ) : null}
+                          </div>
+                          {/* SA-ENROLL-UX G5: Per-store enrollment codes */}
+                          <div style={{ marginTop: "12px" }}>
+                            <label style={{ fontSize: "12px", color: "#666", display: "block", marginBottom: "6px" }}>Enrollment Codes</label>
+                            {storeEnrollmentsLoading[s.id] ? (
+                              <span style={{ fontSize: 12, color: "#888" }}>Loading...</span>
+                            ) : storeEnrollments[s.id] && storeEnrollments[s.id].length > 0 ? (
+                              <div style={{ display: "flex", gap: "8px", flexWrap: "wrap" }}>
+                                {storeEnrollments[s.id].map((e) => {
+                                  const badgeStyle: React.CSSProperties = {
+                                    display: "inline-flex", alignItems: "center", gap: 6,
+                                    padding: "4px 10px", borderRadius: 6, fontSize: 12, fontWeight: 500,
+                                    ...(e.status === "ACTIVE" ? { background: "#dcfce7", color: "#166534" }
+                                      : e.status === "REVOKED" ? { background: "#fee2e2", color: "#991b1b" }
+                                      : e.status === "USED" ? { background: "#dbeafe", color: "#1e40af" }
+                                      : { background: "#fef3c7", color: "#92400e" }),
+                                  };
+                                  return (
+                                    <span key={e.id} style={badgeStyle}>
+                                      <span className="mono">{e.code}</span>
+                                      <span>{e.status}</span>
+                                      <span style={{ fontSize: 10, opacity: 0.7 }}>
+                                        {e.uses_count}/{e.max_uses} uses
+                                      </span>
+                                      {e.status === "ACTIVE" && (
+                                        <button
+                                          onClick={() => handleRevokeEnrollment(e.code)}
+                                          disabled={revokeLoading}
+                                          style={{ background: "none", border: "none", cursor: "pointer", color: "#dc2626", fontSize: 11, textDecoration: "underline", padding: 0 }}
+                                        >
+                                          revoke
+                                        </button>
+                                      )}
+                                    </span>
+                                  );
+                                })}
+                              </div>
+                            ) : (
+                              <span style={{ fontSize: 12, color: "#888" }}>No enrollment codes yet</span>
+                            )}
                           </div>
                         </td>
                       </tr>


### PR DESCRIPTION
## Summary

Implements 5 UX gaps (G1-G5) blocking field onboarding in SuperAdmin enrollment flow. After GCP deploy, the complete end-to-end works: SuperAdmin creates store → generates QR → retailer scans on POS → device enrolled.

- **G1**: Store picker dropdown replaces freeform text input
- **G2**: Code revocation — `PATCH /device-enrollments/:code/revoke` + UI button
- **G3**: "QR" button per store row in Stores tab for inline enrollment creation
- **G4**: Configurable TTL — `ENROLLMENT_TTL_MINUTES` env var (default 24hr for field agents)
- **G5**: Per-store enrollment code status badges (ACTIVE/EXPIRED/USED/REVOKED) in expanded store row

### Files changed (6)
| File | Change |
|------|--------|
| `backend/src/services/enrollmentCodeService.ts` | TTL env-configurable (24hr default) |
| `backend/src/routes/v1/admin/deviceEnrollments.ts` | Enhanced GET + PATCH revoke endpoint |
| `supermandi-superadmin/src/api/deviceEnrollments.ts` | New types + revoke + fetch API functions |
| `supermandi-superadmin/src/App.tsx` | State + handlers + prop wiring |
| `supermandi-superadmin/src/tabs/DevicesTab.tsx` | Store dropdown + revoke button |
| `supermandi-superadmin/src/tabs/StoresTab.tsx` | QR button + enrollment status badges |

### GCP Staging Parity
- No new migrations needed (`revoked_at` column exists from migration 016)
- `ENROLLMENT_TTL_MINUTES` optional env var (defaults to 1440)
- New PATCH route uses existing `requireAdminToken` middleware
- Same CORS/routing paths (`/api/v1/admin/*`)

## Test plan
- [x] SuperAdmin typecheck passes (`tsc --noEmit`)
- [x] Backend typecheck passes (`tsc --noEmit`)
- [x] SuperAdmin Vite build passes (`VITE_API_BASE_URL="" vite build`)
- [x] Backend build passes (`tsc --project tsconfig.json`)
- [ ] Post-GCP: Create enrollment via store dropdown → QR appears
- [ ] Post-GCP: Revoke code → verify 409 on second revoke
- [ ] Post-GCP: Expand store row → enrollment badges visible
- [ ] Post-GCP: Full E2E — create store → QR → POS enroll → device appears

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)