### PR TITLE
fix(SCR-NAV-PARITY): GCP-parity — theme token, ForceUpdate type safety, deep link config

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -347,6 +347,19 @@ import { registerForPushNotifications, setupNotificationListeners } from "./src/
 
 const Stack = createNativeStackNavigator();
 
+// SCR-NAV-PARITY: Deep link config for enrollment QR codes (supermandi://enroll?code=X)
+const linking = {
+  prefixes: ["supermandi://"],
+  config: {
+    screens: {
+      EnrollDevice: {
+        path: "enroll",
+        parse: { enrollmentCode: (code: string) => code },
+      },
+    },
+  },
+};
+
 export default function App() {
   const [appReady, setAppReady] = useState(false);
 
@@ -412,7 +425,7 @@ export default function App() {
         />
 
         <ErrorBoundary>
-        <NavigationContainer>
+        <NavigationContainer linking={linking}>
         <Stack.Navigator
           initialRouteName="Splash"
           screenOptions={{

--- a/src/screens/PosRootLayout.tsx
+++ b/src/screens/PosRootLayout.tsx
@@ -93,6 +93,7 @@ type RootStackParamList = {
   SellScan: undefined;
   EnrollDevice: undefined;
   DeviceBlocked: undefined;
+  ForceUpdate: { currentVersion?: string; requiredVersion?: string };
 };
 
 type Nav = NativeStackNavigationProp<RootStackParamList, "SellScan">;
@@ -534,7 +535,7 @@ export default function PosRootLayout() {
           navigation.reset({
             index: 0,
             routes: [{
-              name: "ForceUpdate" as any,
+              name: "ForceUpdate",
               params: {
                 currentVersion: meta.appVersion ?? "unknown",
                 requiredVersion: status.minAppVersion ?? "unknown",

--- a/src/screens/SplashScreen.tsx
+++ b/src/screens/SplashScreen.tsx
@@ -209,7 +209,7 @@ const styles = StyleSheet.create({
   // S1-1: Error state styles
   errorCard: {
     marginTop: spacing.xl,
-    backgroundColor: "rgba(255,255,255,0.15)",
+    backgroundColor: colors.overlayInverse,
     borderRadius: theme.borderRadius.lg,
     padding: spacing.lg,
     alignItems: "center",

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -42,6 +42,7 @@ export const colors = {
   // Overlays
   overlay: "rgba(15, 23, 42, 0.45)",
   overlayLight: "rgba(15, 23, 42, 0.2)",
+  overlayInverse: "rgba(255, 255, 255, 0.15)",
   ink: "#0B1220",
 } as const;
 


### PR DESCRIPTION
## Summary
Final pre-GCP parity fixes for Screens 1-3 navigation and theme consistency:

- **SplashScreen**: Hardcoded `rgba(255,255,255,0.15)` → `colors.overlayInverse` theme token
- **colors.ts**: New `overlayInverse` token for inverse overlay backgrounds
- **PosRootLayout**: Add `ForceUpdate` to `RootStackParamList` type — removes unsafe `as any` cast on line 537
- **App.tsx**: Add `linking` config to `NavigationContainer` — enables `supermandi://enroll?code=X` deep links to route directly to EnrollDevice screen on cold start

## Files Changed (4 files, +18/-3)
- `App.tsx` — linking config + NavigationContainer prop
- `src/screens/PosRootLayout.tsx` — ForceUpdate type + remove `as any`
- `src/screens/SplashScreen.tsx` — theme token
- `src/theme/colors.ts` — overlayInverse token

## Test plan
- [ ] `pnpm -r typecheck` passes (verified locally)
- [ ] ForceUpdate navigation from PosRootLayout is type-safe (no `as any`)
- [ ] Deep link `supermandi://enroll?code=SM-TEST` routes to EnrollDevice with pre-filled code
- [ ] SplashScreen error card background uses theme token

🤖 Generated with [Claude Code](https://claude.com/claude-code)