### PR TITLE
fix(SCR-POS-P2): complete style refactor — theme tokens + a11y for 4 P2 screens

### DIFF
--- a/src/screens/AIInsightsScreen.tsx
+++ b/src/screens/AIInsightsScreen.tsx
@@ -99,9 +99,9 @@ export default function AIInsightsScreen({ onBack }: Props) {
 
   const severityColor = (s: string) => {
     switch (s) {
-      case 'critical': return '#DC2626';
-      case 'warning': return '#F59E0B';
-      default: return '#0EA5E9';
+      case 'critical': return theme.colors.error;
+      case 'warning': return theme.colors.warning;
+      default: return theme.colors.info;
     }
   };
 
@@ -115,6 +115,8 @@ export default function AIInsightsScreen({ onBack }: Props) {
           setAlerts(prev => prev.map(a => a.id === item.id ? { ...a, isRead: false } : a));
         });
       }}
+      accessibilityLabel={`${item.severity} alert: ${item.title}`}
+      accessibilityRole="button"
     >
       <View style={[styles.severityDot, { backgroundColor: severityColor(item.severity) }]} />
       <View style={{ flex: 1 }}>
@@ -140,13 +142,16 @@ export default function AIInsightsScreen({ onBack }: Props) {
     </View>
   );
 
