### PR TITLE
fix(SCR-AUDIT-310): production-grade screen hardening — gate bypass, deep link, ScrollView

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -347,15 +347,15 @@ import { registerForPushNotifications, setupNotificationListeners } from "./src/
 
 const Stack = createNativeStackNavigator();
 
-// SCR-NAV-PARITY: Deep link config for enrollment QR codes (supermandi://enroll?code=X)
+// SCR-AUDIT-311: Deep link config for enrollment QR codes (supermandi://enroll?code=X)
+// Path-only matching: React Navigation routes to EnrollDevice screen.
+// Param extraction (code=X → codeInput) is handled by EnrollDeviceScreen's own
+// Linking.getInitialURL() + addEventListener handler, which correctly parses ?code=X.
 const linking = {
   prefixes: ["supermandi://"],
   config: {
     screens: {
-      EnrollDevice: {
-        path: "enroll",
-        parse: { enrollmentCode: (code: string) => code },
-      },
+      EnrollDevice: "enroll",
     },
   },
 };

--- a/src/screens/DeviceBlockedScreen.tsx
+++ b/src/screens/DeviceBlockedScreen.tsx
@@ -1,31 +1,52 @@
+// SCR-AUDIT-310: Production-grade DeviceBlocked with strict fetch + theme tokens + a11y
 import React, { useState } from "react";
-import { View, Text, StyleSheet, Pressable, Alert } from "react-native";
+import { View, Text, StyleSheet, Pressable, Alert, ActivityIndicator } from "react-native";
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
+import NetInfo from "@react-native-community/netinfo";
 
-import { fetchUiStatus } from "../services/api/uiStatusApi";
+import { fetchUiStatusStrict } from "../services/api/uiStatusApi";
 import { clearDeviceSession } from "../services/deviceSession";
 import { ApiError } from "../services/api/apiClient";
 import { POS_MESSAGES } from "../utils/uiStatus";
-import { theme } from "../theme";
+import { theme, colors, typography, spacing } from "../theme";
 
 type RootStackParamList = {
   DeviceBlocked: undefined;
   SellScan: undefined;
   EnrollDevice: undefined;
+  ForceUpdate: { currentVersion?: string; requiredVersion?: string };
 };
 
 type Nav = NativeStackNavigationProp<RootStackParamList, "DeviceBlocked">;
