### PR TITLE
fix(DEPLOY-BLOCKER-404-405): enrollment_code_hash + label + BackHandler

### DIFF
--- a/backend/migrations/165_onboarding_schema_hardening.sql
+++ b/backend/migrations/165_onboarding_schema_hardening.sql
@@ -73,10 +73,14 @@ CREATE POLICY rls_application_status_log_admin ON auth.application_status_log
 
 -- =============================================================================
 -- DB-9: Index on pos_device_enrollments(store_id, enrollment_code_hash)
--- Used by admin dashboard to list codes per store and by enrollment lookup
+-- Column added in migration 166. Safe wrapper in case migrations run out of order.
 -- =============================================================================
-CREATE INDEX IF NOT EXISTS idx_enrollments_store_code_hash
-  ON pos_device_enrollments (store_id, enrollment_code_hash);
+DO $$ BEGIN
+  CREATE INDEX IF NOT EXISTS idx_enrollments_store_code_hash
+    ON pos_device_enrollments (store_id, enrollment_code_hash);
+EXCEPTION WHEN undefined_column THEN
+  RAISE NOTICE 'enrollment_code_hash column not yet created — index deferred to migration 166';
+END $$;
 
 -- =============================================================================
 -- DB-10: Index on pos_devices(device_token) for token-based auth

--- a/backend/migrations/166_add_enrollment_code_hash.sql
+++ b/backend/migrations/166_add_enrollment_code_hash.sql
@@ -1,0 +1,62 @@
+-- Migration: 166_add_enrollment_code_hash
+-- #404: Add enrollment_code_hash column to pos_device_enrollments
+--
+-- Problem: enroll.ts queries WHERE enrollment_code_hash = $1 but column doesn't exist.
+-- The column was only in scripts/migrations/prov-001-enhance-devices.sql (provisioning),
+-- never in the automated migration pipeline.
+--
+-- This migration:
+--   1. Adds enrollment_code_hash column
+--   2. Populates it from existing code values using SHA256
+--   3. Creates trigger to auto-compute hash on INSERT/UPDATE
+--   4. Creates unique index for fast lookup
+--   5. Re-creates the composite index from migration 165 (which may have failed)
+--
+-- Safe: IF NOT EXISTS + DO $$ exception handlers
+-- Requires: pgcrypto extension (for digest function)
+
+BEGIN;
+
+-- Ensure pgcrypto is available (needed for digest/SHA256)
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Step 1: Add enrollment_code_hash column
+ALTER TABLE pos_device_enrollments
+  ADD COLUMN IF NOT EXISTS enrollment_code_hash TEXT;
+
+-- Step 2: Populate hash from existing code values
+-- SHA256 hash of the code, hex-encoded (matches backend hashCode() function:
+--   createHash("sha256").update(code).digest("hex")
+-- )
+UPDATE pos_device_enrollments
+  SET enrollment_code_hash = encode(digest(code, 'sha256'), 'hex')
+  WHERE enrollment_code_hash IS NULL AND code IS NOT NULL;
+
+-- Step 3: Trigger to auto-compute hash on INSERT/UPDATE
+-- Ensures all future INSERTs automatically get the hash without code changes
+CREATE OR REPLACE FUNCTION trg_enrollment_code_hash()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.code IS NOT NULL THEN
+    NEW.enrollment_code_hash := encode(digest(NEW.code, 'sha256'), 'hex');
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_enrollment_code_hash_insert ON pos_device_enrollments;
+CREATE TRIGGER trg_enrollment_code_hash_insert
+  BEFORE INSERT OR UPDATE OF code ON pos_device_enrollments
+  FOR EACH ROW
+  EXECUTE FUNCTION trg_enrollment_code_hash();
+
+-- Step 4: Unique index on enrollment_code_hash for fast enrollment lookup
+CREATE UNIQUE INDEX IF NOT EXISTS idx_enrollments_code_hash
+  ON pos_device_enrollments (enrollment_code_hash);
+
+-- Step 5: Composite index (store_id, enrollment_code_hash) for admin dashboard
+-- This was attempted in migration 165 but may have failed due to missing column
+CREATE INDEX IF NOT EXISTS idx_enrollments_store_code_hash
+  ON pos_device_enrollments (store_id, enrollment_code_hash);
+
+COMMIT;

