### PR TITLE
test(SCR-AUDIT-310): production-grade test hardening — all 3 gate screens

### DIFF
--- a/src/__tests__/screens/ForceUpdateScreen.test.tsx
+++ b/src/__tests__/screens/ForceUpdateScreen.test.tsx
@@ -4,7 +4,7 @@
  */
 import React from "react";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react-native";
-import { Alert, Linking, Platform } from "react-native";
+import { Alert, Linking, Platform, BackHandler } from "react-native";
 
 // Mock navigation + route
 const mockReset = jest.fn();
@@ -74,16 +74,16 @@ describe("ForceUpdateScreen", () => {
 
   it("displays version params correctly", () => {
     render(<ForceUpdateScreen />);
-    expect(screen.getByTestId("force-update-current-version")).toHaveTextContent("1.0.0");
-    expect(screen.getByTestId("force-update-required-version")).toHaveTextContent("2.0.0");
+    expect(screen.getByTestId("force-update-current-version").props.children).toBe("1.0.0");
+    expect(screen.getByTestId("force-update-required-version").props.children).toBe("2.0.0");
   });
 
   it("falls back to 'unknown' for missing params (S2-5)", () => {
     mockRouteParams.currentVersion = undefined as any;
     mockRouteParams.requiredVersion = "";
     render(<ForceUpdateScreen />);
-    expect(screen.getByTestId("force-update-current-version")).toHaveTextContent("unknown");
-    expect(screen.getByTestId("force-update-required-version")).toHaveTextContent("unknown");
+    expect(screen.getByTestId("force-update-current-version").props.children).toBe("unknown");
+    expect(screen.getByTestId("force-update-required-version").props.children).toBe("unknown");
   });
 
   it("has a11y labels on interactive elements (S2-6)", () => {
@@ -161,5 +161,14 @@ describe("ForceUpdateScreen", () => {
         routes: [{ name: "EnrollDevice" }],
       });
     });
+  });
+
+  it("prevents Android back button from bypassing gate (DEPLOY-390)", () => {
+    const addListenerSpy = jest.spyOn(BackHandler, "addEventListener");
+    render(<ForceUpdateScreen />);
+    expect(addListenerSpy).toHaveBeenCalledWith("hardwareBackPress", expect.any(Function));
+    const handler = addListenerSpy.mock.calls[0][1];
+    expect(handler()).toBe(true);
+    addListenerSpy.mockRestore();
   });
 });

--- a/src/__tests__/screens/SplashScreen.test.tsx
+++ b/src/__tests__/screens/SplashScreen.test.tsx
@@ -1,9 +1,11 @@
 /**
- * SCR-S1-HARDENING (S1-9): Comprehensive SplashScreen tests
- * Covers: render, navigation branches, error state, retry, timeout, a11y
+ * SCR-AUDIT-310 + #407: Comprehensive SplashScreen tests
+ * Covers: render, navigation branches (SellScan, EnrollDevice, ForceUpdate, DeviceBlocked),
+ *         error state, retry, timeout, BackHandler, a11y
  */
 import React from "react";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react-native";
+import { BackHandler } from "react-native";
 
 // Mock navigation
 const mockReplace = jest.fn();
@@ -11,7 +13,7 @@ jest.mock("@react-navigation/native", () => ({
   useNavigation: () => ({ replace: mockReplace }),
 }));
 
-// Mock services
+// Mock services — boot infra (non-blocking)
 jest.mock("../../services/cloudEventLogger", () => ({
   startCloudEventLogger: jest.fn(),
 }));
@@ -30,11 +32,24 @@ jest.mock("../../services/offline/sync", () => ({
   syncOutbox: jest.fn().mockResolvedValue(undefined),
 }));
 
+// Mock deviceSession
 const mockGetDeviceSession = jest.fn();
 jest.mock("../../services/deviceSession", () => ({
   getDeviceSession: (...args: unknown[]) => mockGetDeviceSession(...args),
 }));
 
