### PR TITLE
fix(DEPLOY-BLOCKER-388): GCP deploy parity — pnpm + CORS + cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -122,33 +122,23 @@ jobs:
       # STAGING-FIREBASE-001: Firebase config injected at build time for phone OTP
       - name: Build retailer-admin
         run: |
+          # STAGING-FIX-007: Firebase config loaded from .env.production at build time (not Docker ARGs)
           docker build \
             -t "${{ env.AR_REPO }}/retailer-admin:${{ env.SHA }}" \
             -f retailer-admin/Dockerfile \
             --build-arg VITE_API_BASE_URL="" \
             --build-arg VITE_GIT_SHA="${{ env.SHA }}" \
             --build-arg VITE_BUILD_TIME="${{ env.BUILD_TIME }}" \
-            --build-arg VITE_FIREBASE_API_KEY="${{ secrets.FIREBASE_API_KEY }}" \
-            --build-arg VITE_FIREBASE_AUTH_DOMAIN="${{ secrets.FIREBASE_AUTH_DOMAIN }}" \
-            --build-arg VITE_FIREBASE_PROJECT_ID="${{ secrets.FIREBASE_PROJECT_ID }}" \
-            --build-arg VITE_FIREBASE_STORAGE_BUCKET="${{ secrets.FIREBASE_STORAGE_BUCKET }}" \
-            --build-arg VITE_FIREBASE_MESSAGING_SENDER_ID="${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}" \
-            --build-arg VITE_FIREBASE_APP_ID="${{ secrets.FIREBASE_APP_ID }}" \
             retailer-admin/
 
       - name: Build supplier-portal
         run: |
+          # STAGING-FIX-007: Firebase config loaded from .env.production at build time (not Docker ARGs)
           docker build \
             -t "${{ env.AR_REPO }}/supplier-portal:${{ env.SHA }}" \
             -f supplier-portal/Dockerfile \
             --build-arg NEXT_PUBLIC_API_BASE_URL="" \
             --build-arg NEXT_PUBLIC_GIT_SHA="${{ env.SHA }}" \
-            --build-arg NEXT_PUBLIC_FIREBASE_API_KEY="${{ secrets.FIREBASE_API_KEY }}" \
-            --build-arg NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="${{ secrets.FIREBASE_AUTH_DOMAIN }}" \
-            --build-arg NEXT_PUBLIC_FIREBASE_PROJECT_ID="${{ secrets.FIREBASE_PROJECT_ID }}" \
-            --build-arg NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="${{ secrets.FIREBASE_STORAGE_BUCKET }}" \
-            --build-arg NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID="${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}" \
-            --build-arg NEXT_PUBLIC_FIREBASE_APP_ID="${{ secrets.FIREBASE_APP_ID }}" \
             supplier-portal/
 
       - name: Build superadmin
@@ -585,8 +575,6 @@ jobs:
           PORTAL_BASE_URL=https://staging.supermandi.tech,\
           POS_APP_DOWNLOAD_URL=https://staging.supermandi.tech/pos,\
           ADMIN_EMAIL_ALLOWLIST=supermanditech@gmail.com,\
-          ALLOWED_ORIGINS=https://staging.supermandi.tech,\
-          CORS_ALLOWED_ORIGINS=https://staging.supermandi.tech,\
           DOCUMENT_STORAGE_DIR=/tmp/documents,\
           GCS_DOCUMENTS_BUCKET=supermandi-pos-documents,\
           GCS_IMAGES_BUCKET=supermandi-pos-images,\
@@ -598,6 +586,7 @@ jobs:
           SUPERMANDI_STATE=Rajasthan,\
           FRONTEND_URL=https://staging.supermandi.tech" \
             --set-secrets="DATABASE_URL=database-url:latest,DB_PASSWORD=postgres-password:latest,JWT_SECRET=jwt-secret:latest,ADMIN_TOKEN=admin-token:latest,SMTP_PASS=smtp-password:latest,WHATSAPP_ACCESS_TOKEN=WHATSAPP_ACCESS_TOKEN:latest,WHATSAPP_PHONE_NUMBER_ID=WHATSAPP_PHONE_NUMBER_ID:latest,WHATSAPP_VERIFY_TOKEN=WHATSAPP_VERIFY_TOKEN:latest,WHATSAPP_APP_SECRET=WHATSAPP_APP_SECRET:latest,OPENAI_API_KEY=OPENAI_API_KEY:latest" \
+            --update-env-vars="^;^ALLOWED_ORIGINS=https://staging.supermandi.tech,https://www.staging.supermandi.tech,https://supermandi.tech,https://www.supermandi.tech;CORS_ALLOWED_ORIGINS=https://staging.supermandi.tech,https://www.staging.supermandi.tech,https://supermandi.tech,https://www.supermandi.tech" \
             --allow-unauthenticated \
             --quiet
           echo "    OK: $SERVICE_NAME deployed"
@@ -641,10 +630,10 @@ jobs:
           GIT_SHA=${{ env.SHA }},\
           MIN_APP_VERSION=${{ env.APP_VERSION }},\
           ADMIN_SERVICE_URL=$MB_URL,\
-          CORS_ALLOWED_ORIGINS=https://staging.supermandi.tech,\
           REDIS_HOST=10.107.71.27,\
           REDIS_PORT=6379,\
           REDIS_URL=redis://10.107.71.27:6379" \
+            --update-env-vars="^;^CORS_ALLOWED_ORIGINS=https://staging.supermandi.tech,https://www.staging.supermandi.tech,https://supermandi.tech,https://www.supermandi.tech" \
             --set-secrets="JWT_SECRET=jwt-secret:latest,ADMIN_TOKEN=admin-token:latest" \
             --allow-unauthenticated \
             --quiet