+
+/** Icon/layout constants */
+const ICON_SIZE = 28;
+const ICON_WRAP_SIZE = 52;
 
 export default function DeviceBlockedScreen() {
   const navigation = useNavigation<Nav>();
   const [checking, setChecking] = useState(false);
 
   const handleRetry = async () => {
+    // Check network before API call
+    try {
+      const netState = await NetInfo.fetch();
+      if (!netState.isConnected) {
+        Alert.alert("No Internet", "Please connect to the internet and try again.");
+        return;
+      }
+    } catch {
+      // NetInfo failed — proceed anyway
+    }
+
     setChecking(true);
     try {
-      const status = await fetchUiStatus();
+      // SCR-AUDIT-310: Use strict fetch that throws on server errors.
+      // Regular fetchUiStatus returns safe defaults (deviceActive: true),
+      // which would incorrectly let the user exit the blocked state.
+      const status = await fetchUiStatusStrict();
       if (!status.deviceActive) {
         Alert.alert("Device Disabled", POS_MESSAGES.deviceInactive);
         return;
@@ -47,25 +68,54 @@ export default function DeviceBlockedScreen() {
           return;
         }
       }
-      Alert.alert("Check Failed", "Unable to verify device status.");
+      Alert.alert("Check Failed", "Unable to verify device status. Please try again.");
     } finally {
       setChecking(false);
     }
   };
 
   return (
-    <View style={styles.container}>
-      <View style={styles.card}>
-        <View style={styles.iconWrap}>
-          <MaterialCommunityIcons name="shield-alert" size={28} color={theme.colors.error} />
+    <View
+      style={styles.container}
+      testID="device-blocked-screen"
+      accessibilityLabel="Device disabled screen"
+    >
+      <View style={styles.card} testID="device-blocked-card">
+        <View style={styles.iconWrap} accessibilityElementsHidden>
+          <MaterialCommunityIcons name="shield-alert" size={ICON_SIZE} color={colors.error} />
         </View>
-        <Text style={styles.title}>Device Disabled</Text>
-        <Text style={styles.subtitle}>
+        <Text
+          style={styles.title}
+          testID="device-blocked-title"
+          accessibilityRole="header"
+        >
+          Device Disabled
+        </Text>
+        <Text
+          style={styles.subtitle}
+          testID="device-blocked-subtitle"
+          accessibilityLabel="This device has been disabled by the administrator. Contact your SuperAdmin."
+        >
           {POS_MESSAGES.deviceInactive}
         </Text>
 
-        <Pressable style={styles.button} onPress={handleRetry} disabled={checking}>
-          <Text style={styles.buttonText}>{checking ? "Checking..." : "Check Again"}</Text>
+        <Pressable
+          style={[styles.button, checking && styles.buttonDisabled]}
+          onPress={handleRetry}
+          disabled={checking}
+          testID="device-blocked-check-button"
+          accessibilityLabel={checking ? "Checking device status" : "Check again"}
+          accessibilityRole="button"
+          accessibilityState={{ disabled: checking }}
+        >
+          {checking ? (
+            <View style={styles.checkingRow}>
+              <ActivityIndicator size="small" color={colors.textInverse} style={{ marginRight: spacing.xs }} />
+              <Text style={styles.buttonText}>Checking...</Text>
+            </View>
+          ) : (
+            <Text style={styles.buttonText}>Check Again</Text>
+          )}
         </Pressable>
       </View>
     </View>
@@ -75,49 +125,60 @@ export default function DeviceBlockedScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: theme.colors.background,
-    padding: 24,
+    backgroundColor: colors.background,
+    padding: spacing.lg,
     justifyContent: "center",
-    alignItems: "center"
+    alignItems: "center",
   },
   card: {
     width: "100%",
-    backgroundColor: theme.colors.surface,
-    borderRadius: 16,
-    padding: 20,
+    backgroundColor: colors.surface,
+    borderRadius: theme.borderRadius.xl,
+    padding: spacing.lg,
     alignItems: "center",
     borderWidth: 1,
-    borderColor: theme.colors.border
+    borderColor: colors.border,
   },
   iconWrap: {
-    width: 52,
-    height: 52,
-    borderRadius: 26,
-    backgroundColor: theme.colors.errorSoft,
+    width: ICON_WRAP_SIZE,
+    height: ICON_WRAP_SIZE,
+    borderRadius: ICON_WRAP_SIZE / 2,
+    backgroundColor: colors.errorSoft,
     alignItems: "center",
     justifyContent: "center",
-    marginBottom: 12
+    marginBottom: spacing.md,
   },
   title: {
-    fontSize: 22,
+    ...typography.h4,
     fontWeight: "800",
-    color: theme.colors.textPrimary,
-    marginBottom: 10
+    color: colors.textPrimary,
+    marginBottom: spacing.sm,
   },
   subtitle: {
-    fontSize: 14,
-    color: theme.colors.textSecondary,
+    ...typography.caption,
+    color: colors.textSecondary,
     textAlign: "center",
-    marginBottom: 24
+    marginBottom: spacing.lg,
   },
   button: {
-    backgroundColor: theme.colors.primary,
-    paddingHorizontal: 18,
-    paddingVertical: 12,
-    borderRadius: 10
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: colors.primary,
+    paddingHorizontal: spacing.lg,
+    paddingVertical: spacing.md,
+    borderRadius: theme.borderRadius.lg,
+    width: "100%",
+  },
+  buttonDisabled: {
+    opacity: 0.6,
   },
   buttonText: {
-    color: theme.colors.textInverse,
-    fontWeight: "700"
-  }
+    ...typography.button,
+    color: colors.textInverse,
+  },
+  checkingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
 });

