### PR TITLE
fix(GCP-PARITY-409): deviceQueries broken columns + ensureSchema sync + test coverage

### DIFF
--- a/backend/services/platform-service/src/db/deviceQueries.ts
+++ b/backend/services/platform-service/src/db/deviceQueries.ts
@@ -44,40 +44,48 @@ export interface DeviceEnrollment extends BaseEntity {
 // =============================================================================
 
 export async function getDevicesForStore(storeId: string): Promise<Device[]> {
+  // GCP-PARITY-409: Map actual DB columns to interface fields
+  // device_id → id (no separate device_id column)
+  // status → computed from active boolean
+  // enrolled_at → created_at (enrollment time = row creation time)
+  // last_seen_at → last_seen_online (actual column name)
   return query<Device>(
     `SELECT
-      id, store_id as "storeId", device_id as "deviceId",
+      id, store_id as "storeId", id::TEXT as "deviceId",
       device_token as "deviceToken", label,
       device_type as "deviceType", printing_mode as "printingMode",
       manufacturer, model, android_version as "androidVersion",
       app_version as "appVersion",
-      status, active,
-      enrolled_at as "enrolledAt",
-      last_seen_at as "lastSeenAt",
+      CASE WHEN active THEN 'active' ELSE 'blocked' END as status,
+      active,
+      created_at as "enrolledAt",
+      last_seen_online as "lastSeenAt",
       created_at as "createdAt",
       updated_at as "updatedAt"
     FROM public.pos_devices
     WHERE store_id = $1
-    ORDER BY enrolled_at DESC`,
+    ORDER BY created_at DESC`,
     [storeId]
   );
 }
 
 export async function getDeviceById(deviceId: string): Promise<Device | null> {
+  // GCP-PARITY-409: Map actual DB columns (see getDevicesForStore comment)
   const rows = await query<Device>(
     `SELECT
-      id, store_id as "storeId", device_id as "deviceId",
+      id, store_id as "storeId", id::TEXT as "deviceId",
       device_token as "deviceToken", label,
       device_type as "deviceType", printing_mode as "printingMode",
       manufacturer, model, android_version as "androidVersion",
       app_version as "appVersion",
-      status, active,
-      enrolled_at as "enrolledAt",
-      last_seen_at as "lastSeenAt",
+      CASE WHEN active THEN 'active' ELSE 'blocked' END as status,
+      active,
+      created_at as "enrolledAt",
+      last_seen_online as "lastSeenAt",
       created_at as "createdAt",
       updated_at as "updatedAt"
     FROM public.pos_devices
-    WHERE id = $1 OR device_id = $1`,
+    WHERE id = $1`,
     [deviceId]
   );
   return rows[0] || null;
@@ -87,22 +95,24 @@ export async function updateDeviceStatus(
   deviceId: string,
   status: 'active' | 'blocked'
 ): Promise<Device | null> {
+  // GCP-PARITY-409: Only SET active (no status column in DB), map in RETURNING
   const rows = await query<Device>(
     `UPDATE public.pos_devices
-    SET status = $1, active = $2, updated_at = NOW()
-    WHERE id = $3 OR device_id = $3
+    SET active = $1, updated_at = NOW()
+    WHERE id = $2
     RETURNING
-      id, store_id as "storeId", device_id as "deviceId",
+      id, store_id as "storeId", id::TEXT as "deviceId",
       device_token as "deviceToken", label,
       device_type as "deviceType", printing_mode as "printingMode",
       manufacturer, model, android_version as "androidVersion",
       app_version as "appVersion",
-      status, active,
-      enrolled_at as "enrolledAt",
-      last_seen_at as "lastSeenAt",
+      CASE WHEN active THEN 'active' ELSE 'blocked' END as status,
+      active,
+      created_at as "enrolledAt",
+      last_seen_online as "lastSeenAt",
       created_at as "createdAt",
       updated_at as "updatedAt"`,
-    [status, status === 'active', deviceId]
+    [status === 'active', deviceId]
   );
   return rows[0] || null;
 }

--- a/backend/src/db/ensureSchema.ts
+++ b/backend/src/db/ensureSchema.ts
@@ -313,6 +313,8 @@ export async function ensureCoreSchema(): Promise<void> {
       app_version TEXT NULL,
       printing_mode TEXT NULL,
       device_fingerprint TEXT NULL,
+      enrollment_id TEXT NULL,
+      enrollment_code TEXT NULL,
       last_seen_online TIMESTAMPTZ NULL,
       last_sync_at TIMESTAMPTZ NULL,
       pending_outbox_count INTEGER NOT NULL DEFAULT 0,
@@ -320,6 +322,10 @@ export async function ensureCoreSchema(): Promise<void> {
       re_enrolled BOOLEAN NOT NULL DEFAULT FALSE,
       re_enrolled_at TIMESTAMPTZ NULL,
       inventory_sync_status TEXT DEFAULT 'synced',
+      token_expires_at TIMESTAMPTZ NULL,
+      token_refreshed_at TIMESTAMPTZ NULL,
+      token_revoked_at TIMESTAMPTZ NULL,
+      last_active_at TIMESTAMPTZ NULL,
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
       updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     );
@@ -327,10 +333,18 @@ export async function ensureCoreSchema(): Promise<void> {
     CREATE TABLE IF NOT EXISTS pos_device_enrollments (
       code TEXT PRIMARY KEY,
       store_id TEXT NOT NULL /* FK to stores omitted — public.stores is a view */,
+      enrollment_code_hash TEXT NULL,
+      label TEXT NULL,
       expires_at TIMESTAMPTZ NOT NULL,
       used_at TIMESTAMPTZ NULL,
+      used_device_id TEXT NULL,
+      revoked_at TIMESTAMPTZ NULL,
+      max_uses INTEGER NOT NULL DEFAULT 1,
+      uses_count INTEGER NOT NULL DEFAULT 0,
+      last_used_at TIMESTAMPTZ NULL,
       created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-      created_by TEXT NOT NULL DEFAULT 'superadmin'
+      created_by TEXT NOT NULL DEFAULT 'superadmin',
+      updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
     );
 
     CREATE TABLE IF NOT EXISTS purchases (

--- a/src/__tests__/screens/EnrollDeviceScreen.test.tsx
+++ b/src/__tests__/screens/EnrollDeviceScreen.test.tsx
@@ -1,10 +1,12 @@
 /**
- * #404 + #405: EnrollDeviceScreen tests
- * Covers: render, inputs, label requirement, enroll flow, offline detection, error codes, a11y
+ * #404 + #405 + #409: EnrollDeviceScreen tests
+ * Covers: render, inputs, label requirement, enroll flow, offline detection, error codes, a11y,
+ *         phone lookup (lookupActivation), PaymentSetup routing (upiVpa + AsyncStorage)
  */
 import React from "react";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react-native";
 import { Alert } from "react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 
 // Mock navigation + route
 const mockReplace = jest.fn();
@@ -251,5 +253,138 @@ describe("EnrollDeviceScreen", () => {
     render(<EnrollDeviceScreen />);
     // expo-device mock has modelName: "TestDevice"
     expect(screen.getByTestId("enroll-label-input").props.value).toBe("TestDevice");
+  });
+
+  // =========================================================================
+  // #409: Phone Lookup (lookupActivation) tests
+  // =========================================================================
+
+  it("looks up activation code by phone number", async () => {
+    mockLookupActivation.mockResolvedValue({ code: "SM-FOUND1", storeName: "My Store" });
+    render(<EnrollDeviceScreen />);
+
+    fireEvent.changeText(screen.getByTestId("enroll-phone-input"), "9876543210");
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("enroll-lookup-button"));
+    });
+
+    await waitFor(() => {
+      expect(mockLookupActivation).toHaveBeenCalledWith("9876543210");
+      // Code input should be filled with the looked-up code
+      expect(screen.getByTestId("enroll-code-input").props.value).toBe("SM-FOUND1");
+    });
+  });
+
+  it("shows error for invalid phone number in lookup", async () => {
+    render(<EnrollDeviceScreen />);
+
+    fireEvent.changeText(screen.getByTestId("enroll-phone-input"), "12345");
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("enroll-lookup-button"));
+    });
+
+    // Should NOT call the API
+    expect(mockLookupActivation).not.toHaveBeenCalled();
+  });
+
+  it("shows error when lookup returns STORE_NOT_FOUND", async () => {
+    const { ApiError } = require("../../services/api/apiClient");
+    mockLookupActivation.mockRejectedValue(new ApiError("STORE_NOT_FOUND", 404));
+    render(<EnrollDeviceScreen />);
+
+    fireEvent.changeText(screen.getByTestId("enroll-phone-input"), "9876543210");
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("enroll-lookup-button"));
+    });
+
+    // lookupActivation was called
+    expect(mockLookupActivation).toHaveBeenCalledWith("9876543210");
+  });
+
+  it("blocks lookup when offline", async () => {
+    mockNetInfoFetch.mockResolvedValue({ isConnected: false });
+    render(<EnrollDeviceScreen />);
+
+    fireEvent.changeText(screen.getByTestId("enroll-phone-input"), "9876543210");
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("enroll-lookup-button"));
+    });
+
+    expect(mockLookupActivation).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // #409: PaymentSetup routing tests (upiVpa + AsyncStorage)
+  // =========================================================================
+
+  it("navigates to PaymentSetup when upiVpa is missing and not prompted before", async () => {
+    mockEnrollDevice.mockResolvedValue({
+      deviceId: "d1",
+      storeId: "s1",
+      deviceToken: "token123",
+      storeName: "Test Store",
+      storeCode: "TS",
+      storeActive: true,
+      upiVpa: null, // No UPI VPA
+    });
+    // AsyncStorage returns null (not prompted before)
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+
+    render(<EnrollDeviceScreen />);
+
+    fireEvent.changeText(screen.getByTestId("enroll-code-input"), "SM-ABC123");
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("enroll-submit-button"));
+    });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("PaymentSetup");
+    });
+  });
+
+  it("navigates to SellScan when upiVpa is missing but already prompted", async () => {
+    mockEnrollDevice.mockResolvedValue({
+      deviceId: "d1",
+      storeId: "s1",
+      deviceToken: "token123",
+      storeName: "Test Store",
+      storeCode: "TS",
+      storeActive: true,
+      upiVpa: null, // No UPI VPA
+    });
+    // AsyncStorage returns truthy (already prompted)
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValue("true");
+
+    render(<EnrollDeviceScreen />);
+
+    fireEvent.changeText(screen.getByTestId("enroll-code-input"), "SM-ABC123");
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("enroll-submit-button"));
+    });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("SellScan");
+    });
+  });
+
+  it("navigates to SellScan when upiVpa is present (regardless of prompt state)", async () => {
+    // Default mock has upiVpa: "test@upi"
+    render(<EnrollDeviceScreen />);
+
+    fireEvent.changeText(screen.getByTestId("enroll-code-input"), "SM-ABC123");
+
+    await act(async () => {
+      fireEvent.press(screen.getByTestId("enroll-submit-button"));
+    });
+
+    await waitFor(() => {
+      expect(mockReplace).toHaveBeenCalledWith("SellScan");
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **CRITICAL fix**: `deviceQueries.ts` referenced 4 non-existent DB columns (`status`, `enrolled_at`, `last_seen_at`, `device_id`), causing SuperAdmin device management (list/block/unblock) to crash at runtime. Fixed by mapping to actual columns.
- **ensureSchema.ts** synced: Added 14 missing columns across `pos_devices` (6) and `pos_device_enrollments` (8) to match migration-created schema.
- **7 new tests** added: Phone lookup flow (4 tests) + PaymentSetup routing (3 tests). Total: 17 EnrollDeviceScreen tests passing.

## Changes

| File | Change |
|------|--------|
| `backend/services/platform-service/src/db/deviceQueries.ts` | Map `status`→active, `enrolled_at`→created_at, `last_seen_at`→last_seen_online, `device_id`→id |
| `backend/src/db/ensureSchema.ts` | Add 14 missing columns to pos_devices + pos_device_enrollments |
| `src/__tests__/screens/EnrollDeviceScreen.test.tsx` | Add 7 tests: phone lookup + PaymentSetup routing |

## Test Results

- SplashScreen: 12/12 ✓
- ForceUpdateScreen: 10/10 ✓
- EnrollDeviceScreen: 17/17 ✓ (was 10, +7 new)
- All typechecks: 4/4 clean (POS, backend, retailer-admin, supplier-portal)

## Test plan
- [ ] Verify SuperAdmin device list endpoint no longer crashes
- [ ] Verify device block/unblock endpoints work
- [ ] Verify fresh DB setup creates correct schema

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)