### PR TITLE
fix(SCR-S1-HARDENING): production-grade SplashScreen — error state, timeout, retry, a11y (#302)

### DIFF
--- a/src/__tests__/screens/SplashScreen.test.tsx
+++ b/src/__tests__/screens/SplashScreen.test.tsx
@@ -1,27 +1,23 @@
 /**
- * TQ-002: SplashScreen render tests
- * Verifies the splash/loading screen renders and attempts device check.
+ * SCR-S1-HARDENING (S1-9): Comprehensive SplashScreen tests
+ * Covers: render, navigation branches, error state, retry, timeout, a11y
  */
 import React from "react";
-import { render, screen } from "@testing-library/react-native";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react-native";
 
 // Mock navigation
-const mockNavigate = jest.fn();
 const mockReplace = jest.fn();
 jest.mock("@react-navigation/native", () => ({
-  useNavigation: () => ({ navigate: mockNavigate, replace: mockReplace }),
+  useNavigation: () => ({ replace: mockReplace }),
 }));
 
-// Mock all services that SplashScreen initializes
+// Mock services
 jest.mock("../../services/cloudEventLogger", () => ({
   startCloudEventLogger: jest.fn(),
 }));
 jest.mock("../../services/printerService", () => ({
   printerService: {
     initialize: jest.fn().mockResolvedValue(true),
-    checkConnectivity: jest.fn().mockResolvedValue({ connected: false }),
-    getStatus: jest.fn().mockReturnValue({ connected: false }),
-    print: jest.fn().mockResolvedValue(true),
   },
 }));
 jest.mock("../../services/syncService", () => ({
@@ -33,8 +29,10 @@ jest.mock("../../services/offline/localDb", () => ({
 jest.mock("../../services/offline/sync", () => ({
   syncOutbox: jest.fn().mockResolvedValue(undefined),
 }));
+
+const mockGetDeviceSession = jest.fn();
 jest.mock("../../services/deviceSession", () => ({
-  getDeviceSession: jest.fn().mockResolvedValue({ deviceToken: "test-token", storeId: "store-1" }),
+  getDeviceSession: (...args: unknown[]) => mockGetDeviceSession(...args),
 }));
 
 jest.mock("react-native-svg", () => {
@@ -51,21 +49,108 @@ import SplashScreen from "../../screens/SplashScreen";
 describe("SplashScreen", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    jest.useFakeTimers();
+    mockGetDeviceSession.mockResolvedValue({ deviceToken: "test-token", storeId: "store-1" });
   });
 
-  it("renders without crashing", () => {
-    render(<SplashScreen />);
+  afterEach(() => {
+    jest.useRealTimers();
   });
 
-  it("shows SuperMandi brand name", () => {
+  it("renders brand name and loading indicator", () => {
     render(<SplashScreen />);
     expect(screen.getByText("SuperMandi")).toBeTruthy();
+    expect(screen.getByText("POS")).toBeTruthy();
+    expect(screen.getByTestId("splash-loader")).toBeTruthy();
   });
 
-  it("shows loading indicator", () => {
+  it("has correct a11y labels on loading state", () => {
     render(<SplashScreen />);
-    // ActivityIndicator doesn't render text, but the component renders
-    // The screen should have visual feedback while loading
-    expect(screen.getByText("SuperMandi")).toBeTruthy();
+    expect(screen.getByTestId("splash-screen")).toBeTruthy();
+    expect(screen.getByTestId("splash-brand-name")).toBeTruthy();
+  });
+
+  it("navigates to SellScan when session exists", async () => {
+    mockGetDeviceSession.mockResolvedValue({ deviceToken: "t", storeId: "s" });
+    render(<SplashScreen />);
+
+    // Advance past splash duration
+    act(() => { jest.advanceTimersByTime(1100); });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("SellScan");
+    });
+  });
+
+  it("navigates to EnrollDevice when no session", async () => {
+    mockGetDeviceSession.mockResolvedValue(null);
+    render(<SplashScreen />);
+
+    act(() => { jest.advanceTimersByTime(1100); });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("EnrollDevice");
+    });
+  });
+
+  it("shows error state when getDeviceSession rejects", async () => {
+    mockGetDeviceSession.mockRejectedValue(new Error("SecureStore locked"));
+    render(<SplashScreen />);
+
+    act(() => { jest.advanceTimersByTime(1100); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("splash-error-card")).toBeTruthy();
+    });
+    expect(screen.getByText("Something went wrong")).toBeTruthy();
+    expect(screen.getByText("SecureStore locked")).toBeTruthy();
+  });
+
+  it("retry button resets error and re-checks session", async () => {
+    // First call fails, second succeeds
+    mockGetDeviceSession
+      .mockRejectedValueOnce(new Error("Fail"))
+      .mockResolvedValueOnce({ deviceToken: "t", storeId: "s" });
+
+    render(<SplashScreen />);
+    act(() => { jest.advanceTimersByTime(1100); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("splash-retry-button")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("splash-retry-button"));
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("SellScan");
+    });
+  });
+
+  it("skip button navigates to EnrollDevice", async () => {
+    mockGetDeviceSession.mockRejectedValue(new Error("Fail"));
+    render(<SplashScreen />);
+
+    act(() => { jest.advanceTimersByTime(1100); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("splash-skip-button")).toBeTruthy();
+    });
+
+    fireEvent.press(screen.getByTestId("splash-skip-button"));
+    expect(mockReplace).toHaveBeenCalledWith("EnrollDevice");
+  });
+
+  it("shows error on session timeout", async () => {
+    // Session never resolves (simulate hang)
+    mockGetDeviceSession.mockImplementation(() => new Promise(() => {}));
+    render(<SplashScreen />);
+
+    // Advance past splash + session timeout (1s + 5s)
+    act(() => { jest.advanceTimersByTime(6200); });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("splash-error-card")).toBeTruthy();
+    });
+    expect(screen.getByText("Session check timed out")).toBeTruthy();
   });
 });

--- a/src/screens/SplashScreen.tsx
+++ b/src/screens/SplashScreen.tsx
@@ -1,6 +1,7 @@
 // T-107: Brand-styled splash screen with shortmark icon
-import React, { useEffect } from "react";
-import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
+// SCR-S1-HARDENING: Production-grade error handling, timeout, retry, a11y
+import React, { useEffect, useState, useCallback } from "react";
+import { View, Text, StyleSheet, ActivityIndicator, Pressable } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import Svg, { Path } from "react-native-svg";
@@ -23,10 +24,16 @@ type RootStackParamList = {
 
 type NavProp = NativeStackNavigationProp<RootStackParamList, "Splash">;
 
+/** S1-8: Named constant for splash hold time */
+const SPLASH_DURATION_MS = 1000;
+
+/** S1-3: Timeout for getDeviceSession() to prevent infinite hang */
+const SESSION_TIMEOUT_MS = 5000;
+
 /** T-107: Brand shortmark — S-curve icon rendered as inline SVG */
 function BrandShortmark({ size = 64, color = colors.textInverse }: { size?: number; color?: string }) {
   return (
-    <Svg width={size} height={size} viewBox="0 0 64 64" fill="none">
+    <Svg width={size} height={size} viewBox="0 0 64 64" fill="none" accessibilityElementsHidden>
       {/* S-curve path representing the SuperMandi brand shortmark */}
       <Path
         d="M44 16C44 16 40 12 32 12C24 12 18 17 18 23C18 29 24 31 32 33C40 35 46 37 46 43C46 49 40 52 32 52C24 52 20 48 20 48"
@@ -47,24 +54,55 @@ function BrandShortmark({ size = 64, color = colors.textInverse }: { size?: numb
 
 export default function SplashScreen() {
   const navigation = useNavigation<NavProp>();
+  const [errorState, setErrorState] = useState<string | null>(null);
+
+  /** S1-3: Race getDeviceSession against a timeout */
+  const getSessionWithTimeout = useCallback(async () => {
+    const timeoutPromise = new Promise<null>((_, reject) =>
+      setTimeout(() => reject(new Error("Session check timed out")), SESSION_TIMEOUT_MS)
+    );
+    return Promise.race([getDeviceSession(), timeoutPromise]);
+  }, []);
+
+  /** S1-4: Retry handler — resets error and re-runs session check */
+  const handleRetry = useCallback(() => {
+    setErrorState(null);
+    navigateAfterSession();
+  }, []);
+
+  /** S1-1 + S1-2 + S1-3: Session check with full error handling */
+  const navigateAfterSession = useCallback(async () => {
+    try {
+      const session = await getSessionWithTimeout();
+      navigation.replace(session ? "SellScan" : "EnrollDevice");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : "Unknown error";
+      console.warn("[SplashScreen] Session check failed:", msg);
+      setErrorState(msg);
+    }
+  }, [navigation, getSessionWithTimeout]);
 
   useEffect(() => {
-    // Non-blocking infra boot (POS-safe)
+    // S1-6: Non-blocking infra boot with error logging (not silent swallow)
     startCloudEventLogger();
-    printerService.initialize().catch(() => undefined);
-    initOfflineDb().catch(() => undefined);
-    syncOutbox().catch(() => undefined);
+    printerService.initialize().catch((err) =>
+      console.warn("[SplashScreen] Printer init failed:", err)
+    );
+    initOfflineDb().catch((err) =>
+      console.warn("[SplashScreen] OfflineDB init failed:", err)
+    );
+    syncOutbox().catch((err) =>
+      console.warn("[SplashScreen] SyncOutbox failed:", err)
+    );
     startAutoSync();
 
     let cancelled = false;
     // Controlled splash time (UX stability)
     const timer = setTimeout(() => {
-      void (async () => {
-        const session = await getDeviceSession();
-        if (cancelled) return;
-        navigation.replace(session ? "SellScan" : "EnrollDevice");
-      })();
-    }, 1000); // 1 second = best POS balance
+      if (!cancelled) {
+        navigateAfterSession();
+      }
+    }, SPLASH_DURATION_MS);
 
     return () => {
       cancelled = true;
@@ -72,15 +110,76 @@ export default function SplashScreen() {
     };
   }, []);
 
+  // S1-1 + S1-4: Error state with retry button
+  if (errorState) {
+    return (
+      <View
+        style={styles.container}
+        testID="splash-error-screen"
+        accessibilityLabel="Splash screen error"
+      >
+        <BrandShortmark size={64} color={theme.colors.textInverse} />
+        <Text style={styles.brandName} accessibilityRole="header">SuperMandi</Text>
+        <View style={styles.errorCard} testID="splash-error-card">
+          <Text
+            style={styles.errorText}
+            accessibilityLabel={`Error: ${errorState}`}
+            accessibilityRole="alert"
+          >
+            Something went wrong
+          </Text>
+          <Text style={styles.errorDetail}>{errorState}</Text>
+          <Pressable
+            onPress={handleRetry}
+            style={styles.retryButton}
+            testID="splash-retry-button"
+            accessibilityLabel="Retry loading"
+            accessibilityRole="button"
+          >
+            <Text style={styles.retryText}>Retry</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => navigation.replace("EnrollDevice")}
+            style={styles.skipButton}
+            testID="splash-skip-button"
+            accessibilityLabel="Continue to enrollment"
+            accessibilityRole="button"
+          >
+            <Text style={styles.skipText}>Continue without session</Text>
+          </Pressable>
+        </View>
+      </View>
+    );
+  }
+
+  // S1-7: Normal loading state with a11y labels and testIDs
   return (
-    <View style={styles.container}>
+    <View
+      style={styles.container}
+      testID="splash-screen"
+      accessibilityLabel="SuperMandi loading screen"
+    >
       <BrandShortmark size={64} color={theme.colors.textInverse} />
-      <Text style={styles.brandName}>SuperMandi</Text>
-      <Text style={styles.subtitle}>POS</Text>
+      <Text
+        style={styles.brandName}
+        testID="splash-brand-name"
+        accessibilityRole="header"
+      >
+        SuperMandi
+      </Text>
+      <Text
+        style={styles.subtitle}
+        testID="splash-subtitle"
+      >
+        POS
+      </Text>
+      {/* S1-5: Use theme token for indicator color */}
       <ActivityIndicator
         size="small"
-        color="rgba(255,255,255,0.7)"
+        color={theme.colors.textInverse}
         style={styles.loader}
+        testID="splash-loader"
+        accessibilityLabel="Loading"
       />
     </View>
   );
@@ -106,5 +205,49 @@ const styles = StyleSheet.create({
   },
   loader: {
     marginTop: spacing.xl,
+  },
+  // S1-1: Error state styles
+  errorCard: {
+    marginTop: spacing.xl,
+    backgroundColor: "rgba(255,255,255,0.15)",
+    borderRadius: theme.borderRadius.lg,
+    padding: spacing.lg,
+    alignItems: "center",
+    maxWidth: 280,
+  },
+  errorText: {
+    ...typography.label,
+    color: colors.textInverse,
+    fontWeight: "600",
+    marginBottom: spacing.xs,
+  },
+  errorDetail: {
+    ...typography.caption,
+    color: colors.textInverse,
+    opacity: 0.7,
+    textAlign: "center",
+    marginBottom: spacing.md,
+  },
+  retryButton: {
+    backgroundColor: colors.textInverse,
+    borderRadius: theme.borderRadius.md,
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.xl,
+    marginBottom: spacing.sm,
+  },
+  retryText: {
+    ...typography.label,
+    color: colors.primary,
+    fontWeight: "600",
+  },
+  skipButton: {
+    paddingVertical: spacing.xs,
+    paddingHorizontal: spacing.md,
+  },
+  skipText: {
+    ...typography.caption,
+    color: colors.textInverse,
+    opacity: 0.8,
+    textDecorationLine: "underline",
   },
 });


### PR DESCRIPTION
## Summary
- **S1-1**: Error state UI with card when `getDeviceSession()` fails
- **S1-2**: try/catch around async navigation (no unhandled promise rejections)
- **S1-3**: 5s timeout on `getDeviceSession()` via `Promise.race`
- **S1-4**: Retry button + "Continue without session" fallback
- **S1-5**: ActivityIndicator color uses `theme.colors.textInverse` token
- **S1-6**: Background service errors logged via `console.warn` (not silent swallow)
- **S1-7**: `testID` + `accessibilityLabel` on all elements
- **S1-8**: `SPLASH_DURATION_MS` named constant (1000ms)
- **S1-9**: Comprehensive tests — navigation branches, error, retry, timeout

## Files Changed
- `src/screens/SplashScreen.tsx` — full rewrite with error state, timeout, a11y
- `src/__tests__/screens/SplashScreen.test.tsx` — 7 test cases (render, SellScan nav, EnrollDevice nav, error state, retry, skip, timeout)

## Test plan
- [ ] `pnpm -r typecheck` passes (verified locally)
- [ ] SplashScreen renders with brand elements
- [ ] Session found → navigates to SellScan
- [ ] No session → navigates to EnrollDevice
- [ ] Session error → shows error card with retry
- [ ] Session timeout (5s) → shows error card
- [ ] Retry button resets and re-checks
- [ ] "Continue without session" → EnrollDevice

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)