--- a/src/screens/EnrollDeviceScreen.tsx
+++ b/src/screens/EnrollDeviceScreen.tsx
@@ -7,7 +7,9 @@ import {
   Pressable,
   Alert,
   Linking,
-  Platform
+  Platform,
+  ScrollView,
+  ActivityIndicator,
 } from "react-native";
 import Constants from "expo-constants";
 import * as Device from "expo-device";
@@ -74,6 +76,8 @@ import { useSettingsStore } from "../stores/settingsStore";
 type RootStackParamList = {
   EnrollDevice: { enrollmentCode?: string } | undefined;  // DRX-003: Optional pre-fill from registration
   SellScan: undefined;
+  ForceUpdate: { currentVersion?: string; requiredVersion?: string };
+  DeviceBlocked: undefined;
 };
 
 type Nav = NativeStackNavigationProp<RootStackParamList, "EnrollDevice">;
@@ -321,6 +325,12 @@ export default function EnrollDeviceScreen() {
       return;
     }
 
+    // SCR-AUDIT-312: Block enrollment while label check is in-flight to prevent race condition
+    if (checkingLabel) {
+      Alert.alert("Please Wait", "Label availability check is in progress. Please wait a moment.");
+      return;
+    }
+
     // S3-1: Offline detection before enrollment attempt
     try {
       const netState = await NetInfo.fetch();
@@ -485,7 +495,13 @@ export default function EnrollDeviceScreen() {
   };
 
   return (
-    <View style={styles.container} testID="enroll-device-screen" accessibilityLabel="Enroll POS device screen">
+    <ScrollView
+      style={styles.scrollView}
+      contentContainerStyle={styles.scrollContent}
+      keyboardShouldPersistTaps="handled"
+      testID="enroll-device-screen"
+      accessibilityLabel="Enroll POS device screen"
+    >
       <Text style={styles.title} testID="enroll-title" accessibilityRole="header">Enroll POS Device</Text>
       <Text style={styles.subtitle} testID="enroll-subtitle">Scan the QR code or enter the enrollment code.</Text>
 
@@ -661,9 +677,14 @@ export default function EnrollDeviceScreen() {
           accessibilityRole="button"
           accessibilityState={{ disabled: loading }}
         >
-          <Text style={[styles.primaryButtonText, loading && styles.primaryButtonTextDisabled]}>
-            {loading ? "Enrolling..." : "Enroll Device"}
-          </Text>
+          {loading ? (
+            <View style={styles.enrollingRow}>
+              <ActivityIndicator size="small" color={colors.textInverse} style={{ marginRight: spacing.xs }} />
+              <Text style={styles.primaryButtonText}>Enrolling...</Text>
+            </View>
+          ) : (
+            <Text style={styles.primaryButtonText}>Enroll Device</Text>
+          )}
         </Pressable>
 
         {/* DEV-only Test Store Shortcuts */}
@@ -704,15 +725,18 @@ export default function EnrollDeviceScreen() {
           </View>
         )}
       </View>
-    </View>
+    </ScrollView>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
+  scrollView: {
     flex: 1,
     backgroundColor: colors.background,
-    padding: 20
+  },
+  scrollContent: {
+    padding: spacing.lg,
+    paddingBottom: spacing.xxxl,
   },
   title: {
     ...typography.h4,
@@ -738,7 +762,7 @@ const styles = StyleSheet.create({
   permissionBox: {
     padding: spacing.md,
     alignItems: "center",
-    gap: 12,
+    gap: spacing.sm,
   },
   permissionText: {
     ...typography.caption,
@@ -746,8 +770,8 @@ const styles = StyleSheet.create({
     textAlign: "center",
   },
   controls: {
-    marginTop: 18,
-    gap: 12
+    marginTop: spacing.md,
+    gap: spacing.sm,
   },
   label: {
     ...typography.caption,
@@ -758,9 +782,9 @@ const styles = StyleSheet.create({
     ...typography.bodySmall,
     borderWidth: 1,
     borderColor: colors.border,
-    borderRadius: 10,
-    paddingHorizontal: 12,
-    paddingVertical: 10,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
     backgroundColor: colors.surfaceAlt,
     color: colors.textPrimary,
   },
@@ -770,21 +794,23 @@ const styles = StyleSheet.create({
     backgroundColor: colors.errorSoft
   },
   labelHint: {
+    ...typography.caption,
     fontSize: 11,
     color: colors.textSecondary,
-    fontStyle: "italic"
+    fontStyle: "italic",
   },
   duplicateWarning: {
     backgroundColor: colors.errorSoft,
-    padding: 10,
-    borderRadius: 8,
+    padding: spacing.sm,
+    borderRadius: theme.borderRadius.md,
     borderWidth: 1,
-    borderColor: colors.error
+    borderColor: colors.error,
   },
   duplicateWarningText: {
+    ...typography.caption,
     fontSize: 12,
     color: colors.error,
-    fontWeight: "500"
+    fontWeight: "500",
   },
   suggestions: {
     marginTop: spacing.sm,
@@ -792,30 +818,31 @@ const styles = StyleSheet.create({
   suggestionsLabel: {
     fontSize: 11,
     color: colors.textSecondary,
-    marginBottom: 6
+    marginBottom: spacing.xs,
   },
   suggestionPills: {
     flexDirection: "row",
     flexWrap: "wrap",
-    gap: 6
+    gap: spacing.xs,
   },
   suggestionPill: {
     backgroundColor: colors.primarySoft,
-    paddingHorizontal: 10,
-    paddingVertical: 5,
-    borderRadius: 999,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.xs,
+    borderRadius: theme.borderRadius.full,
     borderWidth: 1,
     borderColor: colors.primary
   },
   suggestionPillText: {
+    ...typography.caption,
     fontSize: 12,
     fontWeight: "600",
-    color: colors.primaryDark
+    color: colors.primaryDark,
   },
   labelAvailable: {
     fontSize: 11,
     color: colors.success,
-    fontWeight: "500"
+    fontWeight: "500",
   },
   pillRow: {
     flexDirection: "row",
@@ -823,9 +850,9 @@ const styles = StyleSheet.create({
     gap: spacing.sm,
   },
   pill: {
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 999,
+    paddingHorizontal: spacing.sm,
+    paddingVertical: spacing.sm,
+    borderRadius: theme.borderRadius.full,
     borderWidth: 1,
     borderColor: colors.border,
     backgroundColor: colors.surface
@@ -835,17 +862,18 @@ const styles = StyleSheet.create({
     backgroundColor: colors.accentSoft
   },
   pillText: {
+    ...typography.caption,
     fontSize: 12,
     fontWeight: "600",
-    color: colors.textSecondary
+    color: colors.textSecondary,
   },
   pillTextActive: {
     color: colors.primaryDark
   },
   primaryButton: {
     backgroundColor: colors.primary,
-    paddingVertical: 12,
-    borderRadius: 10,
+    paddingVertical: spacing.sm,
+    borderRadius: theme.borderRadius.lg,
     alignItems: "center",
   },
   primaryButtonDisabled: {
@@ -862,9 +890,9 @@ const styles = StyleSheet.create({
   secondaryButton: {
     borderWidth: 1,
     borderColor: colors.primary,
-    borderRadius: 10,
-    paddingVertical: 10,
-    alignItems: "center"
+    borderRadius: theme.borderRadius.lg,
+    paddingVertical: spacing.sm,
+    alignItems: "center",
   },
   secondaryButtonText: {
     ...typography.bodySmall,
@@ -873,9 +901,9 @@ const styles = StyleSheet.create({
   },
   devSection: {
     marginTop: spacing.lg,
-    padding: 12,
+    padding: spacing.sm,
     backgroundColor: colors.warning + "15",
-    borderRadius: 10,
+    borderRadius: theme.borderRadius.lg,
     borderWidth: 1,
     borderColor: colors.warning,
     borderStyle: "dashed"
@@ -885,11 +913,11 @@ const styles = StyleSheet.create({
     fontWeight: "800",
     color: colors.warning,
     textTransform: "uppercase",
-    marginBottom: 8
+    marginBottom: spacing.sm,
   },
   devInfoRow: {
     flexDirection: "row",
-    marginBottom: 4
+    marginBottom: spacing.xs,
   },
   devInfoLabel: {
     fontSize: 11,
@@ -904,23 +932,27 @@ const styles = StyleSheet.create({
     color: colors.textPrimary
   },
   devButton: {
-    marginTop: 8,
+    marginTop: spacing.sm,
     backgroundColor: colors.warning,
-    paddingVertical: 8,
-    paddingHorizontal: 12,
-    borderRadius: 6,
-    alignItems: "center"
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.sm,
+    borderRadius: theme.borderRadius.sm,
+    alignItems: "center",
   },
   devButtonText: {
     color: colors.ink,
     fontWeight: "700",
     fontSize: 12,
   },
+  enrollingRow: {
+    flexDirection: "row",
+    alignItems: "center",
+  },
   devWarning: {
-    marginTop: 8,
+    marginTop: spacing.sm,
     fontSize: 10,
     color: colors.textSecondary,
     fontStyle: "italic",
-    lineHeight: 14
-  }
+    lineHeight: 14,
+  },
 });

--- a/src/screens/ForceUpdateScreen.tsx
+++ b/src/screens/ForceUpdateScreen.tsx
@@ -7,7 +7,7 @@ import { useNavigation, useRoute, type RouteProp } from "@react-navigation/nativ
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import NetInfo from "@react-native-community/netinfo";
 
-import { fetchUiStatus } from "../services/api/uiStatusApi";
+import { fetchUiStatusStrict } from "../services/api/uiStatusApi";
 import { clearDeviceSession } from "../services/deviceSession";
 import { ApiError } from "../services/api/apiClient";
 import { theme, colors, typography, spacing } from "../theme";
@@ -16,6 +16,7 @@ type RootStackParamList = {
   ForceUpdate: { currentVersion?: string; requiredVersion?: string };
   SellScan: undefined;
   EnrollDevice: undefined;
+  DeviceBlocked: undefined;
 };
 
 type Nav = NativeStackNavigationProp<RootStackParamList, "ForceUpdate">;
@@ -72,7 +73,10 @@ export default function ForceUpdateScreen() {
 
     setChecking(true);
     try {
-      const status = await fetchUiStatus();
+      // SCR-AUDIT-310: Use strict fetch that throws on server errors.
+      // Regular fetchUiStatus returns safe defaults on errors, which would
+      // bypass this gate (forceUpdate: false → navigate to SellScan).
+      const status = await fetchUiStatusStrict();
       if (status.forceUpdate) {
         Alert.alert(
           "Update Still Required",

--- a/src/screens/SplashScreen.tsx
+++ b/src/screens/SplashScreen.tsx
@@ -18,6 +18,8 @@ type RootStackParamList = {
   Splash: undefined;
   EnrollDevice: undefined;
   SellScan: undefined;
+  ForceUpdate: { currentVersion?: string; requiredVersion?: string };
+  DeviceBlocked: undefined;
   Payment: undefined;
   SuccessPrint: undefined;
 };
@@ -64,12 +66,6 @@ export default function SplashScreen() {
     return Promise.race([getDeviceSession(), timeoutPromise]);
   }, []);
 
-  /** S1-4: Retry handler — resets error and re-runs session check */
-  const handleRetry = useCallback(() => {
-    setErrorState(null);
-    navigateAfterSession();
-  }, []);
-
   /** S1-1 + S1-2 + S1-3: Session check with full error handling */
   const navigateAfterSession = useCallback(async () => {
     try {
@@ -81,6 +77,12 @@ export default function SplashScreen() {
       setErrorState(msg);
     }
   }, [navigation, getSessionWithTimeout]);
+
+  /** S1-4: Retry handler — resets error and re-runs session check */
+  const handleRetry = useCallback(() => {
+    setErrorState(null);
+    navigateAfterSession();
+  }, [navigateAfterSession]);
 
   useEffect(() => {
     // S1-6: Non-blocking infra boot with error logging (not silent swallow)
@@ -108,7 +110,7 @@ export default function SplashScreen() {
       cancelled = true;
       clearTimeout(timer);
     };
-  }, []);
+  }, [navigateAfterSession]);
 
   // S1-1 + S1-4: Error state with retry button
   if (errorState) {

--- a/src/services/api/uiStatusApi.ts
+++ b/src/services/api/uiStatusApi.ts
@@ -2,6 +2,7 @@ import { API_BASE_URL } from "../../config/api";
 import { getDeviceToken, getDeviceSession } from "../deviceSession";
 import { getDeviceMeta } from "../deviceInfo";
 import { useSettingsStore } from "../../stores/settingsStore";
+import { ApiError } from "./apiClient";
 
 export type UiStatusResponse = {
   storeId?: string | null;
@@ -176,4 +177,45 @@ export async function fetchUiStatus(): Promise<UiStatusResponse> {
       deviceId: session?.deviceId ?? null,
     };
   }
+}
+
+/**
+ * SCR-AUDIT-310: Strict version of fetchUiStatus that THROWS on errors.
+ *
+ * Used by gate screens (ForceUpdate, DeviceBlocked) where returning safe defaults
+ * would incorrectly let the user bypass the security gate.
+ *
+ * The regular fetchUiStatus() returns defaults on errors (correct for PosRootLayout
+ * offline mode). This version throws so callers can show an error alert instead
+ * of navigating away from the gate.
+ */
+export async function fetchUiStatusStrict(): Promise<UiStatusResponse> {
+  const deviceToken = await getDeviceToken();
+  if (!deviceToken) {
+    throw new ApiError(401, "DEVICE_SESSION_MISSING");
+  }
+
+  const response = await fetch(`${API_BASE_URL}/api/v1/pos/ui-status`, {
+    headers: {
+      "X-Device-Token": deviceToken,
+      "X-App-Version": getDeviceMeta().appVersion ?? "unknown",
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => "");
+    let message = `Server error (${response.status})`;
+    try {
+      const data = JSON.parse(text);
+      if (data?.error) {
+        message = typeof data.error === "string" ? data.error : data.error?.code || message;
+      }
+    } catch {
+      // JSON parse failed — use default message
+    }
+    throw new ApiError(response.status, message);
+  }
+
+  const data = await response.json();
+  return parseUiStatusResponse(data);
 }


### PR DESCRIPTION
## Summary

- **CRITICAL**: Added `fetchUiStatusStrict()` that throws on server errors instead of returning safe defaults — prevents ForceUpdate and DeviceBlocked gate bypass (#310)
- **HIGH**: Fixed App.tsx deep link config — path-only matching instead of broken `parse: { enrollmentCode }` that expected wrong query parameter (#311)
- **HIGH**: Wrapped EnrollDeviceScreen in ScrollView for small devices (#312)
- **MEDIUM**: Replaced ~30 hardcoded pixel values with theme tokens in EnrollDeviceScreen (#313)
- Fixed label check race condition — blocks enrollment while label check is in-flight
- Fixed SplashScreen useCallback dependency order (was using `navigateAfterSession` before declaration)
- Added `ForceUpdate` + `DeviceBlocked` to RootStackParamList in all screens
- Full DeviceBlockedScreen rewrite with NetInfo offline check, ActivityIndicator, a11y labels

## Files Changed (6)

| File | Changes |
|------|---------|
| `src/services/api/uiStatusApi.ts` | New `fetchUiStatusStrict()` function |
| `src/screens/ForceUpdateScreen.tsx` | Use strict fetch + expanded types |
| `src/screens/DeviceBlockedScreen.tsx` | Full production-grade rewrite |
| `src/screens/SplashScreen.tsx` | Fix useCallback deps + expanded types |
| `src/screens/EnrollDeviceScreen.tsx` | ScrollView + theme tokens + race fix |
| `App.tsx` | Fix deep link config |

## Test plan

- [x] `npx tsc --noEmit` — zero errors
- [ ] ForceUpdate: server 500/timeout → user stays on ForceUpdate (no bypass)
- [ ] DeviceBlocked: server error → user stays blocked (no bypass)
- [ ] Deep link `supermandi://enroll?code=SM-ABC123` routes to EnrollDevice
- [ ] EnrollDeviceScreen scrolls on small devices
- [ ] Label check in-flight → tap Enroll → "Please Wait" alert

Closes #310, #311, #312, #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)