+// Mock uiStatusApi — fetchUiStatus called after session check
+const mockFetchUiStatus = jest.fn().mockResolvedValue({ forceUpdate: false, storeActive: true });
+jest.mock("../../services/api/uiStatusApi", () => ({
+  fetchUiStatus: () => mockFetchUiStatus(),
+}));
+
+// Mock deviceInfo — getDeviceMeta called for appVersion
+jest.mock("../../services/deviceInfo", () => ({
+  getDeviceMeta: () => ({ appVersion: "1.0.0" }),
+}));
+
+// Mock react-native-svg
 jest.mock("react-native-svg", () => {
   const React = require("react");
   return {
@@ -51,6 +66,7 @@ describe("SplashScreen", () => {
     jest.clearAllMocks();
     jest.useFakeTimers();
     mockGetDeviceSession.mockResolvedValue({ deviceToken: "test-token", storeId: "store-1" });
+    mockFetchUiStatus.mockResolvedValue({ forceUpdate: false, storeActive: true, deviceActive: true });
   });
 
   afterEach(() => {
@@ -70,11 +86,11 @@ describe("SplashScreen", () => {
     expect(screen.getByTestId("splash-brand-name")).toBeTruthy();
   });
 
-  it("navigates to SellScan when session exists", async () => {
+  it("navigates to SellScan when session exists and no force update", async () => {
     mockGetDeviceSession.mockResolvedValue({ deviceToken: "t", storeId: "s" });
+    mockFetchUiStatus.mockResolvedValue({ forceUpdate: false, deviceActive: true });
     render(<SplashScreen />);
 
-    // Advance past splash duration
     act(() => { jest.advanceTimersByTime(1100); });
 
     await waitFor(() => {
@@ -93,6 +109,44 @@ describe("SplashScreen", () => {
     });
   });
 
+  it("navigates to ForceUpdate when forceUpdate is true", async () => {
+    mockGetDeviceSession.mockResolvedValue({ deviceToken: "t", storeId: "s" });
+    mockFetchUiStatus.mockResolvedValue({ forceUpdate: true, minAppVersion: "2.0.0" });
+    render(<SplashScreen />);
+
+    act(() => { jest.advanceTimersByTime(1100); });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("ForceUpdate", expect.objectContaining({
+        currentVersion: "1.0.0",
+      }));
+    });
+  });
+
+  it("navigates to DeviceBlocked when deviceActive is false", async () => {
+    mockGetDeviceSession.mockResolvedValue({ deviceToken: "t", storeId: "s" });
+    mockFetchUiStatus.mockResolvedValue({ forceUpdate: false, deviceActive: false });
+    render(<SplashScreen />);
+
+    act(() => { jest.advanceTimersByTime(1100); });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("DeviceBlocked");
+    });
+  });
+
+  it("proceeds to SellScan when fetchUiStatus throws (offline-first)", async () => {
+    mockGetDeviceSession.mockResolvedValue({ deviceToken: "t", storeId: "s" });
+    mockFetchUiStatus.mockRejectedValue(new Error("Network error"));
+    render(<SplashScreen />);
+
+    act(() => { jest.advanceTimersByTime(1100); });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("SellScan");
+    });
+  });
+
   it("shows error state when getDeviceSession rejects", async () => {
     mockGetDeviceSession.mockRejectedValue(new Error("SecureStore locked"));
     render(<SplashScreen />);
@@ -107,7 +161,6 @@ describe("SplashScreen", () => {
   });
 
   it("retry button resets error and re-checks session", async () => {
-    // First call fails, second succeeds
     mockGetDeviceSession
       .mockRejectedValueOnce(new Error("Fail"))
       .mockResolvedValueOnce({ deviceToken: "t", storeId: "s" });
@@ -141,7 +194,6 @@ describe("SplashScreen", () => {
   });
 
   it("shows error on session timeout", async () => {
-    // Session never resolves (simulate hang)
     mockGetDeviceSession.mockImplementation(() => new Promise(() => {}));
     render(<SplashScreen />);
 
@@ -152,5 +204,15 @@ describe("SplashScreen", () => {
       expect(screen.getByTestId("splash-error-card")).toBeTruthy();
     });
     expect(screen.getByText("Session check timed out")).toBeTruthy();
+  });
+
+  it("prevents Android back button during splash (#405)", () => {
+    const addListenerSpy = jest.spyOn(BackHandler, "addEventListener");
+    render(<SplashScreen />);
+    expect(addListenerSpy).toHaveBeenCalledWith("hardwareBackPress", expect.any(Function));
+    // Verify the handler returns true (blocks back)
+    const handler = addListenerSpy.mock.calls[0][1];
+    expect(handler()).toBe(true);
+    addListenerSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary

- **SplashScreen.test.tsx**: Was completely broken (all 7 tests crashed at import — missing API config mock). Now **12/12 pass** with full coverage including ForceUpdate navigation, DeviceBlocked navigation, offline-first fallback, and BackHandler.
- **ForceUpdateScreen.test.tsx**: 2 tests failed (`toHaveTextContent` from missing library). Now **10/10 pass** with `props.children` assertions + BackHandler test.
- **EnrollDeviceScreen.test.tsx**: Already fixed in #406. **10/10 pass**.

**Total: 32 gate screen tests, zero failures.**

## Before/After

| Screen | Before | After |
|--------|--------|-------|
| SplashScreen | 0/7 (CRASH) | 12/12 |
| ForceUpdateScreen | 7/9 (2 fail) | 10/10 |
| EnrollDeviceScreen | 3/8 (5 fail) | 10/10 |
| **Total** | **10/24** | **32/32** |

## Test plan

- [x] `npx jest src/__tests__/screens/SplashScreen.test.tsx` — 12/12 pass
- [x] `npx jest src/__tests__/screens/ForceUpdateScreen.test.tsx` — 10/10 pass
- [x] `npx jest src/__tests__/screens/EnrollDeviceScreen.test.tsx` — 10/10 pass
- [x] `npx tsc --noEmit` — POS + backend clean

Closes #407

🤖 Generated with [Claude Code](https://claude.com/claude-code)