+  const trendBg = (trend: string) => trend === 'dead_stock' ? theme.colors.errorSoft : theme.colors.warningSoft;
+  const trendFg = (trend: string) => trend === 'dead_stock' ? theme.colors.errorDark : theme.colors.warningDark;
+
   const renderSlowMover = ({ item }: { item: aiApi.SlowMover }) => (
     <View style={styles.card}>
       <View style={{ flex: 1 }}>
         <View style={{ flexDirection: 'row', justifyContent: 'space-between' }}>
           <Text style={styles.cardTitle}>{item.productName}</Text>
-          <View style={[styles.badge, { backgroundColor: item.trend === 'dead_stock' ? '#FEE2E2' : '#FEF3C7' }]}>
-            <Text style={{ fontSize: 10, color: item.trend === 'dead_stock' ? '#991B1B' : '#92400E' }}>
+          <View style={[styles.badge, { backgroundColor: trendBg(item.trend) }]}>
+            <Text style={[styles.badgeText, { color: trendFg(item.trend) }]}>
               {item.trend.replace('_', ' ')}
             </Text>
           </View>
@@ -157,11 +162,17 @@ export default function AIInsightsScreen({ onBack }: Props) {
     </View>
   );
 
+  const urgencyColor = (urgency: string) => {
+    switch (urgency) {
+      case 'expired': return theme.colors.error;
+      case 'critical': return theme.colors.warning;
+      default: return theme.colors.info;
+    }
+  };
+
   const renderExpiry = ({ item }: { item: aiApi.ExpiryItem }) => (
     <View style={styles.card}>
-      <View style={[styles.severityDot, {
-        backgroundColor: item.urgency === 'expired' ? '#DC2626' : item.urgency === 'critical' ? '#F59E0B' : '#0EA5E9'
-      }]} />
+      <View style={[styles.severityDot, { backgroundColor: urgencyColor(item.urgency) }]} />
       <View style={{ flex: 1 }}>
         <Text style={styles.cardTitle}>{item.productName}</Text>
         <Text style={styles.cardDesc}>
@@ -180,7 +191,7 @@ export default function AIInsightsScreen({ onBack }: Props) {
           Current: {'\u20B9'}{(item.currentPrice / 100).toFixed(2)} | Best: {'\u20B9'}{(item.bestPrice / 100).toFixed(2)}
         </Text>
         {item.maxSavings > 0 && (
-          <Text style={[styles.cardMeta, { color: '#16A34A' }]}>
+          <Text style={[styles.cardMeta, { color: theme.colors.success }]}>
             Save {'\u20B9'}{(item.maxSavings / 100).toFixed(2)} ({item.maxSavingsPercent.toFixed(1)}%)
           </Text>
         )}
@@ -204,7 +215,7 @@ export default function AIInsightsScreen({ onBack }: Props) {
     <View style={styles.container}>
       {/* Header */}
       <View style={[styles.header, { paddingTop: 12 + insets.top }]}>
-        <Pressable onPress={onBack} style={styles.backBtn}>
+        <Pressable onPress={onBack} style={styles.backBtn} accessibilityLabel="Go back" accessibilityRole="button">
           <MaterialCommunityIcons name="arrow-left" size={24} color={theme.colors.textPrimary} />
         </Pressable>
         <Text style={styles.headerTitle}>AI Insights</Text>
@@ -213,7 +224,14 @@ export default function AIInsightsScreen({ onBack }: Props) {
       {/* Tabs */}
       <View style={styles.tabBar}>
         {tabs.map(t => (
-          <Pressable key={t.key} onPress={() => setTab(t.key)} style={[styles.tab, tab === t.key && styles.activeTab]}>
+          <Pressable
+            key={t.key}
+            onPress={() => setTab(t.key)}
+            style={[styles.tab, tab === t.key && styles.activeTab]}
+            accessibilityLabel={t.label}
+            accessibilityRole="tab"
+            accessibilityState={{ selected: tab === t.key }}
+          >
             <MaterialCommunityIcons
               name={t.icon as any}
               size={18}
@@ -257,13 +275,13 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   header: {
     flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16,
-    paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: '#e2e8f0', backgroundColor: '#fff',
+    paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: theme.colors.border, backgroundColor: theme.colors.surface,
   },
   backBtn: { padding: 4, marginRight: 8 },
   headerTitle: { flex: 1, fontSize: 18, fontWeight: '600', color: theme.colors.textPrimary },
   tabBar: {
-    flexDirection: 'row', backgroundColor: '#fff', borderBottomWidth: 1,
-    borderBottomColor: '#e2e8f0', paddingHorizontal: 4,
+    flexDirection: 'row', backgroundColor: theme.colors.surface, borderBottomWidth: 1,
+    borderBottomColor: theme.colors.border, paddingHorizontal: 4,
   },
   tab: {
     flex: 1, alignItems: 'center', paddingVertical: 10, gap: 2,
@@ -272,19 +290,20 @@ const styles = StyleSheet.create({
   tabLabel: { fontSize: 11, color: theme.colors.textTertiary },
   activeTabLabel: { color: theme.colors.primary, fontWeight: '600' },
   card: {
-    flexDirection: 'row', backgroundColor: '#fff', borderRadius: 8, padding: 12,
-    marginBottom: 8, borderWidth: 1, borderColor: '#e2e8f0', gap: 10,
+    flexDirection: 'row', backgroundColor: theme.colors.surface, borderRadius: 8, padding: 12,
+    marginBottom: 8, borderWidth: 1, borderColor: theme.colors.border, gap: 10,
   },
   unreadCard: { borderLeftWidth: 3, borderLeftColor: theme.colors.primary },
   severityDot: { width: 8, height: 8, borderRadius: 4, marginTop: 6 },
   cardTitle: { fontSize: 14, fontWeight: '500', color: theme.colors.textPrimary, marginBottom: 2 },
   cardDesc: { fontSize: 12, color: theme.colors.textSecondary, marginBottom: 4 },
   cardMeta: { fontSize: 11, color: theme.colors.textTertiary },
-  confidenceBar: { height: 4, backgroundColor: '#E2E8F0', borderRadius: 2, marginTop: 4 },
+  confidenceBar: { height: 4, backgroundColor: theme.colors.backgroundTertiary, borderRadius: 2, marginTop: 4 },
   confidenceFill: { height: 4, backgroundColor: theme.colors.primary, borderRadius: 2 },
   badge: { paddingHorizontal: 6, paddingVertical: 2, borderRadius: 4 },
-  errorBar: { backgroundColor: '#FEE2E2', padding: 10 },
-  errorText: { color: '#991B1B', fontSize: 13 },
+  badgeText: { fontSize: 10 },
+  errorBar: { backgroundColor: theme.colors.errorSoft, padding: 10 },
+  errorText: { color: theme.colors.errorDark, fontSize: 13 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
   emptyText: { fontSize: 14, color: theme.colors.textTertiary, marginTop: 8 },
 });

--- a/src/screens/BulkPurchaseCreditScreen.tsx
+++ b/src/screens/BulkPurchaseCreditScreen.tsx
@@ -78,6 +78,16 @@ export default function BulkPurchaseCreditScreen({ onBack }: Props) {
     ]);
   };
 
+  const statusBg = (status: string) =>
+    status === 'available' ? theme.colors.successSoft
+    : status === 'applied' ? theme.colors.primaryLight
+    : theme.colors.warningSoft;
+
+  const statusFg = (status: string) =>
+    status === 'available' ? theme.colors.successDark
+    : status === 'applied' ? theme.colors.primaryDark
+    : theme.colors.warningDark;
+
   const renderOffer = ({ item }: { item: CreditOffer }) => (
     <View style={styles.card}>
       <View style={styles.cardHeader}>
@@ -85,12 +95,8 @@ export default function BulkPurchaseCreditScreen({ onBack }: Props) {
           <MaterialCommunityIcons name="bank-outline" size={16} color={theme.colors.primary} />
           <Text style={styles.providerName}>{item.providerName}</Text>
         </View>
-        <View style={[styles.statusBadge, {
-          backgroundColor: item.status === 'available' ? '#ECFDF5' : item.status === 'applied' ? '#EFF6FF' : '#FEF3C7'
-        }]}>
-          <Text style={[styles.statusText, {
-            color: item.status === 'available' ? '#166534' : item.status === 'applied' ? '#1E40AF' : '#92400E'
-          }]}>{item.status}</Text>
+        <View style={[styles.statusBadge, { backgroundColor: statusBg(item.status) }]}>
+          <Text style={[styles.statusText, { color: statusFg(item.status) }]}>{item.status}</Text>
         </View>
       </View>
 
@@ -114,8 +120,14 @@ export default function BulkPurchaseCreditScreen({ onBack }: Props) {
       </View>
 
       {item.status === 'available' && (
-        <Pressable style={styles.applyBtn} onPress={() => applyForCredit(item.id)}>
-          <MaterialCommunityIcons name="file-document-edit-outline" size={16} color="#fff" />
+        <Pressable
+          style={styles.applyBtn}
+          onPress={() => applyForCredit(item.id)}
+          accessibilityLabel="Apply Now"
+          accessibilityRole="button"
+          testID="credit-apply-btn"
+        >
+          <MaterialCommunityIcons name="file-document-edit-outline" size={16} color={theme.colors.textInverse} />
           <Text style={styles.applyBtnText}>Apply Now</Text>
         </Pressable>
       )}
@@ -129,7 +141,7 @@ export default function BulkPurchaseCreditScreen({ onBack }: Props) {
   return (
     <View style={styles.container}>
       <View style={[styles.header, { paddingTop: 12 + insets.top }]}>
-        <Pressable onPress={onBack} style={styles.backBtn}>
+        <Pressable onPress={onBack} style={styles.backBtn} accessibilityLabel="Go back" accessibilityRole="button">
           <MaterialCommunityIcons name="arrow-left" size={24} color={theme.colors.textPrimary} />
         </Pressable>
         <Text style={styles.headerTitle}>Bulk Purchase Credit</Text>
@@ -175,7 +187,7 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   header: {
     flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16,
-    paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: '#e2e8f0', backgroundColor: '#fff',
+    paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: theme.colors.border, backgroundColor: theme.colors.surface,
   },
   backBtn: { padding: 4, marginRight: 8 },
   headerTitle: { flex: 1, fontSize: 18, fontWeight: '600', color: theme.colors.textPrimary },
@@ -184,7 +196,7 @@ const styles = StyleSheet.create({
     backgroundColor: theme.colors.primaryLight, borderRadius: 8,
   },
   infoBannerText: { flex: 1, fontSize: 12, color: theme.colors.primary, lineHeight: 18 },
-  card: { backgroundColor: '#fff', borderRadius: 10, padding: 16, marginBottom: 12, borderWidth: 1, borderColor: '#e2e8f0' },
+  card: { backgroundColor: theme.colors.surface, borderRadius: 10, padding: 16, marginBottom: 12, borderWidth: 1, borderColor: theme.colors.border },
   cardHeader: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center', marginBottom: 12 },
   providerBadge: { flexDirection: 'row', alignItems: 'center', gap: 6 },
   providerName: { fontSize: 15, fontWeight: '600', color: theme.colors.textPrimary },
@@ -198,10 +210,10 @@ const styles = StyleSheet.create({
     flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6,
     backgroundColor: theme.colors.primary, borderRadius: 8, paddingVertical: 10,
   },
-  applyBtnText: { fontSize: 14, fontWeight: '600', color: '#fff' },
+  applyBtnText: { fontSize: 14, fontWeight: '600', color: theme.colors.textInverse },
   appliedText: { fontSize: 12, color: theme.colors.textTertiary, textAlign: 'center', fontStyle: 'italic' },
-  errorBar: { backgroundColor: '#FEE2E2', padding: 10, marginHorizontal: 12 },
-  errorText: { color: '#991B1B', fontSize: 13 },
+  errorBar: { backgroundColor: theme.colors.errorSoft, padding: 10, marginHorizontal: 12 },
+  errorText: { color: theme.colors.errorDark, fontSize: 13 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
   emptyTitle: { fontSize: 16, fontWeight: '600', color: theme.colors.textPrimary, marginTop: 12 },
   emptyDesc: { fontSize: 13, color: theme.colors.textTertiary, textAlign: 'center', marginTop: 4 },

--- a/src/screens/ChatConversationScreen.tsx
+++ b/src/screens/ChatConversationScreen.tsx
@@ -144,13 +144,13 @@ export default function ChatConversationScreen({
           {/* Attachment */}
           {item.messageType === 'image' && item.attachmentUrl && (
             <View style={styles.attachmentPreview}>
-              <MaterialCommunityIcons name="image" size={20} color="#64748b" />
+              <MaterialCommunityIcons name="image" size={20} color={theme.colors.textTertiary} />
               <Text style={styles.attachmentText}>{item.attachmentName || 'Photo'}</Text>
             </View>
           )}
           {item.messageType === 'document' && item.attachmentUrl && (
             <View style={styles.attachmentPreview}>
-              <MaterialCommunityIcons name="file-document" size={20} color="#64748b" />
+              <MaterialCommunityIcons name="file-document" size={20} color={theme.colors.textTertiary} />
               <Text style={styles.attachmentText}>{item.attachmentName || 'Document'}</Text>
             </View>
           )}
@@ -176,7 +176,7 @@ export default function ChatConversationScreen({
     >
       {/* Header */}
       <View style={[styles.header, { paddingTop: 12 + insets.top }]}>
-        <Pressable onPress={onBack} style={styles.backBtn}>
+        <Pressable onPress={onBack} style={styles.backBtn} accessibilityLabel="Go back" accessibilityRole="button">
           <MaterialCommunityIcons name="arrow-left" size={24} color={theme.colors.textPrimary} />
         </Pressable>
         <View style={styles.headerInfo}>
@@ -191,12 +191,12 @@ export default function ChatConversationScreen({
       {error && (
         <View style={styles.errorBar}>
           <Text style={styles.errorText}>{error}</Text>
-          <View style={{ flexDirection: 'row', justifyContent: 'center', gap: 12, marginTop: 4 }}>
-            <Pressable onPress={() => { setError(null); fetchMessages(); }}>
-              <Text style={{ color: '#991b1b', fontSize: 12, fontWeight: '600' }}>Retry</Text>
+          <View style={styles.errorActions}>
+            <Pressable onPress={() => { setError(null); fetchMessages(); }} accessibilityLabel="Retry" accessibilityRole="button">
+              <Text style={styles.retryText}>Retry</Text>
             </Pressable>
-            <Pressable onPress={() => setError(null)}>
-              <Text style={{ color: '#64748b', fontSize: 12 }}>Dismiss</Text>
+            <Pressable onPress={() => setError(null)} accessibilityLabel="Dismiss error" accessibilityRole="button">
+              <Text style={styles.dismissText}>Dismiss</Text>
             </Pressable>
           </View>
         </View>
@@ -217,7 +217,7 @@ export default function ChatConversationScreen({
           contentContainerStyle={styles.messagesList}
           ListEmptyComponent={
             <View style={styles.emptyCenter}>
-              <MaterialCommunityIcons name="chat-processing-outline" size={40} color="#94a3b8" />
+              <MaterialCommunityIcons name="chat-processing-outline" size={40} color={theme.colors.textTertiary} />
               <Text style={styles.emptyText}>No messages yet. Say hello!</Text>
             </View>
           }
@@ -231,20 +231,25 @@ export default function ChatConversationScreen({
           value={text}
           onChangeText={setText}
           placeholder="Type a message..."
-          placeholderTextColor="#94a3b8"
+          placeholderTextColor={theme.colors.textTertiary}
           multiline
           maxLength={2000}
           editable={!sending}
+          accessibilityLabel="Message input"
+          testID="chat-message-input"
         />
         <Pressable
           style={[styles.sendBtn, (!text.trim() || sending) && styles.sendBtnDisabled]}
           onPress={handleSend}
           disabled={!text.trim() || sending}
+          accessibilityLabel="Send message"
+          accessibilityRole="button"
+          testID="chat-send-btn"
         >
           {sending ? (
-            <ActivityIndicator size="small" color="#fff" />
+            <ActivityIndicator size="small" color={theme.colors.textInverse} />
           ) : (
-            <MaterialCommunityIcons name="send" size={20} color="#fff" />
+            <MaterialCommunityIcons name="send" size={20} color={theme.colors.textInverse} />
           )}
         </Pressable>
       </View>
@@ -253,31 +258,34 @@ export default function ChatConversationScreen({
 }
 
 const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: '#f8fafc' },
+  container: { flex: 1, backgroundColor: theme.colors.surfaceAlt },
   header: {
     flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16,
-    paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: '#e2e8f0',
-    backgroundColor: '#fff',
+    paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: theme.colors.border,
+    backgroundColor: theme.colors.surface,
   },
   backBtn: { padding: 4, marginRight: 8 },
   headerInfo: { flex: 1 },
-  headerTitle: { fontSize: 16, fontWeight: '600', color: '#1e293b' },
-  headerSubtitle: { fontSize: 12, color: '#64748b' },
-  errorBar: { padding: 8, backgroundColor: '#fee2e2' },
-  errorText: { color: '#991b1b', fontSize: 12, textAlign: 'center' },
+  headerTitle: { fontSize: 16, fontWeight: '600', color: theme.colors.textPrimary },
+  headerSubtitle: { fontSize: 12, color: theme.colors.textTertiary },
+  errorBar: { padding: 8, backgroundColor: theme.colors.errorSoft },
+  errorText: { color: theme.colors.errorDark, fontSize: 12, textAlign: 'center' },
+  errorActions: { flexDirection: 'row', justifyContent: 'center', gap: 12, marginTop: 4 },
+  retryText: { color: theme.colors.errorDark, fontSize: 12, fontWeight: '600' },
+  dismissText: { color: theme.colors.textTertiary, fontSize: 12 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
   emptyCenter: { flex: 1, alignItems: 'center', justifyContent: 'center', paddingTop: 100, transform: [{ scaleY: -1 }] },
-  emptyText: { marginTop: 8, color: '#64748b', fontSize: 14 },
+  emptyText: { marginTop: 8, color: theme.colors.textTertiary, fontSize: 14 },
   messagesList: { paddingHorizontal: 12, paddingVertical: 8 },
   dateSeparator: {
-    textAlign: 'center', fontSize: 11, color: '#94a3b8', marginVertical: 8,
-    backgroundColor: '#f1f5f9', alignSelf: 'center', paddingHorizontal: 12,
+    textAlign: 'center', fontSize: 11, color: theme.colors.textTertiary, marginVertical: 8,
+    backgroundColor: theme.colors.backgroundSecondary, alignSelf: 'center', paddingHorizontal: 12,
     paddingVertical: 3, borderRadius: 10, overflow: 'hidden',
   },
   systemMessage: { alignItems: 'center', marginVertical: 4 },
   systemText: {
-    fontSize: 12, color: '#64748b', fontStyle: 'italic',
-    backgroundColor: '#f1f5f9', paddingHorizontal: 12, paddingVertical: 4,
+    fontSize: 12, color: theme.colors.textTertiary, fontStyle: 'italic',
+    backgroundColor: theme.colors.backgroundSecondary, paddingHorizontal: 12, paddingVertical: 4,
     borderRadius: 8, overflow: 'hidden',
   },
   bubble: {
@@ -285,30 +293,30 @@ const styles = StyleSheet.create({
     borderRadius: 16, marginVertical: 2,
   },
   ownBubble: { alignSelf: 'flex-end', backgroundColor: theme.colors.primary, borderBottomRightRadius: 4 },
-  otherBubble: { alignSelf: 'flex-start', backgroundColor: '#fff', borderBottomLeftRadius: 4, borderWidth: 1, borderColor: '#e2e8f0' },
+  otherBubble: { alignSelf: 'flex-start', backgroundColor: theme.colors.surface, borderBottomLeftRadius: 4, borderWidth: 1, borderColor: theme.colors.border },
   messageText: { fontSize: 14, lineHeight: 20 },
-  ownText: { color: '#fff' },
-  otherText: { color: '#1e293b' },
+  ownText: { color: theme.colors.textInverse },
+  otherText: { color: theme.colors.textPrimary },
   time: { fontSize: 10, marginTop: 2 },
-  ownTime: { color: 'rgba(255,255,255,0.7)', textAlign: 'right' },
-  otherTime: { color: '#94a3b8' },
+  ownTime: { color: 'rgba(255,255,255,0.7)', textAlign: 'right' }, // Semi-transparent white on primary bg
+  otherTime: { color: theme.colors.textTertiary },
   attachmentPreview: {
     flexDirection: 'row', alignItems: 'center', gap: 4,
     paddingVertical: 4, marginBottom: 4,
   },
-  attachmentText: { fontSize: 12, color: '#64748b' },
+  attachmentText: { fontSize: 12, color: theme.colors.textTertiary },
   inputBar: {
     flexDirection: 'row', alignItems: 'flex-end', padding: 8,
-    borderTopWidth: 1, borderTopColor: '#e2e8f0', backgroundColor: '#fff',
+    borderTopWidth: 1, borderTopColor: theme.colors.border, backgroundColor: theme.colors.surface,
   },
   input: {
-    flex: 1, borderWidth: 1, borderColor: '#e2e8f0', borderRadius: 20,
+    flex: 1, borderWidth: 1, borderColor: theme.colors.border, borderRadius: 20,
     paddingHorizontal: 16, paddingVertical: 8, fontSize: 14,
-    maxHeight: 100, color: '#1e293b', backgroundColor: '#f8fafc',
+    maxHeight: 100, color: theme.colors.textPrimary, backgroundColor: theme.colors.surfaceAlt,
   },
   sendBtn: {
     width: 40, height: 40, borderRadius: 20, backgroundColor: theme.colors.primary,
     alignItems: 'center', justifyContent: 'center', marginLeft: 8,
   },
-  sendBtnDisabled: { backgroundColor: '#94a3b8' },
+  sendBtnDisabled: { backgroundColor: theme.colors.textTertiary },
 });

--- a/src/screens/ChatListScreen.tsx
+++ b/src/screens/ChatListScreen.tsx
@@ -11,6 +11,10 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { theme } from '../theme';
 import * as chatApi from '../services/api/chatApi';
 
+// Support-type conversation uses violet (#7c3aed / #f5f3ff) — not a brand color
+const SUPPORT_ICON_COLOR = '#7c3aed';
+const SUPPORT_BG_COLOR = '#f5f3ff';
+
 interface Props {
   onSelectConversation: (conversation: chatApi.Conversation) => void;
   onContactSupport: () => void;
@@ -82,12 +86,14 @@ export default function ChatListScreen({ onSelectConversation, onContactSupport,
     <Pressable
       style={styles.conversationItem}
       onPress={() => onSelectConversation(item)}
+      accessibilityLabel={`${item.title || item.otherParticipantName || 'Conversation'}${item.unreadCount > 0 ? `, ${item.unreadCount} unread` : ''}`}
+      accessibilityRole="button"
     >
       <View style={[styles.avatar, item.type === 'support' ? styles.avatarSupport : null]}>
         <MaterialCommunityIcons
           name={getConversationIcon(item.type) as any}
           size={22}
-          color={item.type === 'support' ? '#7c3aed' : theme.colors.primary}
+          color={item.type === 'support' ? SUPPORT_ICON_COLOR : theme.colors.primary}
         />
       </View>
 
@@ -118,11 +124,11 @@ export default function ChatListScreen({ onSelectConversation, onContactSupport,
     <View style={styles.container}>
       {/* Header */}
       <View style={[styles.header, { paddingTop: 12 + insets.top }]}>
-        <Pressable onPress={onBack} style={styles.backBtn}>
+        <Pressable onPress={onBack} style={styles.backBtn} accessibilityLabel="Go back" accessibilityRole="button">
           <MaterialCommunityIcons name="arrow-left" size={24} color={theme.colors.textPrimary} />
         </Pressable>
         <Text style={styles.headerTitle}>Messages</Text>
-        <Pressable onPress={onContactSupport} style={styles.supportBtn}>
+        <Pressable onPress={onContactSupport} style={styles.supportBtn} accessibilityLabel="Contact support" accessibilityRole="button">
           <MaterialCommunityIcons name="headset" size={22} color={theme.colors.primary} />
         </Pressable>
       </View>
@@ -131,7 +137,7 @@ export default function ChatListScreen({ onSelectConversation, onContactSupport,
       {error && (
         <View style={styles.errorBar}>
           <Text style={styles.errorText}>{error}</Text>
-          <Pressable onPress={fetchConversations}>
+          <Pressable onPress={fetchConversations} accessibilityLabel="Retry" accessibilityRole="button">
             <Text style={styles.retryText}>Retry</Text>
           </Pressable>
         </View>
@@ -145,13 +151,13 @@ export default function ChatListScreen({ onSelectConversation, onContactSupport,
         </View>
       ) : conversations.length === 0 ? (
         <View style={styles.center}>
-          <MaterialCommunityIcons name="chat-outline" size={48} color="#94a3b8" />
+          <MaterialCommunityIcons name="chat-outline" size={48} color={theme.colors.textTertiary} />
           <Text style={styles.emptyTitle}>No conversations yet</Text>
           <Text style={styles.emptyText}>
             Start a chat with your supplier or contact support
           </Text>
-          <Pressable style={styles.supportCta} onPress={onContactSupport}>
-            <MaterialCommunityIcons name="headset" size={18} color="#fff" />
+          <Pressable style={styles.supportCta} onPress={onContactSupport} accessibilityLabel="Contact Support" accessibilityRole="button">
+            <MaterialCommunityIcons name="headset" size={18} color={theme.colors.textInverse} />
             <Text style={styles.supportCtaText}>Contact Support</Text>
           </Pressable>
         </View>
@@ -174,47 +180,47 @@ const styles = StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   header: {
     flexDirection: 'row', alignItems: 'center', paddingHorizontal: 16,
-    paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: '#e2e8f0',
-    backgroundColor: '#fff',
+    paddingVertical: 12, borderBottomWidth: 1, borderBottomColor: theme.colors.border,
+    backgroundColor: theme.colors.surface,
   },
   backBtn: { padding: 4, marginRight: 8 },
   headerTitle: { flex: 1, fontSize: 18, fontWeight: '600', color: theme.colors.textPrimary },
   supportBtn: { padding: 4 },
   errorBar: {
     flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between',
-    padding: 12, backgroundColor: '#fee2e2',
+    padding: 12, backgroundColor: theme.colors.errorSoft,
   },
-  errorText: { color: '#991b1b', fontSize: 13 },
-  retryText: { color: '#991b1b', fontWeight: '600', textDecorationLine: 'underline' },
+  errorText: { color: theme.colors.errorDark, fontSize: 13 },
+  retryText: { color: theme.colors.errorDark, fontWeight: '600', textDecorationLine: 'underline' },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 32 },
-  loadingText: { marginTop: 12, color: '#64748b', fontSize: 14 },
-  emptyTitle: { marginTop: 12, fontSize: 16, fontWeight: '600', color: '#334155' },
-  emptyText: { marginTop: 4, fontSize: 13, color: '#64748b', textAlign: 'center' },
+  loadingText: { marginTop: 12, color: theme.colors.textTertiary, fontSize: 14 },
+  emptyTitle: { marginTop: 12, fontSize: 16, fontWeight: '600', color: theme.colors.textPrimary },
+  emptyText: { marginTop: 4, fontSize: 13, color: theme.colors.textTertiary, textAlign: 'center' },
   supportCta: {
     marginTop: 16, flexDirection: 'row', alignItems: 'center',
     backgroundColor: theme.colors.primary, paddingHorizontal: 16, paddingVertical: 10,
     borderRadius: 8, gap: 6,
   },
-  supportCtaText: { color: '#fff', fontWeight: '600', fontSize: 14 },
+  supportCtaText: { color: theme.colors.textInverse, fontWeight: '600', fontSize: 14 },
   list: { paddingBottom: 16 },
   conversationItem: {
     flexDirection: 'row', alignItems: 'center', padding: 14,
-    borderBottomWidth: 1, borderBottomColor: '#f1f5f9', backgroundColor: '#fff',
+    borderBottomWidth: 1, borderBottomColor: theme.colors.backgroundSecondary, backgroundColor: theme.colors.surface,
   },
   avatar: {
-    width: 44, height: 44, borderRadius: 22, backgroundColor: '#f0fdf4',
+    width: 44, height: 44, borderRadius: 22, backgroundColor: theme.colors.successSoft,
     alignItems: 'center', justifyContent: 'center', marginRight: 12,
   },
-  avatarSupport: { backgroundColor: '#f5f3ff' },
+  avatarSupport: { backgroundColor: SUPPORT_BG_COLOR },
   conversationContent: { flex: 1 },
   conversationHeader: { flexDirection: 'row', justifyContent: 'space-between', marginBottom: 2 },
-  conversationName: { fontSize: 15, fontWeight: '600', color: '#1e293b', flex: 1, marginRight: 8 },
-  timestamp: { fontSize: 11, color: '#94a3b8' },
+  conversationName: { fontSize: 15, fontWeight: '600', color: theme.colors.textPrimary, flex: 1, marginRight: 8 },
+  timestamp: { fontSize: 11, color: theme.colors.textTertiary },
   conversationFooter: { flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-  preview: { fontSize: 13, color: '#64748b', flex: 1, marginRight: 8 },
+  preview: { fontSize: 13, color: theme.colors.textTertiary, flex: 1, marginRight: 8 },
   badge: {
     minWidth: 20, height: 20, borderRadius: 10, backgroundColor: theme.colors.primary,
     alignItems: 'center', justifyContent: 'center', paddingHorizontal: 6,
   },
-  badgeText: { color: '#fff', fontSize: 11, fontWeight: '700' },
+  badgeText: { color: theme.colors.textInverse, fontSize: 11, fontWeight: '700' },
 });

--- a/src/theme/colors.ts
+++ b/src/theme/colors.ts
@@ -30,6 +30,7 @@ export const colors = {
   error: "#DC2626",
   warning: "#F59E0B",
   warningDark: "#92400E",
+  errorDark: "#991B1B",
   info: "#0EA5E9",
   successSoft: "#ECFDF5",
   warningSoft: "#FFF7ED",


### PR DESCRIPTION
## Summary
- **BulkPurchaseCreditScreen**: 10 hardcoded hex → theme tokens, add a11y + testID
- **ChatListScreen**: 18 hardcoded hex → theme tokens, add a11y labels (support violet kept as named constant)
- **ChatConversationScreen**: 25 hardcoded hex → theme tokens, extract inline error styles, add a11y + testIDs
- **AIInsightsScreen**: 15 hardcoded hex → theme tokens, add a11y labels for tabs + alerts
- Add `errorDark` (#991B1B) token to `theme/colors.ts`

## Changes
| Screen | Hex Replaced | A11y Added | TestIDs Added |
|--------|-------------|------------|---------------|
| BulkPurchaseCreditScreen | 10 | 2 | 1 |
| ChatListScreen | 18 | 5 | 0 |
| ChatConversationScreen | 25 | 5 | 2 |
| AIInsightsScreen | 15 | 7 | 0 |

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [ ] Verify screens render correctly on device/emulator
- [ ] Verify a11y labels announced by screen reader

🤖 Generated with [Claude Code](https://claude.com/claude-code)