### PR TITLE
fix(WAVE2-P0): GCP parity — dead domains, splash gate, deep link, RLS validation

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -142,7 +142,7 @@ POS_APP_DOWNLOAD_URL=https://supermandi.tech/pos
 # Provider: 'resend' (recommended), 'smtp', or 'disabled'
 EMAIL_PROVIDER=disabled
 # From address for verification emails
-EMAIL_FROM=SuperMandi <noreply@supermandi.com>
+EMAIL_FROM=SuperMandi <noreply@supermandi.tech>
 
 # Resend Configuration (if EMAIL_PROVIDER=resend)
 # Get API key from: https://resend.com/api-keys

--- a/backend/services/platform-service/src/routes/retailerAdmin.ts
+++ b/backend/services/platform-service/src/routes/retailerAdmin.ts
@@ -117,7 +117,7 @@ router.post(
       data: {
         storeId,
         storeCode: store.code,
-        portalUrl: `https://supermandi.in/s/${store.code}`,
+        portalUrl: `https://supermandi.tech/s/${store.code}`,
         phone: normalizedPhone,
         maskedPhone: maskPhoneNumber(normalizedPhone),
         message: 'Retailer portal initialized. User will complete registration on first login.',
@@ -288,7 +288,7 @@ router.post(
       data: {
         storeId,
         storeCode: store.code,
-        portalUrl: `https://supermandi.in/s/${store.code}`,
+        portalUrl: `https://supermandi.tech/s/${store.code}`,
         expiresAt: tokenExpiresAt,
         impersonatedBy: adminUserId,
         message: 'Impersonation session created. Token generation requires auth-service integration.',

--- a/backend/src/db/client.ts
+++ b/backend/src/db/client.ts
@@ -75,6 +75,10 @@ export function getPool(): Pool | undefined {
   return pool;
 }
 
+// #343: UUID format validation for RLS store context
+// rls_store_check() casts to ::uuid — passing non-UUID would throw at DB level.
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // T-216: RLS store context helper
 // Sets app.current_store_id for the duration of a transaction/callback
 // SET LOCAL requires an active transaction — this wraps fn in BEGIN/COMMIT.
@@ -83,6 +87,9 @@ export async function withStoreContext<T>(
   storeId: string,
   fn: (client: import("pg").PoolClient) => Promise<T>
 ): Promise<T> {
+  if (!UUID_RE.test(storeId)) {
+    throw new Error(`withStoreContext: invalid store_id format (expected UUID): ${storeId}`);
+  }
   const p = getPool();
   if (!p) throw new Error("Database pool not initialized");
   const client = await p.connect();

--- a/backend/src/routes/v1/admin/adminOtp.ts
+++ b/backend/src/routes/v1/admin/adminOtp.ts
@@ -151,7 +151,7 @@ adminOtpRouter.post("/otp/request", async (req: Request, res: Response) => {
         secure: process.env.SMTP_SECURE === "true",
         auth: { user: process.env.SMTP_USER || "", pass: process.env.SMTP_PASS || "" },
       });
-      const from = process.env.EMAIL_FROM || "SuperMandi <noreply@supermandi.com>";
+      const from = process.env.EMAIL_FROM || "SuperMandi <noreply@supermandi.tech>";
       await transporter.sendMail({
         from,
         to: email,

--- a/backend/src/services/barcodeLookupProvider.ts
+++ b/backend/src/services/barcodeLookupProvider.ts
@@ -85,7 +85,7 @@ async function lookupOpenFoodFacts(barcode: string): Promise<BarcodeProductPrefi
       {
         signal: controller.signal,
         headers: {
-          "User-Agent": "SuperMandi-POS/1.0 (contact@supermandi.com)"
+          "User-Agent": "SuperMandi-POS/1.0 (hello@supermandi.tech)"
         }
       }
     );

--- a/backend/src/services/emailService.ts
+++ b/backend/src/services/emailService.ts
@@ -41,7 +41,7 @@ export interface VerificationEmailData {
 
 function getEmailConfig(): EmailConfig {
   const provider = (process.env.EMAIL_PROVIDER || 'disabled').toLowerCase() as EmailConfig['provider'];
-  const from = process.env.EMAIL_FROM || 'SuperMandi <noreply@supermandi.com>';
+  const from = process.env.EMAIL_FROM || 'SuperMandi <noreply@supermandi.tech>';
 
   const config: EmailConfig = {
     provider,
@@ -472,7 +472,7 @@ export async function sendPasswordResetEmail(
   }
 
   // Build reset URL - use frontend URL or fallback
-  const frontendUrl = process.env.SUPPLIER_PORTAL_URL || process.env.FRONTEND_URL || 'https://supplier.supermandi.in';
+  const frontendUrl = process.env.SUPPLIER_PORTAL_URL || process.env.FRONTEND_URL || 'https://supermandi.tech/supplier';
   const resetUrl = `${frontendUrl}/reset-password?token=${encodeURIComponent(resetToken)}`;
 
   const subject = 'Reset your SuperMandi password';

--- a/backend/src/services/notificationService.ts
+++ b/backend/src/services/notificationService.ts
@@ -58,7 +58,7 @@ async function sendGenericEmail(
       return { sent: false, errorCode: "MISSING_API_KEY", errorMessage: "Resend API key not configured" };
     }
 
-    const from = process.env.EMAIL_FROM || "SuperMandi <noreply@supermandi.com>";
+    const from = process.env.EMAIL_FROM || "SuperMandi <noreply@supermandi.tech>";
     const response = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {
@@ -89,7 +89,7 @@ async function sendGenericEmail(
         auth: { user: process.env.SMTP_USER || "", pass: process.env.SMTP_PASS || "" },
       });
 
-      const from = process.env.EMAIL_FROM || "SuperMandi <noreply@supermandi.com>";
+      const from = process.env.EMAIL_FROM || "SuperMandi <noreply@supermandi.tech>";
       const info = await transporter.sendMail({ from, to, subject, text, html });
       return { sent: true, messageId: info.messageId as string };
     } catch (err) {

--- a/src/screens/EnrollDeviceScreen.tsx
+++ b/src/screens/EnrollDeviceScreen.tsx
@@ -42,7 +42,7 @@ import { useProductsStore } from "../stores/productsStore";
 import { useSettingsStore } from "../stores/settingsStore";
 
 type RootStackParamList = {
-  EnrollDevice: { enrollmentCode?: string } | undefined;
+  EnrollDevice: { enrollmentCode?: string; code?: string } | undefined;
   SellScan: undefined;
   PaymentSetup: undefined;
   ForceUpdate: { currentVersion?: string; requiredVersion?: string };
@@ -122,7 +122,8 @@ const PAYMENT_PROMPTED_KEY = "supermandi.payment_setup_prompted";
 export default function EnrollDeviceScreen() {
   const navigation = useNavigation<Nav>();
   const route = useRoute<EnrollRoute>();
-  const [codeInput, setCodeInput] = useState(route.params?.enrollmentCode || "");
+  // #342: Accept both ?enrollmentCode=X and ?code=X from deep links
+  const [codeInput, setCodeInput] = useState(route.params?.enrollmentCode || route.params?.code || "");
   const [loading, setLoading] = useState(false);
 
   // Phone lookup state

--- a/src/screens/SplashScreen.tsx
+++ b/src/screens/SplashScreen.tsx
@@ -13,6 +13,8 @@ import { startAutoSync } from "../services/syncService";
 import { initOfflineDb } from "../services/offline/localDb";
 import { syncOutbox } from "../services/offline/sync";
 import { getDeviceSession } from "../services/deviceSession";
+import { fetchUiStatus } from "../services/api/uiStatusApi";
+import { getDeviceMeta } from "../services/deviceInfo";
 
 type RootStackParamList = {
   Splash: undefined;
@@ -66,11 +68,36 @@ export default function SplashScreen() {
     return Promise.race([getDeviceSession(), timeoutPromise]);
   }, []);
 
-  /** S1-1 + S1-2 + S1-3: Session check with full error handling */
+  /** S1-1 + S1-2 + S1-3 + #337: Session + version/blocked check */
   const navigateAfterSession = useCallback(async () => {
     try {
       const session = await getSessionWithTimeout();
-      navigation.replace(session ? "SellScan" : "EnrollDevice");
+      if (!session) {
+        navigation.replace("EnrollDevice");
+        return;
+      }
+
+      // #337: Check version enforcement and device-blocked status before SellScan.
+      // fetchUiStatus returns safe defaults on error (forceUpdate=false, deviceActive=true)
+      // so offline users are NOT blocked — PosRootLayout re-checks with polling.
+      try {
+        const status = await fetchUiStatus();
+        if (status.forceUpdate) {
+          navigation.replace("ForceUpdate", {
+            currentVersion: getDeviceMeta().appVersion ?? "unknown",
+            requiredVersion: status.minAppVersion ?? undefined,
+          });
+          return;
+        }
+        if (status.deviceActive === false) {
+          navigation.replace("DeviceBlocked");
+          return;
+        }
+      } catch {
+        // Network/parse error — proceed to SellScan (offline-first)
+      }
+
+      navigation.replace("SellScan");
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Unknown error";
       console.warn("[SplashScreen] Session check failed:", msg);

--- a/supermandi-superadmin/src/components/LoginGate.tsx
+++ b/supermandi-superadmin/src/components/LoginGate.tsx
@@ -100,7 +100,7 @@ export function LoginGate({ onLogin }: { onLogin: () => void }) {
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                placeholder="admin@supermandi.com"
+                placeholder="admin@supermandi.tech"
                 disabled={loading}
                 autoFocus
               />


### PR DESCRIPTION
## Summary
- **#339**: Replace all `supermandi.in` / `supermandi.com` references with `supermandi.tech` across 7 backend files + 1 frontend placeholder (10 occurrences total)
- **#337**: Add `fetchUiStatus()` check in SplashScreen before routing to SellScan — prevents bypass of version enforcement and device-blocked gates
- **#342**: Accept both `?code=X` and `?enrollmentCode=X` in deep link params for EnrollDeviceScreen
- **#343**: Add UUID format validation in `withStoreContext()` before `SET LOCAL` — prevents RLS `::uuid` cast error on non-UUID store_id values
- **#338**: Closed as false positive (SuperAdmin API_BASE usage is correct everywhere)
- **#341**: Closed as non-blocker (migration runner sorts by full filename, tracks by name)

## Files Changed (10)
| File | Change |
|------|--------|
| `backend/services/platform-service/src/routes/retailerAdmin.ts` | 3× `supermandi.in` → `supermandi.tech` |
| `backend/src/services/emailService.ts` | 2× `.com`/`.in` → `.tech` |
| `backend/src/services/notificationService.ts` | 2× `.com` → `.tech` |
| `backend/src/routes/v1/admin/adminOtp.ts` | 1× `.com` → `.tech` |
| `backend/src/services/barcodeLookupProvider.ts` | User-Agent `.com` → `.tech` |
| `backend/.env.example` | EMAIL_FROM default `.com` → `.tech` |
| `supermandi-superadmin/src/components/LoginGate.tsx` | Placeholder `.com` → `.tech` |
| `src/screens/SplashScreen.tsx` | Add fetchUiStatus gate before SellScan |
| `src/screens/EnrollDeviceScreen.tsx` | Accept `code` param from deep links |
| `backend/src/db/client.ts` | UUID validation in withStoreContext |

## Typecheck
- [x] `backend` — zero errors
- [x] `supermandi-superadmin` — zero errors
- [x] `retailer-admin` — zero errors
- [x] POS root — zero errors

Closes #337, #338, #339, #341, #342, #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)