--- a/src/__tests__/screens/EnrollDeviceScreen.test.tsx
+++ b/src/__tests__/screens/EnrollDeviceScreen.test.tsx
@@ -1,16 +1,17 @@
 /**
- * SCR-S3-HARDENING (S3-5): EnrollDeviceScreen tests
- * Covers: render, inputs, enroll flow, offline detection, error codes, QR scan, deep link, a11y
+ * #404 + #405: EnrollDeviceScreen tests
+ * Covers: render, inputs, label requirement, enroll flow, offline detection, error codes, a11y
  */
 import React from "react";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react-native";
-import { Alert, Linking } from "react-native";
+import { Alert } from "react-native";
 
 // Mock navigation + route
 const mockReplace = jest.fn();
-const mockRouteParams: { enrollmentCode?: string } = {};
+const mockGoBack = jest.fn();
+const mockRouteParams: { enrollmentCode?: string; code?: string } = {};
 jest.mock("@react-navigation/native", () => ({
-  useNavigation: () => ({ replace: mockReplace }),
+  useNavigation: () => ({ replace: mockReplace, goBack: mockGoBack }),
   useRoute: () => ({ params: mockRouteParams }),
 }));
 
@@ -19,16 +20,6 @@ const mockNetInfoFetch = jest.fn().mockResolvedValue({ isConnected: true });
 jest.mock("@react-native-community/netinfo", () => ({
   __esModule: true,
   default: { fetch: () => mockNetInfoFetch() },
-}));
-
-// Mock expo-camera
-const mockRequestPermission = jest.fn().mockResolvedValue({ granted: true });
-jest.mock("expo-camera", () => ({
-  CameraView: (props: any) => {
-    const React = require("react");
-    return React.createElement("View", { testID: "mock-camera", ...props });
-  },
-  useCameraPermissions: () => [{ granted: false, canAskAgain: true }, mockRequestPermission],
 }));
 
 // Mock expo-constants