--- a/retailer-admin/Dockerfile
+++ b/retailer-admin/Dockerfile
@@ -17,11 +17,11 @@ ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 ENV VITE_GIT_SHA=$VITE_GIT_SHA
 ENV VITE_BUILD_TIME=$VITE_BUILD_TIME
 
-# Copy package files
-COPY package*.json ./
+# Copy package files + lockfile
+COPY package.json pnpm-lock.yaml ./
 
-# Install dependencies (npm install: no lockfile in pnpm-managed project)
-RUN npm install
+# DEPLOY-388: Use pnpm for deterministic builds (lockfile exists)
+RUN corepack enable && pnpm install --frozen-lockfile
 
 # Copy source
 COPY . .
@@ -32,7 +32,7 @@ RUN if [ -f .env.production ]; then cp .env.production .env; \
     fi
 
 # ENV-001: Set build time if not provided
-RUN if [ -z "$VITE_BUILD_TIME" ]; then export VITE_BUILD_TIME=$(date -Iseconds); fi && npm run build
+RUN if [ -z "$VITE_BUILD_TIME" ]; then export VITE_BUILD_TIME=$(date -Iseconds); fi && pnpm run build
 
 # Production stage - serve with nginx
 FROM nginx:alpine

--- a/supermandi-superadmin/Dockerfile
+++ b/supermandi-superadmin/Dockerfile
@@ -14,17 +14,17 @@ ENV VITE_API_BASE_URL=$VITE_API_BASE_URL
 ENV VITE_GIT_SHA=$VITE_GIT_SHA
 ENV VITE_BUILD_TIME=$VITE_BUILD_TIME
 
-# Copy package files
-COPY package*.json ./
+# Copy package files + lockfile
+COPY package.json pnpm-lock.yaml ./
 
-# Install dependencies (npm install: no lockfile in pnpm-managed project)
-RUN npm install
+# DEPLOY-388: Use pnpm for deterministic builds (lockfile exists)
+RUN corepack enable && pnpm install --frozen-lockfile
 
 # Copy source
 COPY . .
 
 # Build
-RUN if [ -z "$VITE_BUILD_TIME" ]; then export VITE_BUILD_TIME=$(date -Iseconds); fi && npm run build
+RUN if [ -z "$VITE_BUILD_TIME" ]; then export VITE_BUILD_TIME=$(date -Iseconds); fi && pnpm run build
 
 # Production stage - serve with nginx
 FROM nginx:alpine

--- a/supplier-portal/Dockerfile
+++ b/supplier-portal/Dockerfile
@@ -11,12 +11,11 @@ RUN apk add --no-cache libc6-compat
 
 WORKDIR /app
 
-# Copy package files
-COPY package*.json ./
+# Copy package files + lockfile
+COPY package.json pnpm-lock.yaml ./
 
-# Install all dependencies (including devDependencies for build)
-# Using npm install instead of npm ci since package-lock.json is gitignored
-RUN npm install
+# DEPLOY-388: Use pnpm for deterministic builds (lockfile exists)
+RUN corepack enable && pnpm install --frozen-lockfile
 
 # Copy source code
 COPY . .
@@ -37,7 +36,7 @@ RUN if [ -f .env.production ]; then echo "Using .env.production"; \
     elif [ -f .env.production.example ]; then cp .env.production.example .env.production && echo "Using .env.production.example as .env.production"; \
     fi
 
-RUN npm run build
+RUN pnpm run build
 
 # =============================================================================
 # PRODUCTION STAGE
@@ -50,11 +49,11 @@ WORKDIR /app
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001
 
-# Copy package files
-COPY package*.json ./
+# Copy package files + lockfile
+COPY package.json pnpm-lock.yaml ./
 
-# Install production dependencies only
-RUN npm install --omit=dev
+# DEPLOY-388: Use pnpm for deterministic production deps
+RUN corepack enable && pnpm install --frozen-lockfile --prod
 
 # Copy built application from builder
 COPY --from=builder /app/.next ./.next
@@ -80,4 +79,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:${PORT}/supplier/ || exit 1
 
 # Start Next.js production server
-CMD ["npm", "start"]
+CMD ["pnpm", "start"]


### PR DESCRIPTION
## Summary
- **Fix 1**: All 3 portal Dockerfiles now use `pnpm install --frozen-lockfile` (deterministic builds)
- **Fix 2**: Removed vestigial Firebase build-args from deploy.yml (handled via `.env.production`)
- **Fix 4**: CORS origins include `www.` variants via `--update-env-vars` with `^;^` delimiter
- Fix 3 (RATE_LIMIT_MULTIPLIER=5) and Fix 5 (dead domain → PORTAL_BASE_URL) already resolved

## Files Changed (4)
- `retailer-admin/Dockerfile` — npm → pnpm
- `supplier-portal/Dockerfile` — npm → pnpm (both build + production stages)
- `supermandi-superadmin/Dockerfile` — npm → pnpm
- `.github/workflows/deploy.yml` — CORS www. + remove Firebase build-args

## Test Plan
- [ ] CI Docker build succeeds for all 3 portals
- [ ] `pnpm install --frozen-lockfile` uses existing lockfiles
- [ ] CORS env vars contain 4 origins (staging, www.staging, prod, www.prod)
- [ ] Firebase auth works (loaded from .env.production, not Docker ARGs)

Closes #388

🤖 Generated with [Claude Code](https://claude.com/claude-code)