### PR TITLE
fix(SCR-POS-011-043): batch brand polish — theme tokens across 7 screens

### DIFF
--- a/src/screens/BillDetailScreen.tsx
+++ b/src/screens/BillDetailScreen.tsx
@@ -169,7 +169,7 @@ export default function BillDetailScreen() {
           onPress={handleWhatsApp}
           disabled={whatsapping}
         >
-          <MaterialCommunityIcons name="whatsapp" size={18} color="#fff" />
+          <MaterialCommunityIcons name="whatsapp" size={18} color={theme.colors.textInverse} />
           <Text style={styles.actionTextPrimary}>{whatsapping ? "..." : "WhatsApp"}</Text>
         </Pressable>
         <Pressable

--- a/src/screens/MenuScreen.tsx
+++ b/src/screens/MenuScreen.tsx
@@ -59,7 +59,7 @@ type RootStackParamList = {
 type Nav = NativeStackNavigationProp<RootStackParamList>;
 
 /** T-108: Compact brand shortmark for menu header */
-function HeaderBrandIcon({ size = 24, color = "#FFFFFF" }: { size?: number; color?: string }) {
+function HeaderBrandIcon({ size = 24, color = theme.colors.textInverse }: { size?: number; color?: string }) {
   return (
     <Svg width={size} height={size} viewBox="0 0 64 64" fill="none">
       <Path
@@ -411,7 +411,7 @@ export default function MenuScreen() {
       <View style={styles.header}>
         <View style={styles.brandHeader}>
           <View style={styles.brandIconCircle}>
-            <HeaderBrandIcon size={20} color="#FFFFFF" />
+            <HeaderBrandIcon size={20} color={theme.colors.textInverse} />
           </View>
           <Text style={styles.title}>{t('menu.title')}</Text>
         </View>

--- a/src/screens/OrderDetailScreen.tsx
+++ b/src/screens/OrderDetailScreen.tsx
@@ -488,7 +488,7 @@ export default function OrderDetailScreen({
           <MaterialCommunityIcons
             name="whatsapp"
             size={18}
-            color="#FFFFFF"
+            color={theme.colors.textInverse}
           />
         </Pressable>
 

--- a/src/screens/PaymentScreen.tsx
+++ b/src/screens/PaymentScreen.tsx
@@ -969,7 +969,7 @@ const PaymentScreen = () => {
                 </View>
               ) : loadingUpi ? (
                 <View style={{ alignItems: "center", padding: 16 }}>
-                  <ActivityIndicator size="large" color="#2563EB" />
+                  <ActivityIndicator size="large" color={theme.colors.primary} />
                   <Text style={[styles.qrHint, { marginTop: 8 }]}>Generating QR...</Text>
                 </View>
               ) : (
@@ -987,7 +987,7 @@ const PaymentScreen = () => {
             {upiIntent && qrSecondsLeft !== null && qrSecondsLeft > 0 && (
               <Text style={{
                 fontSize: 13,
-                color: qrSecondsLeft <= 60 ? "#DC2626" : "#64748B",
+                color: qrSecondsLeft <= 60 ? theme.colors.error : theme.colors.textTertiary,
                 fontWeight: qrSecondsLeft <= 60 ? "700" : "500",
                 marginTop: 8,
                 textAlign: "center",
@@ -1021,9 +1021,9 @@ const PaymentScreen = () => {
 
       {/* FIX-039: Stale price warning banner */}
       {stalePriceCount > 0 && (
-        <View style={{ backgroundColor: "#FEF3C7", paddingHorizontal: 16, paddingVertical: 8, flexDirection: "row", alignItems: "center" }}>
-          <MaterialCommunityIcons name="alert-outline" size={18} color="#D97706" />
-          <Text style={{ color: "#92400E", fontSize: 13, marginLeft: 8, flex: 1 }}>
+        <View style={{ backgroundColor: theme.colors.warningSoft, paddingHorizontal: 16, paddingVertical: 8, flexDirection: "row", alignItems: "center" }}>
+          <MaterialCommunityIcons name="alert-outline" size={18} color={theme.colors.warning} />
+          <Text style={{ color: theme.colors.warningDark, fontSize: 13, marginLeft: 8, flex: 1 }}>
             {stalePriceCount} item(s) have prices loaded over 4 hours ago. Prices may have changed.
           </Text>
         </View>

--- a/src/screens/PrinterSettingsScreen.tsx
+++ b/src/screens/PrinterSettingsScreen.tsx
@@ -131,7 +131,7 @@ export default function PrinterSettingsScreen({ onBack }: PrinterSettingsScreenP
               value={printerAutoPrint}
               onValueChange={setPrinterAutoPrint}
               trackColor={{ false: theme.colors.border, true: theme.colors.primarySoft }}
-              thumbColor={printerAutoPrint ? theme.colors.primary : "#f4f3f4"}
+              thumbColor={printerAutoPrint ? theme.colors.primary : theme.colors.backgroundTertiary}
             />
           </View>
         </View>

--- a/src/screens/SalesHistoryScreen.tsx
+++ b/src/screens/SalesHistoryScreen.tsx
@@ -128,8 +128,8 @@ export default function SalesHistoryScreen() {
             <RefreshControl
               refreshing={refreshing}
               onRefresh={onRefresh}
-              colors={["#2563EB"]}
-              tintColor="#2563EB"
+              colors={[theme.colors.primary]}
+              tintColor={theme.colors.primary}
             />
           }
         />

--- a/src/screens/SuccessPrintScreenV2.tsx
+++ b/src/screens/SuccessPrintScreenV2.tsx
@@ -248,7 +248,7 @@ export default function SuccessPrintScreenV2() {
             disabled={waStatus === "sending"}
           >
             <View style={{ flexDirection: "row", alignItems: "center", justifyContent: "center", gap: 8 }}>
-              <MaterialCommunityIcons name="whatsapp" size={20} color="#fff" />
+              <MaterialCommunityIcons name="whatsapp" size={20} color={theme.colors.textInverse} />
               <Text style={styles.btnText}>
                 {waStatus === "sending" ? "Sending..." : waStatus === "sent" ? "Sent! Tap to Resend" : waStatus === "failed" ? "Retry WhatsApp" : "WhatsApp Bill"}
               </Text>
@@ -270,7 +270,7 @@ export default function SuccessPrintScreenV2() {
             <TextInput
               style={styles.phoneInput}
               placeholder="9876543210"
-              placeholderTextColor="#94A3B8"
+              placeholderTextColor={theme.colors.textTertiary}
               keyboardType="phone-pad"
               maxLength={10}
               value={waPhone}
@@ -294,7 +294,7 @@ export default function SuccessPrintScreenV2() {
                 disabled={waStatus === "sending"}
               >
                 <View style={{ flexDirection: "row", alignItems: "center", gap: 6 }}>
-                  <MaterialCommunityIcons name="whatsapp" size={18} color="#fff" />
+                  <MaterialCommunityIcons name="whatsapp" size={18} color={theme.colors.textInverse} />
                   <Text style={styles.btnText}>{waStatus === "sending" ? "Sending..." : "Send"}</Text>
                 </View>
               </TouchableOpacity>


### PR DESCRIPTION
## Summary
Batch color token fixes across 7 screens (Screens 11-43 audit):

- **PaymentScreen**: 5 hardcoded hex → theme tokens (primary, error, textTertiary, warningSoft, warning, warningDark)
- **SalesHistoryScreen**: RefreshControl `#2563EB` → `theme.colors.primary`
- **SuccessPrintScreenV2**: `#fff` → textInverse, `#94A3B8` → textTertiary
- **BillDetailScreen**: WhatsApp icon `#fff` → textInverse
- **OrderDetailScreen**: WhatsApp icon `#FFFFFF` → textInverse
- **PrinterSettingsScreen**: Switch `#f4f3f4` → backgroundTertiary
- **MenuScreen**: HeaderBrandIcon `#FFFFFF` → textInverse

### Acceptable remaining hex (not fixing)
- `#25D366` — WhatsApp brand color (external brand requirement)
- `shadowColor: "#000"` — Standard React Native shadow pattern
- ChatListScreen, ChatConversationScreen, AIInsightsScreen, BulkPurchaseCreditScreen — Need complete style section refactor (tracked as p2)

## Test Plan
- [x] `pnpm -r typecheck` — zero errors
- [ ] Visual regression: color changes are subtle theme alignment, no visual breakage expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)