@@ -47,10 +38,10 @@ jest.mock("expo-device", () => ({
 
 // Mock services
 const mockEnrollDevice = jest.fn();
-const mockCheckDuplicateLabel = jest.fn().mockResolvedValue({ isDuplicate: false });
+const mockLookupActivation = jest.fn();
 jest.mock("../../services/api/enrollApi", () => ({
   enrollDevice: (...args: unknown[]) => mockEnrollDevice(...args),
-  checkDuplicateLabel: (...args: unknown[]) => mockCheckDuplicateLabel(...args),
+  lookupActivation: (...args: unknown[]) => mockLookupActivation(...args),
 }));
 
 const mockGetDeviceSession = jest.fn().mockResolvedValue(null);
@@ -65,6 +56,7 @@ jest.mock("../../services/deviceSession", () => ({
 jest.mock("../../services/api/apiClient", () => ({
   ApiError: class ApiError extends Error {
     status: number;
+    payload?: unknown;
     constructor(message: string, status = 400) {
       super(message);
       this.name = "ApiError";
@@ -119,18 +111,21 @@ describe("EnrollDeviceScreen", () => {
       storeName: "Test Store",
       storeCode: "TS",
       storeActive: true,
+      upiVpa: "test@upi",
     });
     mockRouteParams.enrollmentCode = undefined;
+    mockRouteParams.code = undefined;
   });
 
   it("renders with key elements and a11y labels", () => {
     render(<EnrollDeviceScreen />);
     expect(screen.getByTestId("enroll-device-screen")).toBeTruthy();
-    expect(screen.getByText("Enroll POS Device")).toBeTruthy();
+    expect(screen.getByText("Activate Your POS")).toBeTruthy();
+    expect(screen.getByTestId("enroll-phone-input")).toBeTruthy();
     expect(screen.getByTestId("enroll-code-input")).toBeTruthy();
     expect(screen.getByTestId("enroll-label-input")).toBeTruthy();
     expect(screen.getByTestId("enroll-submit-button")).toBeTruthy();
-    expect(screen.getByTestId("enroll-scan-button")).toBeTruthy();
+    expect(screen.getByTestId("enroll-lookup-button")).toBeTruthy();
   });
 
   it("pre-fills enrollment code from route params", () => {
@@ -143,6 +138,9 @@ describe("EnrollDeviceScreen", () => {
     const alertSpy = jest.spyOn(Alert, "alert");
     render(<EnrollDeviceScreen />);
 
+    // Clear default label, leave code empty
+    fireEvent.changeText(screen.getByTestId("enroll-label-input"), "Counter-1");
+
     await act(async () => {
       fireEvent.press(screen.getByTestId("enroll-submit-button"));
     });
@@ -151,27 +149,29 @@ describe("EnrollDeviceScreen", () => {
     alertSpy.mockRestore();
   });
 
-  it("shows alert for missing label", async () => {
+  it("shows alert for missing label (#404)", async () => {
     const alertSpy = jest.spyOn(Alert, "alert");
     render(<EnrollDeviceScreen />);
 
     fireEvent.changeText(screen.getByTestId("enroll-code-input"), "SM-ABC123");
+    // Clear the default label
+    fireEvent.changeText(screen.getByTestId("enroll-label-input"), "");
 
     await act(async () => {
       fireEvent.press(screen.getByTestId("enroll-submit-button"));
     });
 
-    expect(alertSpy).toHaveBeenCalledWith("Missing Label", expect.any(String));
+    expect(alertSpy).toHaveBeenCalledWith("Device Name Required", expect.any(String));
     alertSpy.mockRestore();
   });
 
-  it("checks network before enrolling (S3-1) and blocks if offline", async () => {
+  it("checks network before enrolling and blocks if offline", async () => {
     mockNetInfoFetch.mockResolvedValue({ isConnected: false });
     const alertSpy = jest.spyOn(Alert, "alert");
     render(<EnrollDeviceScreen />);
 
     fireEvent.changeText(screen.getByTestId("enroll-code-input"), "SM-ABC123");
-    fireEvent.changeText(screen.getByTestId("enroll-label-input"), "Counter-1");
+    // Label has default from device model ("TestDevice")
 
     await act(async () => {
       fireEvent.press(screen.getByTestId("enroll-submit-button"));
@@ -182,7 +182,7 @@ describe("EnrollDeviceScreen", () => {
     alertSpy.mockRestore();
   });
 
-  it("calls enrollDevice and navigates to SellScan on success", async () => {
+  it("calls enrollDevice with label and navigates to SellScan on success", async () => {
     render(<EnrollDeviceScreen />);
 
     fireEvent.changeText(screen.getByTestId("enroll-code-input"), "SM-ABC123");
@@ -194,6 +194,9 @@ describe("EnrollDeviceScreen", () => {
 
     await waitFor(() => {
       expect(mockEnrollDevice).toHaveBeenCalled();
+      // Verify label is included in deviceMeta
+      const callArgs = mockEnrollDevice.mock.calls[0][0];
+      expect(callArgs.deviceMeta.label).toBe("Counter-1");
       expect(mockReplace).toHaveBeenCalledWith("SellScan");
     });
   });
@@ -205,14 +208,14 @@ describe("EnrollDeviceScreen", () => {
     render(<EnrollDeviceScreen />);
 
     fireEvent.changeText(screen.getByTestId("enroll-code-input"), "SM-EXPIRED");
-    fireEvent.changeText(screen.getByTestId("enroll-label-input"), "Counter-1");
+    // Label has default from device model
 
     await act(async () => {
       fireEvent.press(screen.getByTestId("enroll-submit-button"));
     });
 
     await waitFor(() => {
-      expect(alertSpy).toHaveBeenCalledWith("Enrollment Failed", expect.stringContaining("expired"));
+      expect(alertSpy).toHaveBeenCalledWith("Activation Failed", expect.stringContaining("expired"));
     });
     alertSpy.mockRestore();
   });
@@ -224,14 +227,13 @@ describe("EnrollDeviceScreen", () => {
     render(<EnrollDeviceScreen />);
 
     fireEvent.changeText(screen.getByTestId("enroll-code-input"), "SM-REVOKED");
-    fireEvent.changeText(screen.getByTestId("enroll-label-input"), "Counter-1");
 
     await act(async () => {
       fireEvent.press(screen.getByTestId("enroll-submit-button"));
     });
 
     await waitFor(() => {
-      expect(alertSpy).toHaveBeenCalledWith("Enrollment Failed", expect.stringContaining("revoked"));
+      expect(alertSpy).toHaveBeenCalledWith("Activation Failed", expect.stringContaining("revoked"));
     });
     alertSpy.mockRestore();
   });
@@ -243,5 +245,11 @@ describe("EnrollDeviceScreen", () => {
     await waitFor(() => {
       expect(mockReplace).toHaveBeenCalledWith("SellScan");
     });
+  });
+
+  it("has default label from device model name", () => {
+    render(<EnrollDeviceScreen />);
+    // expo-device mock has modelName: "TestDevice"
+    expect(screen.getByTestId("enroll-label-input").props.value).toBe("TestDevice");
   });
 });

--- a/src/screens/EnrollDeviceScreen.tsx
+++ b/src/screens/EnrollDeviceScreen.tsx
@@ -91,6 +91,18 @@ const ENROLL_ERROR_MESSAGES: Record<string, { message: string; hint?: string }> 
     message: "Too many attempts.",
     hint: "Please wait 15 minutes before trying again."
   },
+  LABEL_REQUIRED: {
+    message: "Device name is required.",
+    hint: "Enter a name for this POS device (e.g., Counter-1)."
+  },
+  LABEL_DUPLICATE: {
+    message: "A device with this name already exists in your store.",
+    hint: "Choose a different name (e.g., Counter-2, Billing-2)."
+  },
+  DEVICE_LIMIT_EXCEEDED: {
+    message: "Maximum devices reached for this store.",
+    hint: "Contact support to increase your device limit."
+  },
   // Legacy error codes
   enrollment_invalid: { message: "Activation code is invalid or expired.", hint: "Contact support for a new code." },
   enrollment_expired: { message: "This activation code has expired.", hint: "Contact support for a new code." },
@@ -135,6 +147,11 @@ export default function EnrollDeviceScreen() {
   const [lookupLoading, setLookupLoading] = useState(false);
   const [lookupStoreName, setLookupStoreName] = useState("");
   const [lookupError, setLookupError] = useState("");
+
+  // #404: Device label (required by backend for device identification)
+  // Default to device model name for convenience
+  const defaultLabel = Device.modelName || Device.deviceName || "";
+  const [labelInput, setLabelInput] = useState(defaultLabel);
   const autoActivateTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const deviceMeta = useMemo(() => ({
@@ -142,6 +159,7 @@ export default function EnrollDeviceScreen() {
     model: Device.modelName ?? Device.deviceName ?? Constants.deviceName ?? null,
     androidVersion: Platform.OS === "android" ? String(Platform.Version) : Device.osVersion ?? null,
     appVersion: getAppVersion(),
+    // #404: label is set dynamically, not memoized — added at call site
   }), []);
 
   // Check existing session on mount — skip to SellScan if already enrolled
@@ -239,6 +257,13 @@ export default function EnrollDeviceScreen() {
       return;
     }
 
+    // #404: Validate label (required by backend)
+    const trimmedLabel = labelInput.trim();
+    if (!trimmedLabel) {
+      Alert.alert("Device Name Required", "Enter a name for this POS device (e.g., Counter-1, Billing-Main).");
+      return;
+    }
+
     // Offline detection
     try {
       const netState = await NetInfo.fetch();
@@ -261,7 +286,7 @@ export default function EnrollDeviceScreen() {
 
       const previousSession = await getDeviceSession();
       const previousStoreId = previousSession?.storeId ?? null;
-      const res = await enrollDevice({ enrollmentCode: activationCode, deviceMeta });
+      const res = await enrollDevice({ enrollmentCode: activationCode, deviceMeta: { ...deviceMeta, label: trimmedLabel } });
       const storeChanged = previousStoreId !== res.storeId;
 
       if (storeChanged) {
@@ -365,7 +390,7 @@ export default function EnrollDeviceScreen() {
     } finally {
       setLoading(false);
     }
-  }, [codeInput, deviceMeta, navigation]);
+  }, [codeInput, labelInput, deviceMeta, navigation]);
 
   // Keep ref current for auto-activate timer
   handleActivateRef.current = handleActivate;
@@ -460,10 +485,32 @@ export default function EnrollDeviceScreen() {
           onChangeText={setCodeInput}
           testID="enroll-code-input"
           accessibilityLabel="Activation code"
+          returnKeyType="next"
+          editable={!loading}
+        />
+      </View>
+
+      {/* #404: Device Label (required) */}
+      <View style={styles.inputSection}>
+        <Text style={styles.label}>
+          Device Name <Text style={styles.requiredMark}>*</Text>
+        </Text>
+        <TextInput
+          style={styles.labelInput}
+          placeholder="e.g., Counter-1, Billing-Main"
+          placeholderTextColor={colors.textTertiary}
+          value={labelInput}
+          onChangeText={setLabelInput}
+          testID="enroll-label-input"
+          accessibilityLabel="Device name for this POS"
           returnKeyType="done"
           onSubmitEditing={handleActivate}
           editable={!loading}
+          maxLength={50}
         />
+        <Text style={styles.labelHint}>
+          A name to identify this device in your store dashboard
+        </Text>
 
         <Pressable
           style={[styles.activateButton, loading && styles.activateButtonDisabled]}
@@ -640,6 +687,24 @@ const styles = StyleSheet.create({
     color: colors.textPrimary,
     textAlign: "center",
     letterSpacing: 3,
+  },
+  labelInput: {
+    ...typography.body,
+    borderWidth: 2,
+    borderColor: colors.border,
+    borderRadius: theme.borderRadius.lg,
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.md,
+    backgroundColor: colors.surfaceAlt,
+    color: colors.textPrimary,
+  },
+  labelHint: {
+    fontSize: 11,
+    color: colors.textTertiary,
+    lineHeight: 14,
+  },
+  requiredMark: {
+    color: colors.error,
   },
   activateButton: {
     backgroundColor: colors.primary,

--- a/src/screens/SplashScreen.tsx
+++ b/src/screens/SplashScreen.tsx
@@ -1,7 +1,7 @@
 // T-107: Brand-styled splash screen with shortmark icon
 // SCR-S1-HARDENING: Production-grade error handling, timeout, retry, a11y
 import React, { useEffect, useState, useCallback } from "react";
-import { View, Text, StyleSheet, ActivityIndicator, Pressable } from "react-native";
+import { View, Text, StyleSheet, ActivityIndicator, Pressable, BackHandler } from "react-native";
 import { useNavigation } from "@react-navigation/native";
 import { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import Svg, { Path } from "react-native-svg";
@@ -59,6 +59,12 @@ function BrandShortmark({ size = 64, color = colors.textInverse }: { size?: numb
 export default function SplashScreen() {
   const navigation = useNavigation<NavProp>();
   const [errorState, setErrorState] = useState<string | null>(null);
+
+  // #405: Prevent Android back button during splash (consistent with gate screens)
+  useEffect(() => {
+    const sub = BackHandler.addEventListener("hardwareBackPress", () => true);
+    return () => sub.remove();
+  }, []);
 
   /** S1-3: Race getDeviceSession against a timeout */
   const getSessionWithTimeout = useCallback(async () => {


### PR DESCRIPTION
## Summary

- **[DEPLOY BLOCKER] #404**: `enrollment_code_hash` column missing from automated migration pipeline — backend `enroll.ts` queries `WHERE e.enrollment_code_hash = $1` but column only existed in manual provisioning script. Also, POS app never sent device label (backend returns 400 LABEL_REQUIRED).
- **#405**: SplashScreen missing BackHandler (Android back button escapes splash), EnrollDeviceScreen tests outdated.

## Changes

### Migration fixes (DB layer)
- **Migration 165** (modified): Wrapped index creation in `DO $$ BEGIN...EXCEPTION WHEN undefined_column` handler so it doesn't fail if enrollment_code_hash doesn't exist yet
- **Migration 166** (new): Adds `enrollment_code_hash` column, populates from existing codes via SHA256, creates auto-hash trigger on INSERT/UPDATE, creates unique + composite indexes

### EnrollDeviceScreen (UI + API layer)
- Added label input field with default from device model name
- Validation: blocks enrollment if label is empty ("Device Name Required")
- `enrollDevice()` call now includes `label` in `deviceMeta`
- New error messages: LABEL_REQUIRED, LABEL_DUPLICATE, DEVICE_LIMIT_EXCEEDED

### SplashScreen (#405)
- Added `BackHandler.addEventListener` to prevent Android back button during splash

### Tests
- Rewrote `EnrollDeviceScreen.test.tsx` — 10 tests, all pass
- Fixed: title expectation, alert messages, route params, mock response (upiVpa for PaymentSetup routing)

## Test plan

- [x] `npx tsc --noEmit` — all 5 packages clean (POS, backend, retailer, supplier, superadmin)
- [x] `npx jest EnrollDeviceScreen.test.tsx` — 10/10 pass
- [ ] CI build gate
- [ ] Operator: verify label input renders on EnrollDevice screen
- [ ] Operator: verify migration 166 runs on Cloud SQL without error
- [ ] Operator: verify enrollment flow completes with label

🤖 Generated with [Claude Code](https://claude.com/claude-code)